### PR TITLE
Updating Pull Requests

### DIFF
--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -131,6 +131,10 @@ async function run() {
       dockerRunner.arg(["-e", `AZURE_WORK_ITEM_ID=${workItemId}`]);
     }
 
+    // Set auto complete, if set
+    let setAutoComplete = tl.getBoolInput('setAutoComplete', false);
+    dockerRunner.arg(["-e", `AZURE_SET_AUTO_COMPLETE=${setAutoComplete}`]);
+
     // Set exception behaviour
     let failOnException = tl.getBoolInput("failOnException", true);
     dockerRunner.arg(["-e", `DEPENDABOT_FAIL_ON_EXCEPTION=${failOnException}`]);
@@ -153,6 +157,7 @@ async function run() {
     else updates = getConfigFromInputs();
 
     for (const update of updates) {
+      // TODO: ensure the arguments are cleared for every call
       dockerRunner.arg(["-e", `DEPENDABOT_PACKAGE_MANAGER=${update.packageEcosystem}`]);
 
       // Set the directory

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -106,8 +106,16 @@
       "type": "boolean",
       "label": "Determines if the execution should fail when an exception occurs. Defaults to `true`",
       "defaultValue": false,
-      "required": true,
+      "required": false,
       "helpMarkDown": "When set to true, a failure in updating a single dependency will cause the container execution to fail thereby causing the task to fail. This is important when you want a single failure to prevent trying to update other dependencies."
+    },
+    {
+      "name": "setAutoComplete",
+      "type": "boolean",
+      "label": "Determines if the pull requests that dependabot creates should have auto complete set",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "When set to `true`, pull requests that pass all policies will be merged automatically."
     },
     {
       "name": "gitHubConnection",

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "workItemId",
-      "type": "int",
+      "type": "string",
       "groupName": "work",
       "label": "Work item identifier to be linked to the Pull Requests.",
       "required": false,

--- a/src/script/Dockerfile
+++ b/src/script/Dockerfile
@@ -20,6 +20,7 @@ RUN bundle config set --local path "vendor" \
 
 # Copy the Ruby scripts
 COPY --chown=dependabot:dependabot update-script.rb ${CODE_DIR}
+COPY --chown=dependabot:dependabot azure_helpers.rb ${CODE_DIR}
 
 # Run update script
 ENTRYPOINT ["bundle", "exec", "ruby", "./update-script.rb"]

--- a/src/script/README.md
+++ b/src/script/README.md
@@ -25,6 +25,7 @@ docker run --rm -t \
            -e DEPENDABOT_ALLOW=<your-allowed-packages> \
            -e DEPENDABOT_IGNORE=<your-ignore-packages> \
            -e AZURE_WORK_ITEM_ID=<your-work-item-id> \
+           -e AZURE_SET_AUTO_COMPLETE=<true/false> \
            tingle/dependabot-azure-devops:0.2.0
 ```
 
@@ -47,6 +48,7 @@ docker run --rm -t \
            -e DEPENDABOT_ALLOW='[{\"name\":"django*",\"type\":\"direct\"}]' \
            -e DEPENDABOT_IGNORE='[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e AZURE_WORK_ITEM_ID=123 \
+           -e AZURE_SET_AUTO_COMPLETE=true \
            tingle/dependabot-azure-devops:0.2.0
 ```
 
@@ -72,3 +74,4 @@ To run the script, some environment variables are required.
 |DEPENDABOT_IGNORE|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
 |DEPENDABOT_FAIL_ON_EXCEPTION|**_Optional_**. Determines if the execution should fail when an exception occurs. Defaults to `true`.|
 |AZURE_WORK_ITEM_ID|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|
+|AZURE_SET_AUTO_COMPLETE|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically|

--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -58,15 +58,15 @@ module Dependabot
                 JSON.parse(response.body).fetch("value")
             end
 
-            def pull_request_auto_complete(pull_request_id, deleteSourceBranch, strategy, user_id)
+            def pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy, delete_source_branch = false)
                 # https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/update?view=azure-devops-rest-6.0
                 content = {
-                    completionOptions: {
-                        deleteSourceBranch: deleteSourceBranch,
-                        mergeStrategy: strategy
-                    },
                     autoCompleteSetBy: {
-                        id: user_id
+                        id: auto_complete_user_id
+                    },
+                    completionOptions: {
+                        mergeStrategy: merge_strategy,
+                        deleteSourceBranch: delete_source_branch
                     }
                 }
 
@@ -86,7 +86,7 @@ module Dependabot
                     **SharedHelpers.excon_defaults(
                         headers: auth_header.merge(
                             {
-                            "Content-Type" => "application/json"
+                                "Content-Type" => "application/json"
                             }
                         )
                     )

--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -22,8 +22,24 @@ def azure_abandon_pr(client, source, pull_request_id)
 end
 
 def azure_delete_branch(client, source, name)
-    # TODO: implement this
-    puts "Deleting branch is not yet implemented"
+    branch_name = name.gsub?("refs/heads/", "")
+    branch = client.branch(branch_name)
+    branch_object_id = branch["objectId"]
+
+    # https://developercommunity.visualstudio.com/t/delete-tags-or-branches-using-rest-apis/698220
+    # https://github.com/MicrosoftDocs/azure-devops-docs/issues/2648
+    content = [
+        {
+            name: name,
+            oldObjectId: branch_object_id,
+            newObjectId: "0000000000000000000000000000000000000000"
+        }
+    ]
+
+    response = client.post(source.api_endpoint +
+                source.organization + "/" + source.project +
+                "/_apis/git/repositories/" + source.unscoped_repo +
+                "/refs?api-version=5.0", content.to_json)
 end
 
 def azure_pull_request_commits(client, source, pull_request_id)
@@ -34,4 +50,9 @@ def azure_pull_request_commits(client, source, pull_request_id)
         "/commits")
 
     JSON.parse(response.body).fetch("value")
