### PR TITLE
Simpler docker tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,5 +79,14 @@ jobs:
     - name: Push image to Docker Hub
       if: startsWith(github.ref, 'refs/tags')
       run: |
+        # Tag with full semver (Major.Minor.Patch)
         docker tag "$IMAGE_NAME" "tingle/$IMAGE_NAME:$GITVERSION_FULLSEMVER"
+        docker push "tingle/$IMAGE_NAME:$GITVERSION_FULLSEMVER"
+
+        # Tag with Major and Minor
+        docker tag "$IMAGE_NAME" "tingle/$IMAGE_NAME:$GITVERSION_MAJOR.$GITVERSION_MINOR"
+        docker push "tingle/$IMAGE_NAME:$GITVERSION_FULLSEMVER"
+
+        # Tag with Major only
+        docker tag "$IMAGE_NAME" "tingle/$IMAGE_NAME:$GITVERSION_MAJOR"
         docker push "tingle/$IMAGE_NAME:$GITVERSION_FULLSEMVER"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,8 +85,8 @@ jobs:
 
         # Tag with Major and Minor
         docker tag "$IMAGE_NAME" "tingle/$IMAGE_NAME:$GITVERSION_MAJOR.$GITVERSION_MINOR"
-        docker push "tingle/$IMAGE_NAME:$GITVERSION_FULLSEMVER"
+        docker push "tingle/$IMAGE_NAME:$GITVERSION_MAJOR.$GITVERSION_MINOR"
 
         # Tag with Major only
         docker tag "$IMAGE_NAME" "tingle/$IMAGE_NAME:$GITVERSION_MAJOR"
-        docker push "tingle/$IMAGE_NAME:$GITVERSION_FULLSEMVER"
+        docker push "tingle/$IMAGE_NAME:$GITVERSION_MAJOR"

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -121,7 +121,7 @@ async function run() {
         // Allow overriding of the docker image tag globally
         let dockerImageTag: string = tl.getVariable('DEPENDABOT_DOCKER_IMAGE_TAG');
         if (!dockerImageTag) {
-            dockerImageTag = '0.1.1';
+            dockerImageTag = '0.1' // will pull the latest patch for 0.1 e.g. 0.1.1
         }
         const dockerImage = `tingle/dependabot-azure-devops:${dockerImageTag}`;
         tl.debug(`Running docker container using '${dockerImage}' ...`);


### PR DESCRIPTION
Publish non-restrictive docker image tags so that the Azure DevOps extension can pull the latest patch or latest minor. For example, 0.1.1, 0.1, and 0 would refer to the same image at push time. Pulling from 0.1 will result in the latest path e.g. 0.1.2 or 0.1.3