### PR TITLE
Fixes 2021 04 23

### DIFF
--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -28,7 +28,7 @@ module Dependabot
             end
 
             def branch_delete(name)
-                branch_name = name.gsub?("refs/heads/", "")
+                branch_name = name.gsub("refs/heads/", "")
                 branch = branch(branch_name)
                 branch_object_id = branch["objectId"]
 

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -386,6 +386,8 @@ dependencies.select(&:top_level?).each do |dep|
           # throw exception here because pull_request.create does not throw
           raise StandardError.new "Pull Request creation failed with status #{req_status}. Message: #{message}"
         end
+      else
+        puts "Seems PR is already present."
       end
     else
       pull_request = existing_pull_request # One already existed


### PR DESCRIPTION
Fixes:
- Extracting branch name before deleting old branch when a new version is available now works.
- When a PR is not created but there is no error, print "exists".