### PR TITLE
Open pull requests limit

### DIFF
--- a/src/docker/README.md
+++ b/src/docker/README.md
@@ -21,6 +21,7 @@ docker run --rm -t \
            -e TARGET_BRANCH=<your-target-branch> \
            -e AZURE_HOSTNAME=<your-hostname> \
            -e AZURE_HOSTNAME_PACKAGING=<your-packaging-hostname> \
+           -e OPEN_PULL_REQUESTS_LIMIT=10 \
            tingle/dependabot-azure-devops:0.1.1
 ```
 
@@ -39,6 +40,7 @@ docker run --rm -t \
            -e TARGET_BRANCH=main \
            -e AZURE_HOSTNAME=dev.azure.com \
            -e AZURE_HOSTNAME_PACKAGING=pkgs.dev.azure.com \
+           -e OPEN_PULL_REQUESTS_LIMIT=10 \
            tingle/dependabot-azure-devops:0.1.1
 ```
 
@@ -59,3 +61,4 @@ To run the script, some environment variables are required.
 |TARGET_BRANCH|**_Optional_**. The branch to be targeted when creating a pull request. When not specified, Dependabot will resolve the default branch of the repository.|
 |AZURE_HOSTNAME|**_Optional_**. The hostname of the where the organization is hosted. Defaults to `dev.azure.com` but for older organizations this may have the format `xxx.visualstudio.com`. Check the url on the browser. For Azure DevOps Server, this may be the unexposed one e.g. `localhost:8080` or one that you have exposed publicly via DNS.|
 |AZURE_HOSTNAME_PACKAGING|**_Optional_**. The hostname for private package repositories, feeds and registries. By default this is inferred from the `AZURE_HOSTNAME` but may occasionally be different. When `AZURE_HOSTNAME` is `dev.azure.com` the value used is `pkgs.dev.azure.com` whereas when the value ends in `visualstudio.com`, the value takes the format `{organization}.pkgs.visualstudio.com`. In some situations, the code may still be referencing the older packaging urls but your organization is transitioning, in this case, you can specify `dev.azure.com` for `AZURE_HOSTNAME` and `xxx.pkgs.visualstudio.com` for `AZURE_HOSTNAME_PACKAGING`.|
+|OPEN_PULL_REQUESTS_LIMIT|**_Optional_**. The maximum number of open pull requests to have at any one time. Defaults to 5.|

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -39,6 +39,7 @@ steps:
   inputs:
     packageManager: 'docker'
     directory: '/docker'
