### PR TITLE
Cleanup and fixes (2021-05-28)

### DIFF
--- a/cronjob-template.yaml
+++ b/cronjob-template.yaml
@@ -68,9 +68,9 @@ spec:
               value: '{{dependabot_versioning_strategy}}'
             - name: DEPENDABOT_EXTRA_CREDENTIALS
               value: '{{dependabot_extra_credentials}}'
-            - name: DEPENDABOT_ALLOW
-              value: '{{dependabot_allow}}'
-            - name: DEPENDABOT_IGNORE
-              value: '{{dependabot_ignore}}'
+            - name: DEPENDABOT_ALLOW_CONDITIONS
+              value: '{{dependabot_allow_conditions}}'
+            - name: DEPENDABOT_IGNORE_CONDITIONS
+              value: '{{dependabot_ignore_conditions}}'
             - name: DEPENDABOT_FAIL_ON_EXCEPTION
               value: '{{dependabot_fail_on_exception}}'

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -94,8 +94,8 @@ schedules:
 # variables declared below can be put in one or more Variable Groups for sharing across pipelines
 variables:
   DEPENDABOT_EXTRA_CREDENTIALS: '[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' # put the credentials for private registries and feeds
-  DEPENDABOT_ALLOW_CONDITIONS: '[{\"name\":"django*",\"type\":\"direct\"}]' # packages allowed to be updated
-  DEPENDABOT_IGNORE_CONDITIONS: '[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored
+  DEPENDABOT_ALLOW_CONDITIONS: '[{\"dependency-name\":"django*",\""dependency-type\":\"direct\"}]' # packages allowed to be updated
+  DEPENDABOT_IGNORE_CONDITIONS: '[{\""dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored
 
 pool:
   vmImage: 'ubuntu-latest' # requires macos or ubuntu (windows is not supported)

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -94,8 +94,8 @@ schedules:
 # variables declared below can be put in one or more Variable Groups for sharing across pipelines
 variables:
   DEPENDABOT_EXTRA_CREDENTIALS: '[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' # put the credentials for private registries and feeds
