### PR TITLE
Allow repo_name to be overridden

### DIFF
--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -14,6 +14,14 @@ project = ENV["AZURE_PROJECT"]
 repository = ENV["AZURE_REPOSITORY"]
 repo_name = "#{organization}/#{project}/_git/#{repository}"
 
+# Allow the user to override the full repo path
+# Useful for legacy org.visualstudio.com URLs where the org name isn't needed in the URL path
+if repository.start_with("https://")
+  repo_name = repository
+end
+
+put "Using '#{repo_name}' as repo path"
+
 # Set auto complete on created pull requests
 set_auto_complete = ENV["AZURE_SET_AUTO_COMPLETE"] == "true"
 


### PR DESCRIPTION
Organisations using the old org.visualstudio.com URL rather than the new dev.azure.com/org structure don't have the same repo path. This allows them to override this fully if the organisation is not yet in a state to migrate domains.

If the repo_name is provided in the pipeline inputs as standard (eg. `dependabot-azure-devops`) then it will behave as standard and build the URL using the other variables.

If it is provided as a full URL (eg. `https://org.visualstudio.com/Project/_git/dependabot-azure-devops`) then this will be used as-provided.