### PR TITLE
dependabot Docker image Permissions fix

### DIFF
--- a/src/script/Dockerfile
+++ b/src/script/Dockerfile
@@ -4,7 +4,8 @@ FROM dependabot/dependabot-core:0.142.1
 COPY ["Gemfile", "Gemfile.lock", "./"]
 
 # Install dependencies
-RUN bundle install -j 3 --path vendor
+RUN bundle config set --local path "vendor" \
+  && bundle install --jobs 4 --retry 3
 
 # Script files are known to change more frequently than Gemfiles.
 # They are copied after installation of dependencies so that the

--- a/src/script/Dockerfile
+++ b/src/script/Dockerfile
@@ -1,7 +1,10 @@
 FROM dependabot/dependabot-core:0.142.1
 
 # Copy the Gemfile and Gemfile.lock
-COPY ["Gemfile", "Gemfile.lock", "./"]
+ARG CODE_DIR=/home/dependabot/dependabot-script
+RUN mkdir -p ${CODE_DIR}
+COPY --chown=dependabot:dependabot Gemfile Gemfile.lock ${CODE_DIR}/
+WORKDIR ${CODE_DIR}
 
 # Install dependencies
 RUN bundle config set --local path "vendor" \
@@ -16,7 +19,7 @@ RUN bundle config set --local path "vendor" \
 # https://testdriven.io/blog/faster-ci-builds-with-docker-cache/
 
 # Copy the Ruby scripts
-COPY ["update-script.rb", "./"]
+COPY --chown=dependabot:dependabot update-script.rb ${CODE_DIR}
 
 # Run update script
 ENTRYPOINT ["bundle", "exec", "ruby", "./update-script.rb"]


### PR DESCRIPTION
Fixes for permissions in Docker for the new dependabot images.
See https://github.com/dependabot/dependabot-core/pull/3495 and guided by https://github.com/dependabot/dependabot-script/blob/main/Dockerfile