### PR TITLE
Allow for null versions DEPENDABOT_IGNORE

### DIFF
--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -203,7 +203,7 @@ end
 def ignore_conditions_for(options, dependency)
   # Find where the name matches then get an array of version requirements, e.g. ["4.x", "5.x"]
   found = options.find { |ig| dependency.name.match?(ig['name']) }
-  found ? found['versions'] : []
+  found ? found['versions'] || [] : []
 end
 
 ################################################


### PR DESCRIPTION
Allow for `versions` to be missing in the entries encoded into `DEPENDABOT_IGNORE`