### PR TITLE
Ignore and Allow bug fix

### DIFF
--- a/src/extension/task/models/IDependabotUpdate.ts
+++ b/src/extension/task/models/IDependabotUpdate.ts
@@ -16,11 +16,11 @@ export interface IDependabotUpdate {
   /**
    * Customize which updates are allowed.
    */
-  allow?: IDependabotAllowDependency[] | string;
+  allow?: string;
   /**
    * Ignore certain dependencies or versions.
    */
-  ignore?: IDependabotIgnoreDependency[] | string;
+  ignore?: string;
   /**
    * 	Limit number of open pull requests for version updates.
    */
@@ -41,16 +41,6 @@ export interface IDependabotUpdate {
    * The milestone to associate pull requests with.
    */
    milestone?: string;
-}
-
-export interface IDependabotAllowDependency {
-  dependencyName: string;
-  dependencyType: string;
-}
-
-export interface IDependabotIgnoreDependency {
-  dependencyName: string;
-  versions: string[];
 }
 
 export interface IDependabotUpdateSchedule {

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -69,8 +69,8 @@ export default function parseConfigFile(): IDependabotUpdate[] {
       milestone: update["milestone"],
 
       // Convert to JSON and shorten the names as required by the script
-      allow: updates["allow"] ? JSON.stringify(updates["allow"]) : undefined,
-      ignore: updates["ignore"] ? JSON.stringify(updates["ignore"]) : undefined,
+      allow: update["allow"] ? JSON.stringify(update["allow"]) : undefined,
+      ignore: update["ignore"] ? JSON.stringify(update["ignore"]) : undefined,
     };
 
     if (!dependabotUpdate.packageEcosystem) {

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -28,6 +28,23 @@ export default function parseConfigFile(): IDependabotUpdate[] {
     throw new Error("Invalid dependabot config object");
   }
 
+  const rawVersion = config["version"];
+  let version = -1;
+
+  // ensure the version has been specified
+  if(!!!rawVersion) throw new Error("The version must be specified in dependabot.yml");
+
+  //try convert the version to integer
+  try{
+    version = parseInt(rawVersion, 10);
+  }
+  catch(e) {
+    throw new Error("Dependabot version specified must be a valid integer");
+  }
+
+  //ensure the version is == 2
+  if(version !== 2) throw new Error("Only version 2 of dependabot is supported. Version specified: " + version);
+
   var updates: IDependabotUpdate[] = [];
 
   //check the updates parsed


### PR DESCRIPTION
`allow` and `ignore` options are now picked correctly by the extension. Fixes #97 
This PR also validates the version set in the configuration