### PR TITLE
Use Ruby as base docker image instead of dependabot so as base image

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,9 +1,11 @@
-FROM dependabot/dependabot-core:0.126.0
+FROM ruby:2.6.6-alpine
+WORKDIR /app
 
 # Copy the Gemfile and Gemfile.lock
 COPY ["Gemfile", "Gemfile.lock", "./"]
 
 # Install dependencies
+RUN apk add --updat build-base
 RUN bundle install -j 3 --path vendor
 
 # Script files are known to change more frequently than Gemfiles.


### PR DESCRIPTION
The base docker image `dependabot/dependabot-core:***` is 4.3GB is size. Adding our content, the resulting image (`tingle/dependabot-azure-devops:**`) is 4.38GB in size. This impacts the download time in runtime environments like the DevOps extension and Kubernetes Jobs.

Switching to a Ruby base image (`ruby:2.6.6-alpha`) reduces the resulting image by 90% (from 4.38GB to 333.4MB). Since functionality is retained, it becomes preferred to use this as the base image.