+end
+
+def azure_set_auto_complete(client, source, pull_request_id)
+    # TODO: implement this
+    puts "Setting auto complete is not yet implemented"
 end

--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -58,9 +58,22 @@ module Dependabot
                 JSON.parse(response.body).fetch("value")
             end
 
-            def pull_request_auto_complete(pull_request_id)
-                # TODO: implement this
-                puts "Setting auto complete is not yet implemented"
+            def pull_request_auto_complete(pull_request_id, deleteSourceBranch, strategy, user_id)
+                # https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/update?view=azure-devops-rest-6.0
+                content = {
+                    completionOptions: {
+                        deleteSourceBranch: deleteSourceBranch,
+                        mergeStrategy: strategy
+                    },
+                    autoCompleteSetBy: {
+                        id: user_id
+                    }
+                }
+
+                response = patch(source.api_endpoint +
+                    source.organization + "/" + source.project +
+                    "/_apis/git/repositories/" + source.unscoped_repo +
+                    "/pullrequests/#{pull_request_id}?api-version=6.0", content.to_json)
             end
 
             def patch(url, json)

--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -17,8 +17,14 @@ module Dependabot
             end
 
             def pull_request_abandon(pull_request_id)
-                # TODO: implement this
-                puts "Abandoning PR is not yet implemented"
+                content = {
+                    status: "abandoned"
+                }
+
+                response = patch(source.api_endpoint +
+                    source.organization + "/" + source.project +
+                    "/_apis/git/repositories/" + source.unscoped_repo +
+                    "/pullrequests/#{pull_request_id}?api-version=5.0", content.to_json)
             end
 
             def branch_delete(name)
@@ -57,6 +63,25 @@ module Dependabot
                 puts "Setting auto complete is not yet implemented"
             end
 
+            def patch(url, json)
+                response = Excon.patch(
+                    url,
+                    body: json,
+                    user: credentials&.fetch("username", nil),
+                    password: credentials&.fetch("password", nil),
+                    idempotent: true,
+                    **SharedHelpers.excon_defaults(
+                        headers: auth_header.merge(
+                            {
+                            "Content-Type" => "application/json"
+                            }
+                        )
+                    )
+                )
+                raise NotFound if response.status == 404
+
+                response
+            end
         end
     end
 end

