### PR TITLE
Support for milestone

### DIFF
--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -64,7 +64,7 @@ Since this task makes use of a docker image, it may take time to install the doc
 |openPullRequestsLimit|**_Optional_**. The maximum number of open pull requests to have at any one time. Defaults to 5.|
 |versioningStrategy|**_Optional_**. The versioning strategy to use. See the [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy). Defaults to `auto`.|
 |failOnException|**_Optional_**. Determines if the execution should fail when an exception occurs. Defaults to `true`.|
-|workItemId|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|
+|milestone|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|
 |setAutoComplete|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically.|
 |autoApprove|**_Optional_**. Determines if the pull requests that dependabot creates should be automatically completed. When set to `true`, pull requests will be approved automatically by the user specified in the `autoApproveUserEmail` field.|
 |autoApproveUserEmail|**_Optional_**. Email of the user that should be used to automatically approve pull requests. Required if `autoApprove` is set to `true`.|

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -153,10 +153,10 @@ async function run() {
     repository = encodeURI(repository); // encode special characters like spaces
     dockerRunner.arg(["-e", `AZURE_REPOSITORY=${repository}`]);
 
-    // Set the work item id, if provided
-    let workItemId = tl.getInput("workItemId");
-    if (workItemId) {
-      dockerRunner.arg(["-e", `DEPENDABOT_MILESTONE=${workItemId}`]);
+    // Set the milestone, if provided
+    let milestone = tl.getInput("milestone");
+    if (milestone) {
+      dockerRunner.arg(["-e", `DEPENDABOT_MILESTONE=${milestone}`]);
     }
 
     // Set auto complete, if set

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -84,10 +84,9 @@ async function run() {
     dockerRunner.arg(["--rm"]); // remove after execution
     dockerRunner.arg(["-i"]); // attach pseudo tty
 
-
     // Set the protocol
     var organizationUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-    var parsedUrl = new URL(organizationUrl);  
+    var parsedUrl = new URL(organizationUrl);
     let protocol: string = parsedUrl.protocol.slice(0, -1);
     dockerRunner.arg(["-e", `AZURE_PROTOCOL=${protocol}`]);
 
@@ -153,12 +152,6 @@ async function run() {
     repository = encodeURI(repository); // encode special characters like spaces
     dockerRunner.arg(["-e", `AZURE_REPOSITORY=${repository}`]);
 
-    // Set the milestone, if provided
-    let milestone = tl.getInput("milestone");
-    if (milestone) {
-      dockerRunner.arg(["-e", `DEPENDABOT_MILESTONE=${milestone}`]);
-    }
-
     // Set auto complete, if set
     let setAutoComplete = tl.getBoolInput('setAutoComplete', false);
     dockerRunner.arg(["-e", `AZURE_SET_AUTO_COMPLETE=${setAutoComplete}`]);
@@ -189,7 +182,7 @@ async function run() {
     let excludeRequirementsToUnlock = tl.getInput('excludeRequirementsToUnlock') || "";
     dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${excludeRequirementsToUnlock}`]);
 
-    // Get the override allow and ignore
+    // Get the override values for allow and ignore
     let allowOvr = tl.getVariable("DEPENDABOT_ALLOW_CONDITIONS");
     let ignoreOvr = tl.getVariable("DEPENDABOT_IGNORE_CONDITIONS");
 
@@ -227,6 +220,11 @@ async function run() {
       let allow = update.allow || allowOvr;
       if (allow) {
         dockerRunner.arg(["-e", `DEPENDABOT_ALLOW_CONDITIONS=${allow}`]);
+      }
+
+      // Set the milestone, if provided
+      if (update.milestone) {
+        dockerRunner.arg(["-e", `DEPENDABOT_MILESTONE=${update.milestone}`]);
       }
 
       // Set the dependencies to ignore

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -156,7 +156,7 @@ async function run() {
     // Set the work item id, if provided
     let workItemId = tl.getInput("workItemId");
     if (workItemId) {
-      dockerRunner.arg(["-e", `AZURE_WORK_ITEM_ID=${workItemId}`]);
+      dockerRunner.arg(["-e", `DEPENDABOT_MILESTONE=${workItemId}`]);
     }
 
     // Set auto complete, if set

--- a/src/extension/task/models/IDependabotUpdate.ts
+++ b/src/extension/task/models/IDependabotUpdate.ts
@@ -5,28 +5,28 @@
  */
 export interface IDependabotUpdate {
   /**
-   * Location of package manifests
+   * Location of package manifests.
    * */
   directory: string;
   /**
-   * Package manager to use
+   * Package manager to use.
    * */
   packageEcosystem: string;
   schedule?: IDependabotUpdateSchedule;
   /**
-   * Customize which updates are allowed
+   * Customize which updates are allowed.
    */
   allow?: IDependabotAllowDependency[] | string;
   /**
-   * Ignore certain dependencies or versions
+   * Ignore certain dependencies or versions.
    */
   ignore?: IDependabotIgnoreDependency[] | string;
   /**
-   * 	Limit number of open pull requests for version updates
+   * 	Limit number of open pull requests for version updates.
    */
   openPullRequestLimit?: number;
   /**
-   * Branch to create pull requests against
+   * Branch to create pull requests against.
    */
   targetBranch?: string;
   /**
@@ -34,9 +34,13 @@ export interface IDependabotUpdate {
    */
   vendor?: boolean;
   /**
-   * How to update manifest version requirements
+   * How to update manifest version requirements.
    */
   versioningStrategy?: string;
+  /**
+   * The milestone to associate pull requests with.
+   */
+   milestone?: string;
 }
 
 export interface IDependabotAllowDependency {

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -115,7 +115,7 @@
       "helpMarkDown": "When set to true, a failure in updating a single dependency will cause the container execution to fail thereby causing the task to fail. This is important when you want a single failure to prevent trying to update other dependencies."
     },
     {
-      "name": "workItemId",
+      "name": "milestone",
       "type": "string",
       "label": "Work item identifier to be linked to the Pull Requests.",
       "required": false,

--- a/src/extension/task/utils/getConfigFromInputs.ts
+++ b/src/extension/task/utils/getConfigFromInputs.ts
@@ -18,6 +18,7 @@ export default function getConfigFromInputs() {
 
     targetBranch: getInput("targetBranch", false),
     versioningStrategy: getInput("versioningStrategy", true),
+    milestone: getInput("milestone"),
   };
 
   return [dependabotUpdate];

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -49,6 +49,7 @@ export default function parseConfigFile(): IDependabotUpdate[] {
 
       targetBranch: update["target-branch"],
       versioningStrategy: update["versioning-strategy"],
+      milestone: update["milestone"],
 
       // Convert to JSON and shorten the names as required by the script
       allow: updates["allow"] ? JSON.stringify(updates["allow"]) : undefined,

--- a/src/script/README.md
+++ b/src/script/README.md
@@ -27,7 +27,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS=<your-extra-credentials> \
            -e DEPENDABOT_ALLOW_CONDITIONS=<your-allowed-packages> \
            -e DEPENDABOT_IGNORE_CONDITIONS=<your-ignore-packages> \
-           -e AZURE_WORK_ITEM_ID=<your-work-item-id> \
+           -e DEPENDABOT_MILESTONE=<your-work-item-id> \
            -e AZURE_SET_AUTO_COMPLETE=<true/false> \
            -e AZURE_AUTO_APPROVE_PR=<true/false> \
            -e AZURE_AUTO_APPROVE_USER_EMAIL=<approving-user-email> \
@@ -53,7 +53,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
            -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
-           -e AZURE_WORK_ITEM_ID=123 \
+           -e DEPENDABOT_MILESTONE=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
            -e AZURE_AUTO_APPROVE_USER_EMAIL=supervisor@contoso.com \
@@ -82,7 +82,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
            -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
-           -e AZURE_WORK_ITEM_ID=123 \
+           -e DEPENDABOT_MILESTONE=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
            -e AZURE_AUTO_APPROVE_USER_EMAIL=supervisor@contoso.com \
@@ -115,7 +115,7 @@ To run the script, some environment variables are required.
 |DEPENDABOT_IGNORE_CONDITIONS|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
 |DEPENDABOT_FAIL_ON_EXCEPTION|**_Optional_**. Determines if the execution should fail when an exception occurs. Defaults to `true`.|
 |DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK|**_Optional_**. Exclude certain dependency updates requirements. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement.|
-|AZURE_WORK_ITEM_ID|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|
+|DEPENDABOT_MILESTONE|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|
 |AZURE_SET_AUTO_COMPLETE|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically|
 |AZURE_AUTO_APPROVE_PR|**_Optional_**. Determines if the pull requests that dependabot creates should be automatically completed. When set to `true`, pull requests will be approved automatically by the user specified in the `AZURE_AUTO_APPROVE_USER_EMAIL` environment variable.|
 |AZURE_AUTO_APPROVE_USER_EMAIL|**_Optional_**. Email of the user that should be used to automatically approve pull requests. Required if `AZURE_AUTO_APPROVE_PR` is set to `true`.|

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -45,7 +45,7 @@ $options = {
   azure_port: nil,
   azure_virtual_directory: ENV["AZURE_VIRTUAL_DIRECTORY"] || "",
 
-  work_item_id: ENV['AZURE_WORK_ITEM_ID'] || nil, # Get the work item to attach
+  work_item_id: ENV['DEPENDABOT_MILESTONE'] || nil, # Get the work item to attach
 
   set_auto_complete: ENV["AZURE_SET_AUTO_COMPLETE"] == "true", # Set auto complete on created pull requests
 


### PR DESCRIPTION
This PR adds support for the [`milestone` option](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#milestone). This is expected to the work item identifier in Azure Boards.

As a result:
1. `AZURE_WORK_ITEM_ID` environment variable has been replaced with `DEPENDABOT_MILESTONE`.
2. `workItemId` task input has been renamed to `milestone`.