### PR TITLE
Redirect *.visualstudio.com URLs to dev.azure.com

### DIFF
--- a/src/extension/task/utils/extractHostname.ts
+++ b/src/extension/task/utils/extractHostname.ts
@@ -1,0 +1,13 @@
+/**
+ * Extract a dependabot compatible hostname from a TeamFoundationCollection URL
+ * @param organizationUrl A URL object constructed from the `System.TeamFoundationCollectionUri` variable.
+ * @returns The hostname component of the {@see organizationUrl} parameter or `dev.azure.com` if the parameter points to an old `*.visualstudio.com` URL.
+ */
+export default function extractHostname(organizationUrl: URL): string {
+  const visualStudioUrlRegex = /^(?<prefix>\S)\.visualstudio\.com$/iu;
+  let hostname = organizationUrl.hostname;
+  if (visualStudioUrlRegex.test(hostname)) {
+    return 'dev.azure.com';
+  }
+  return hostname;
+}

--- a/src/extension/task/utils/getSharedVariables.ts
+++ b/src/extension/task/utils/getSharedVariables.ts
@@ -4,6 +4,7 @@ import {
   getInput,
   getDelimitedInput,
 } from "azure-pipelines-task-lib";
+import extractHostname from "./extractHostname";
 import extractOrganization from "./extractOrganization";
 import extractVirtualDirectory from "./extractVirtualDirectory";
 import getAzureDevOpsAccessToken from "./getAzureDevOpsAccessToken";
@@ -62,7 +63,7 @@ export default function getSharedVariables(): ISharedVariables {
   let organizationUrl = getVariable("System.TeamFoundationCollectionUri");
   let parsedUrl = new URL(organizationUrl);
   let protocol: string = parsedUrl.protocol.slice(0, -1);
-  let hostname: string = parsedUrl.hostname;
+  let hostname: string = extractHostname(parsedUrl);
   let port: string = parsedUrl.port;
   let virtualDirectory: string = extractVirtualDirectory(parsedUrl);
   let organization: string = extractOrganization(organizationUrl);


### PR DESCRIPTION
As explained in https://github.com/tinglesoftware/dependabot-azure-devops/issues/27#issuecomment-768054722 dependabot does not support the older `{organization}.visualstudio.com` URLs.

Even though enabling the new URL on existing organizations should not be problematic, I think there is still value in somehow enabling the old URLs to work without having to force people to switch to the new URL.

I discovered that nowadays Azure DevOps makes it possible to access your repos using `dev.azure.com` **even if your organization settings still say `{organization}.visualstudio.com`.**

Therefore, a quick fix that everyone can do today is to add the following to their azure-pipeline YAML:
``` yaml
- task: dependabot@1
  inputs: 
    ...
    extraEnvironmentVariables: 'AZURE_HOSTNAME=dev.azure.com'
```
Since the extra environment variables are added to the docker command-line at the end, the variables here end up overriding previously configured variables. That means, the command-line with which docker is invoked in this case would be
`docker run ... -e AZURE_HOSTNAME={organization}.visualstudio.com ... -e AZURE_HOSTNAME=dev.azure.com`. And this leads dependabot to see `ENV["AZURE_HOSTNAME"]` as `dev.azure.com`. Since the task also discovers all the other values to properly access Azure DevOps (i.e. organization, reponame, etc.) correctly, this really works.

Because the workaround described above works, I propose that we add a new function `extractHostname` in the task code that switches out `{organization}.visualstudio.com` hostnames with `dev.azure.com`.