### PR TITLE
Add extraEnvironmentVariables support

### DIFF
--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -75,6 +75,7 @@ Since this task makes use of a docker image, it may take time to install the doc
 |targetRepositoryName|**_Optional_**. The name of the repository to target for processing. If this value is not supplied then the Build Repository Name is used. Supplying this value allows creation of a single pipeline that runs Dependablot against multiple repositories.|
 |excludeRequirementsToUnlock|**_Optional_**. Space-separated list of dependency updates requirements to be excluded. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement.|
 |dockerImageTag|**_Optional_**. The image tag to use when pulling the docker container used by the task. A tag also defines the version. By default, the task decides which tag/version to use. This can be the latest or most stable version.|
+|extraEnvironmentVariables|**_Optional_**. A semicolon (`;`) delimited list of environment variables that are sent to the docker container. See possible use case [here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/138)|
 
 ## Advanced
 

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -157,7 +157,7 @@ async function run() {
     else updates = getConfigFromInputs();
 
     // Get extraEnvironmentVariable list
-    let extraEnvironmentVariables = extractExtraEnvironmentVariables(tl.getDelimitedInput("extraEnvironmentVariable", ";", false));
+    let extraEnvironmentVariables = extractExtraEnvironmentVariables(tl.getDelimitedInput("extraEnvironmentVariables", ";", false));
 
     // For each update run docker container
     for (const update of updates) {

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -72,6 +72,25 @@ function extractOrganization(organizationUrl: string): string {
   );
 }
 
+function extractExtraEnvironmentVariables(rawExtraEnvironmentVariables: string[]): Map<string, string> {
+  let formattedEnvironmentVariables = new Map<string, string>();
+
+  // With how this is set up later environment variables could overwrite earlier environment variables but that is on the user
+  for (const extraEnvironmentVariable in rawExtraEnvironmentVariables) {
+    let environmentVariableParts = extraEnvironmentVariable.split("=");
+
+    if (environmentVariableParts.length === 2) {
+      // Add both the given name and value to the formatted list
+      formattedEnvironmentVariables.set(environmentVariableParts[0], environmentVariableParts[1]);
+    } else if (environmentVariableParts.length === 1) {
+      // Treat the single argument as the name and push an empty string as the value
+      formattedEnvironmentVariables.set(environmentVariableParts[0], "");
+    }
+  }
+
+  return formattedEnvironmentVariables;
+}
+
 async function run() {
   try {
     // Checking if docker is installed
@@ -136,6 +155,9 @@ async function run() {
 
     if (useConfigFile) updates = parseConfigFile();
     else updates = getConfigFromInputs();
+
+    // Get extraEnvironmentVariable list
+    let extraEnvironmentVariables = extractExtraEnvironmentVariables(tl.getDelimitedInput("extraEnvironmentVariable", ";", false));
 
     // For each update run docker container
     for (const update of updates) {
@@ -220,6 +242,11 @@ async function run() {
       }
       if (autoApproveUserToken) {
         dockerRunner.arg(["-e", `AZURE_AUTO_APPROVE_USER_TOKEN=${autoApproveUserToken}`]);
+      }
+
+      // Add in extra environment variables
+      for (const [name, value] of extraEnvironmentVariables) {
+        dockerRunner.arg(["-e", `${name}=${value}`]);
       }
 
       const dockerImage = `tingle/dependabot-azure-devops:${dockerImageTag}`;

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -214,6 +214,15 @@
       "required": false,
       "defaultValue": "0.5",
       "helpMarkDown": "The image tag to use when pulling the docker container used by the task. A tag also defines the version. By default, the task decides which tag/version to use. This can be the latest or most stable version. You can also use `major.minor` format to get the latest patch"
+    },
+    {
+      "name": "extraEnvironmentVariables",
+      "type": "string",
+      "groupName": "advanced",
+      "label": "Semicolon delimited list of environment variables",
+      "required": false,
+      "defaultValue": "",
+      "helpMarkDown": "A semicolon (`;`) delimited list of environment variables that are sent to the docker container. See possible use case [here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/138)"
     }
   ],
   "dataSourceBindings": [],


### PR DESCRIPTION
Fixes #138 

This is work on supporting an optional task input called `extraEnvironmentVariables`. This will make it possible to pass in extra environment variables to the container that runs dependabot. This will make the task more extensible and capable of being used to debug issues easier. Now you will be able to do the following.

```yaml
- task: dependabot@1
  inputs:
    ...
    extraEnvironmentVariables: 'EXCON_DEBUG=1'
```

In this example that environment variable would get read by Excon which is what is used to make the HTTP calls during `update-script.rb`.  This will print out request and response data into your azure devops logs. 