-  DEPENDABOT_ALLOW: '[{\"name\":"django*",\"type\":\"direct\"}]' # packages allowed to be updated
-  DEPENDABOT_IGNORE: '[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored
+  DEPENDABOT_ALLOW_CONDITIONS: '[{\"name\":"django*",\"type\":\"direct\"}]' # packages allowed to be updated
+  DEPENDABOT_IGNORE_CONDITIONS: '[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored
 
 pool:
   vmImage: 'ubuntu-latest' # requires macos or ubuntu (windows is not supported)

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -190,8 +190,8 @@ async function run() {
     dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${excludeRequirementsToUnlock}`]);
 
     // Get the override allow and ignore
-    let allowOvr = tl.getVariable("DEPENDABOT_ALLOW");
-    let ignoreOvr = tl.getVariable("DEPENDABOT_IGNORE");
+    let allowOvr = tl.getVariable("DEPENDABOT_ALLOW_CONDITIONS");
+    let ignoreOvr = tl.getVariable("DEPENDABOT_IGNORE_CONDITIONS");
 
     // Check if to use dependabot.yml or task inputs
     let useConfigFile: boolean = tl.getBoolInput("useConfigFile", false);
@@ -226,13 +226,13 @@ async function run() {
       // Set the dependencies to allow
       let allow = update.allow || allowOvr;
       if (allow) {
-        dockerRunner.arg(["-e", `DEPENDABOT_ALLOW=${allow}`]);
+        dockerRunner.arg(["-e", `DEPENDABOT_ALLOW_CONDITIONS=${allow}`]);
       }
 
       // Set the dependencies to ignore
       let ignore = update.ignore || ignoreOvr;
       if (ignore) {
-        dockerRunner.arg(["-e", `DEPENDABOT_IGNORE=${ignore}`]);
+        dockerRunner.arg(["-e", `DEPENDABOT_IGNORE_CONDITIONS=${ignore}`]);
       }
 
       // Allow overriding of the docker image tag

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -51,13 +51,8 @@ export default function parseConfigFile(): IDependabotUpdate[] {
       versioningStrategy: update["versioning-strategy"],
 
       // Convert to JSON and shorten the names as required by the script
-      allow: updates["allow"]
-                ? JSON.stringify(updates["allow"]).replace("dependency-name", "name")
-                                                  .replace("dependency-type", "type")
-                : undefined,
-      ignore: updates["ignore"]
-                ? JSON.stringify(updates["ignore"]).replace("dependency-name", "name")
-                : undefined,
+      allow: updates["allow"] ? JSON.stringify(updates["allow"]) : undefined,
+      ignore: updates["ignore"] ? JSON.stringify(updates["ignore"]) : undefined,
     };
 
     if (!dependabotUpdate.packageEcosystem) {

--- a/src/script/README.md
+++ b/src/script/README.md
@@ -51,8 +51,8 @@ docker run --rm -t \
            -e DEPENDABOT_VERSIONING_STRATEGY=auto \
            -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=10 \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
-           -e DEPENDABOT_ALLOW_CONDITIONS='[{\"name\":"django*",\"type\":\"direct\"}]' \
-           -e DEPENDABOT_IGNORE_CONDITIONS='[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
+           -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
+           -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e AZURE_WORK_ITEM_ID=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
@@ -80,8 +80,8 @@ docker run --rm -t \
            -e DEPENDABOT_VERSIONING_STRATEGY=auto \
            -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=10 \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
-           -e DEPENDABOT_ALLOW_CONDITIONS='[{\"name\":"django*",\"type\":\"direct\"}]' \
-           -e DEPENDABOT_IGNORE_CONDITIONS='[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
+           -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
+           -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e AZURE_WORK_ITEM_ID=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
@@ -111,8 +111,8 @@ To run the script, some environment variables are required.
 |DEPENDABOT_VERSIONING_STRATEGY|**_Optional_**. The versioning strategy to use. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy) for the allowed values|
 |DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT|**_Optional_**. The maximum number of open pull requests to have at any one time. Defaults to 5.|
 |DEPENDABOT_EXTRA_CREDENTIALS|**_Optional_**. The extra credentials in JSON format. Extra credentials can be used to access private NuGet feeds, docker registries, maven repositories, etc. For example a private registry authentication (For example FontAwesome Pro: `[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]`)|
-|DEPENDABOT_ALLOW_CONDITIONS|**_Optional_**. The dependencies whose updates are allowed, in JSON format. This can be used to control which packages can be updated. For example: `[{\"name\":"django*",\"type\":\"direct\"}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow) for more.|
-|DEPENDABOT_IGNORE_CONDITIONS|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
+|DEPENDABOT_ALLOW_CONDITIONS|**_Optional_**. The dependencies whose updates are allowed, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow) for more.|
+|DEPENDABOT_IGNORE_CONDITIONS|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
 |DEPENDABOT_FAIL_ON_EXCEPTION|**_Optional_**. Determines if the execution should fail when an exception occurs. Defaults to `true`.|
 |DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK|**_Optional_**. Exclude certain dependency updates requirements. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement.|
 |AZURE_WORK_ITEM_ID|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|

--- a/src/script/README.md
+++ b/src/script/README.md
@@ -25,8 +25,8 @@ docker run --rm -t \
            -e DEPENDABOT_VERSIONING_STRATEGY=<your-versioning-strategy> \
            -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=10 \
            -e DEPENDABOT_EXTRA_CREDENTIALS=<your-extra-credentials> \
-           -e DEPENDABOT_ALLOW=<your-allowed-packages> \
-           -e DEPENDABOT_IGNORE=<your-ignore-packages> \
+           -e DEPENDABOT_ALLOW_CONDITIONS=<your-allowed-packages> \
+           -e DEPENDABOT_IGNORE_CONDITIONS=<your-ignore-packages> \
            -e AZURE_WORK_ITEM_ID=<your-work-item-id> \
            -e AZURE_SET_AUTO_COMPLETE=<true/false> \
            -e AZURE_AUTO_APPROVE_PR=<true/false> \
@@ -51,8 +51,8 @@ docker run --rm -t \
            -e DEPENDABOT_VERSIONING_STRATEGY=auto \
            -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=10 \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
-           -e DEPENDABOT_ALLOW='[{\"name\":"django*",\"type\":\"direct\"}]' \
-           -e DEPENDABOT_IGNORE='[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
+           -e DEPENDABOT_ALLOW_CONDITIONS='[{\"name\":"django*",\"type\":\"direct\"}]' \
+           -e DEPENDABOT_IGNORE_CONDITIONS='[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e AZURE_WORK_ITEM_ID=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
@@ -80,8 +80,8 @@ docker run --rm -t \
            -e DEPENDABOT_VERSIONING_STRATEGY=auto \
            -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=10 \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
-           -e DEPENDABOT_ALLOW='[{\"name\":"django*",\"type\":\"direct\"}]' \
-           -e DEPENDABOT_IGNORE='[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
+           -e DEPENDABOT_ALLOW_CONDITIONS='[{\"name\":"django*",\"type\":\"direct\"}]' \
+           -e DEPENDABOT_IGNORE_CONDITIONS='[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e AZURE_WORK_ITEM_ID=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
@@ -111,8 +111,8 @@ To run the script, some environment variables are required.
 |DEPENDABOT_VERSIONING_STRATEGY|**_Optional_**. The versioning strategy to use. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy) for the allowed values|
 |DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT|**_Optional_**. The maximum number of open pull requests to have at any one time. Defaults to 5.|
 |DEPENDABOT_EXTRA_CREDENTIALS|**_Optional_**. The extra credentials in JSON format. Extra credentials can be used to access private NuGet feeds, docker registries, maven repositories, etc. For example a private registry authentication (For example FontAwesome Pro: `[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]`)|
-|DEPENDABOT_ALLOW|**_Optional_**. The dependencies whose updates are allowed, in JSON format. This can be used to control which packages can be updated. For example: `[{\"name\":"django*",\"type\":\"direct\"}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow) for more.|
-|DEPENDABOT_IGNORE|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
+|DEPENDABOT_ALLOW_CONDITIONS|**_Optional_**. The dependencies whose updates are allowed, in JSON format. This can be used to control which packages can be updated. For example: `[{\"name\":"django*",\"type\":\"direct\"}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow) for more.|
+|DEPENDABOT_IGNORE_CONDITIONS|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
 |DEPENDABOT_FAIL_ON_EXCEPTION|**_Optional_**. Determines if the execution should fail when an exception occurs. Defaults to `true`.|
 |DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK|**_Optional_**. Exclude certain dependency updates requirements. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement.|
 |AZURE_WORK_ITEM_ID|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -1,4 +1,8 @@
 require "json"
+require "logger"
+require "dependabot/logger"
+
+Dependabot.logger = Logger.new($stdout)
 
 require "dependabot/file_fetchers"
 require "dependabot/file_parsers"
@@ -6,6 +10,7 @@ require "dependabot/update_checkers"
 require "dependabot/file_updaters"
 require "dependabot/pull_request_creator"
 require "dependabot/pull_request_updater"
+require "dependabot/config/file_fetcher"
 require "dependabot/omnibus"
 
 require_relative "azure_helpers"

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -182,7 +182,7 @@ end
 ###########################
 unless ENV["DEPENDABOT_IGNORE_CONDITIONS"].to_s.strip.empty?
   # For example:
-  # [{"dependency-name":"ruby","version-requirement":">= 3.a, < 4"}]
+  # [{"dependency-name":"ruby","versions":[">= 3.a", "< 4"]}]
   $options[:ignore_conditions] = JSON.parse(ENV["DEPENDABOT_IGNORE_CONDITIONS"])
 end
 
@@ -192,7 +192,7 @@ def ignored_versions_for(dep)
     ignore_conditions = $options[:ignore_conditions].map do |ic|
       Dependabot::Config::IgnoreCondition.new(
         dependency_name: ic["dependency-name"],
-        versions: [ic["version-requirement"]].compact,
+        versions: ic["versions"],
         update_types: ic["update-types"]
       )
     end

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -355,7 +355,11 @@ dependencies.select(&:top_level?).each do |dep|
         # If the title does not contain the updated version,
         # we need to close the PR and delete it's branch,
         # because there is a newer version available
-        if !title.include?(updated_deps[0].version)
+        #
+        # Sample Titles:
+        # Bump Tingle.Extensions.Logging.LogAnalytics from 3.4.2-ci0005 to 3.4.2-ci0006
+        # chore(deps): bump dotenv from 9.0.1 to 9.0.2 in /server
+        if !title.include?("#{updated_deps[0].version} ") && !title.end_with?(updated_deps[0].version)
           # Close old version PR
           azure_client.pull_request_abandon(pr_id)
           azure_client.branch_delete(sourceRefName)


### PR DESCRIPTION
This PR creates a centralized place for the options similar to the cores `dry-run.rb` script thus easier to maintain them. It also:
1. Sets the dependabot logger
2. Use the default naming for `allow` and `ignore` members.
3. Accommodates for pre-release versions when checking if to close an existing PR