+    openPullRequestsLimit: 10
 ```
 
 Since this task makes use of a docker image, it may take time to install the docker image. The user can choose to speed this up by using [Caching for Docker](https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#docker-images) in Azure Pipelines. See the [source file](./src/extension/task/index.ts) for the exact image tag, e.g. `tingle/dependabot-azure-devops:0.1.1`. Subsequent dependabot tasks in a job will be faster after the first one pulls the image for the first time.
@@ -53,7 +54,8 @@ Since this task makes use of a docker image, it may take time to install the doc
 |directory|**_Optional_**. The directory in which dependencies are to be checked. Examples: `/` for root, `/src` for src folder.|
 |targetBranch|**_Optional_**. The branch to be targeted when creating pull requests. When not specified, Dependabot will resolve the default branch of the repository. Examples: `master`, `main`, `develop`|
 |azureDevOpsAccessToken|**_Optional_**. The Personal Access Token for accessing Azure DevOps. Supply a value here to avoid using permissions for the Build Service either because you cannot change its permissions or because you prefer that the Pull Requests be done by a different user. When not provided, the current authentication scope is used. In either case, be use the following permissions are granted: <br/>-&nbsp;Code (Full)<br/>-&nbsp;Packaging (Read)<br/>-&nbsp;Pull Requests Threads (Read & Write).<br/>See the [documentation](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page#create-a-pat) to know more about creating a Personal Access Token|
-|packagingHostname|**_Optional_**. The hostname for private package repositories, feeds and registries. By default this is inferred from the current environment but may occasionally be different. When working using he new domain `dev.azure.com` the value used is `pkgs.dev.azure.com` whereas when working in the old url `xxx.visualstudio.com`, the value takes the format `xxx.pkgs.visualstudio.com`. In some situations, the code may still be referencing the older packaging urls but your organization is transitioning, in this case, you can specify `xxx.pkgs.visualstudio.com`.
+|packagingHostname|**_Optional_**. The hostname for private package repositories, feeds and registries. By default this is inferred from the current environment but may occasionally be different. When working using he new domain `dev.azure.com` the value used is `pkgs.dev.azure.com` whereas when working in the old url `xxx.visualstudio.com`, the value takes the format `xxx.pkgs.visualstudio.com`. In some situations, the code may still be referencing the older packaging urls but your organization is transitioning, in this case, you can specify `xxx.pkgs.visualstudio.com`.|
+|openPullRequestsLimit|**_Optional_**. The maximum number of open pull requests to have at any one time. Defaults to 5.|
 
 ## Advanced
 
@@ -85,6 +87,7 @@ steps:
   inputs:
     packageManager: 'docker'
     directory: '/docker'
+    openPullRequestsLimit: 10
 ```
 
 Check the logs for the image that is pulled.

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -137,6 +137,13 @@ async function run() {
             dockerRunner.arg(['-e', `AZURE_HOSTNAME_PACKAGING=${packagingHostname}`]);
         }
 
+        // Set the open pull requests limit
+        let openPullRequestsLimit = tl.getInput('openPullRequestsLimit', true);
+        if (openPullRequestsLimit)
+        {
+            dockerRunner.arg(['-e', `OPEN_PULL_REQUESTS_LIMIT=${openPullRequestsLimit}`]);
+        }
+
         // Allow overriding of the docker image tag globally
         let dockerImageTag: string = tl.getVariable('DEPENDABOT_DOCKER_IMAGE_TAG');
         if (!dockerImageTag) {

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -108,6 +108,14 @@
             "label": "Host name for private feeds.",
             "required": false,
             "helpMarkDown": "The hostname used for creating private feed urls. When not provided, it is inferred from the current environment. Examples: `pkgs.dev.azure.com`, `constoso.pkgs.visualstudio.com`"
+        },
+        {
+            "name": "openPullRequestsLimit",
+            "type": "int",
+            "label": "Limit number of open pull requests for version updates.",
+            "required": false,
+            "defaultValue": "5",
+            "helpMarkDown": "The maximum number of open pull requests to have at any one time. Defaults to 5."
         }
     ],
     "dataSourceBindings": [

--- a/templates/README.md
+++ b/templates/README.md
@@ -53,6 +53,8 @@ spec:
                 value: 'dev.azure.com'
               - name: AZURE_HOSTNAME_PACKAGING
                 value: 'pkgs.dev.azure.com'
+              - name: OPEN_PULL_REQUESTS_LIMIT
+                value: '10'
           restartPolicy: OnFailure
 
 ```

--- a/templates/dependabot-template.yml
+++ b/templates/dependabot-template.yml
@@ -41,4 +41,10 @@ spec:
                 value: '{{DIRECTORY_PATH}}'
               - name: TARGET_BRANCH
                 value: '{{TARGET_BRANCH}}'
+              - name: AZURE_HOSTNAME
+                value: '{{AZURE_HOSTNAME}}'
+              - name: AZURE_HOSTNAME_PACKAGING
+                value: '{{AZURE_HOSTNAME_PACKAGING}}'
+              - name: OPEN_PULL_REQUESTS_LIMIT
+                value: '{{OPEN_PULL_REQUESTS_LIMIT}}'
           restartPolicy: OnFailure


### PR DESCRIPTION
This PR introduces support for limiting the number of open pull requests. It is similar to the official [open-pull-requests-limit](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit) variable.