--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -1,0 +1,37 @@
+require "json"
+require "dependabot/file_fetchers"
+require "dependabot/file_parsers"
+require "dependabot/update_checkers"
+require "dependabot/file_updaters"
+require "dependabot/pull_request_creator"
+require "dependabot/omnibus"
+
+def azure_get_active_prs(client, source, default_branch)
+    response = client.get(source.api_endpoint +
+        source.organization + "/" + source.project +
+        "/_apis/git/repositories/" + source.unscoped_repo +
+        "/pullrequests?searchCriteria.status=active" \
+        "&searchCriteria.targetRefName=refs/heads/" + default_branch)
+
+    JSON.parse(response.body).fetch("value")
+end
+
+def azure_abandon_pr(client, source, pull_request_id)
+    # TODO: implement this
+    puts "Abandoning PR is not yet implemented"
+end
+
+def azure_delete_branch(client, source, name)
+    # TODO: implement this
+    puts "Deleting branch is not yet implemented"
+end
+
+def azure_pull_request_commits(client, source, pull_request_id)
+    response = client.get(source.api_endpoint +
+        source.organization + "/" + source.project +
+        "/_apis/git/repositories/" + source.unscoped_repo +
+        "/pullrequests/" + "#{pull_request_id}" +
+        "/commits")
+
+    JSON.parse(response.body).fetch("value")
+end

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -389,12 +389,14 @@ dependencies.select(&:top_level?).each do |dep|
     # Set auto complete for this Pull Request
     # Pull requests that pass all policies will be merged automatically.
     if ENV["AZURE_SET_AUTO_COMPLETE"]
+      auto_complete_user_id = pull_request["createdBy"]["id"]
+      puts "Setting auto complete on ##{pull_request_id}."
+      # WARN: changing the naming of these arguements (or lack of) causes some wired error
       azure_client.pull_request_auto_complete(
         pull_request_id,
-        deleteSourceBranch: true,
-        # https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/update?view=azure-devops-rest-6.0#gitpullrequestmergestrategy
-        strategy: "squash", # Possible values: noFastForward, rebase, rebaseMerge, squash
-        user_id: pull_request["createdBy"]["id"]
+        auto_complete_user_id,
+        merge_strategy: "squash",
+        delete_source_branch: true,
       )
     end
 

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -365,20 +365,15 @@ dependencies.select(&:top_level?).each do |dep|
       print "Submitting #{dep.name} pull request for creation. "
       pull_request = pr_creator.create
 
-      if pull_request
+      if pull_request && pull_request&.status == 201
         content = JSON[pull_request.body]
-        status_code = pull_request&.status
         pull_request_id = content["pullRequestId"]
-        if status_code == 201
-          puts "Done (PR ##{pull_request_id})."
-        else
-          puts "Failed! PR already exists or an error has occurred."
-          puts "Status: #{status_code}."
-          puts "Message #{content["message"]}"
-          # TODO: throw exception here? (pull_request.create does not throw)
-        end
+        puts "Done (PR ##{pull_request_id})."
       else
-        puts "Seems PR is already present."
+        puts "Failed! PR already exists or an error has occurred."
+        puts "Status: #{pull_request&.status}."
+        puts "Message #{content["message"]}"
+        # TODO: throw exception here? (pull_request.create does not throw)
       end
     else
       pull_request = existing_pull_request # One already existed

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -122,9 +122,9 @@ unless json_credentials.to_s.strip.empty?
 end
 
 # Get the work item to attach
-work_item_id = ENV['AZURE_WORK_ITEM_ID'].to_i || nil
+work_item_id = ENV['AZURE_WORK_ITEM_ID'] || nil
 if work_item_id
-  puts "Pull Requests shall be linked to work item ##{work_item_id}"
+  puts "Pull Requests shall be linked to work item #{work_item_id}"
 end
 
 #####################################

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -381,7 +381,19 @@ dependencies.select(&:top_level?).each do |dep|
     pull_requests_count += 1
     next unless pull_request_id
 
-    # TODO: support setting auto complete here
+    # TODO: support approving the PR
+
+    # Set auto complete for this Pull Request
+    # Pull requests that pass all policies will be merged automatically.
+    if ENV["AZURE_SET_AUTO_COMPLETE"]
+      azure_client.pull_request_auto_complete(
+        pull_request_id,
+        deleteSourceBranch: true,
+        # https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/update?view=azure-devops-rest-6.0#gitpullrequestmergestrategy
+        strategy: "squash", # Possible values: noFastForward, rebase, rebaseMerge, squash
+        user_id: "" # TODO: get the userId from the created PR
+      )
+    end
 
   rescue StandardError => e
     raise e if fail_on_exception


### PR DESCRIPTION
This PR introduces support for updating Pull Requests in the following workflows:

- resolving merge conflicts (useful for when many pull requests are open)
- closing pull requests for dependencies with newer versions
- setting auto-complete for pull requests created

Notes: Resolving merge conflicts and closure of old pull requests requires the task to be executed.

This addresses issue #34 