### PR TITLE
dockerImageTag as task input

### DIFF
--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -64,15 +64,16 @@ Since this task makes use of a docker image, it may take time to install the doc
 |openPullRequestsLimit|**_Optional_**. The maximum number of open pull requests to have at any one time. Defaults to 5.|
 |versioningStrategy|**_Optional_**. The versioning strategy to use. See the [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy). Defaults to `auto`.|
 |failOnException|**_Optional_**. Determines if the execution should fail when an exception occurs. Defaults to `true`.|
+|workItemId|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|
+|setAutoComplete|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically.|
 |autoApprove|**_Optional_**. Determines if the pull requests that dependabot creates should be automatically completed. When set to `true`, pull requests will be approved automatically by the user specified in the `autoApproveUserEmail` field.|
 |autoApproveUserEmail|**_Optional_**. Email of the user that should be used to automatically approve pull requests. Required if `autoApprove` is set to `true`.|
 |autoApproveUserToken|**_Optional_**. A personal access token that is assigned to the user specified in `autoApproveUserEmail` to automatically approve the created PR. Required if `autoApprove` is set to `true`.|
-|setAutoComplete|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically.|
 |gitHubConnection|**_Optional_**. The GitHub service connection for authenticating requests against GitHub public repositories. This is useful to avoid rate limiting errors. The token must include permissions to read public repositories. See the [GitHub docs](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) for more on Personal Access Tokens and [Azure DevOps docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml#sep-github) for the GitHub service connection.|
 |azureDevOpsAccessToken|**_Optional_**. The Personal Access Token for accessing Azure DevOps. Supply a value here to avoid using permissions for the Build Service either because you cannot change its permissions or because you prefer that the Pull Requests be done by a different user. When not provided, the current authentication scope is used. In either case, be use the following permissions are granted: <br/>-&nbsp;Code (Full)<br/>-&nbsp;Pull Requests Threads (Read & Write).<br/>See the [documentation](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page#create-a-pat) to know more about creating a Personal Access Token|
 |targetRepositoryName|**_Optional_**. The name of the repository to target for processing. If this value is not supplied then the Build Repository Name is used. Supplying this value allows creation of a single pipeline that runs Dependablot against multiple repositories.|
 |excludeRequirementsToUnlock|**_Optional_**. Space-separated list of dependency updates requirements to be excluded. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement.|
-|workItemId|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|
+|dockerImageTag|**_Optional_**. The image tag to use when pulling the docker container used by the task. A tag also defines the version. By default, the task decides which tag/version to use. This can be the latest or most stable version.|
 
 ## Advanced
 
@@ -92,7 +93,6 @@ schedules:
 
 # variables declared below can be put in one or more Variable Groups for sharing across pipelines
 variables:
-  DEPENDABOT_DOCKER_IMAGE_TAG: '0.4.0' # could also be 'latest'
   DEPENDABOT_EXTRA_CREDENTIALS: '[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' # put the credentials for private registries and feeds
   DEPENDABOT_ALLOW: '[{\"name\":"django*",\"type\":\"direct\"}]' # packages allowed to be updated
   DEPENDABOT_IGNORE: '[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -215,9 +215,10 @@ async function run() {
         dockerRunner.arg(["-e", `DEPENDABOT_IGNORE=${ignore}`]);
       }
 
-      // Allow overriding of the docker image tag globally
-      let dockerImageTag: string = tl.getVariable("DEPENDABOT_DOCKER_IMAGE_TAG");
+      // Allow overriding of the docker image tag
+      let dockerImageTag: string = tl.getInput('dockerImageTag');
       if (!dockerImageTag) {
+        // TODO: get the latest version to use from a given url
         dockerImageTag = "0.4"; // will pull the latest patch for 0.4 e.g. 0.4.0
       }
 

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -191,6 +191,14 @@
       "label": "Space-separated list of dependency updates requirements to be excluded.",
       "required": false,
       "helpMarkDown": "Exclude certain dependency updates requirements. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement."
+    },
+    {
+      "name": "dockerImageTag",
+      "type": "string",
+      "groupName": "advanced",
+      "label": "Tag of the docker image to be pulled.",
+      "required": false,
+      "helpMarkDown": "The image tag to use when pulling the docker container used by the task. A tag also defines the version. By default, the task decides which tag/version to use. This can be the latest or most stable version."
     }
   ],
   "dataSourceBindings": [],


### PR DESCRIPTION
Replace `DEPENDABOT_DOCKER_IMAGE_TAG` env variable with `dockerImageTag` input hence allow different tasks instances to use different tags/versions.