### PR TITLE
VisibleRule and GroupName conflict fix.

### DIFF
--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -88,7 +88,6 @@
     {
       "name": "versioningStrategy",
       "type": "pickList",
-      "groupName": "advanced",
       "label": "Versioning Strategy",
       "defaultValue": "auto",
       "required": true,


### PR DESCRIPTION
Remove `versioningStrategy` from advanced group as it has `visibleRule` in a different group.

Solves #69 