### PR TITLE
Auto complete fixes

### DIFF
--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -58,7 +58,7 @@ module Dependabot
                 JSON.parse(response.body).fetch("value")
             end
 
-            def pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy, delete_source_branch = false)
+            def pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy)
                 # https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/update?view=azure-devops-rest-6.0
                 content = {
                     autoCompleteSetBy: {
@@ -66,7 +66,7 @@ module Dependabot
                     },
                     completionOptions: {
                         mergeStrategy: merge_strategy,
-                        deleteSourceBranch: delete_source_branch,
+                        deleteSourceBranch: true,
                         transitionWorkItems: false
                     }
                 }

--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -66,7 +66,8 @@ module Dependabot
                     },
                     completionOptions: {
                         mergeStrategy: merge_strategy,
-                        deleteSourceBranch: delete_source_branch
+                        deleteSourceBranch: delete_source_branch,
+                        transitionWorkItems: false
                     }
                 }
 

--- a/src/script/azure_helpers.rb
+++ b/src/script/azure_helpers.rb
@@ -58,14 +58,14 @@ module Dependabot
                 JSON.parse(response.body).fetch("value")
             end
 
-            def pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy)
+            def pull_request_auto_complete(pull_request_id, auto_complete_user_id)
                 # https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/update?view=azure-devops-rest-6.0
                 content = {
                     autoCompleteSetBy: {
                         id: auto_complete_user_id
                     },
                     completionOptions: {
-                        mergeStrategy: merge_strategy,
+                        mergeStrategy: 2, # Setting "squash" seems to not work so instead, we set the value to 2 (as seen in Chrome's developer options)
                         deleteSourceBranch: true,
                         transitionWorkItems: false
                     }

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -410,7 +410,6 @@ dependencies.select(&:top_level?).each do |dep|
         pull_request_id,
         auto_complete_user_id,
         merge_strategy: "squash",
-        delete_source_branch: true,
       )
     end
 

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -405,12 +405,7 @@ dependencies.select(&:top_level?).each do |dep|
     if set_auto_complete
       auto_complete_user_id = pull_request["createdBy"]["id"]
       puts "Setting auto complete on ##{pull_request_id}."
-      # WARN: changing the naming of these arguements (or lack of) causes some wired error
-      azure_client.pull_request_auto_complete(
-        pull_request_id,
-        auto_complete_user_id,
-        merge_strategy: "squash",
-      )
+      azure_client.pull_request_auto_complete(pull_request_id, auto_complete_user_id)
     end
 
   rescue StandardError => e


### PR DESCRIPTION
Changes to auto complete:

- Added `transitionWorkItems`, always set to `false`.
- `deleteSourceBranch` is fixed to `true`.
- `mergeStrategy` seems to not work with `squash` value, instead fix value to `2` which means squash.