### PR TITLE
Added an argument to forward the host ssh socket to the dependabot co…

### DIFF
--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -109,6 +109,12 @@ async function run() {
         dockerRunner.arg(["-e", extraEnvVar]);
       });
 
+      // Forward the host ssh socket
+      if (variables.forwardHostSshSocket) {
+        dockerRunner.arg(['-e', 'SSH_AUTH_SOCK=/ssh-agent']);
+        dockerRunner.arg(['--volume', '$SSH_AUTH_SOCK:/ssh-agent']);
+      }
+
       const dockerImage = `tingle/dependabot-azure-devops:${variables.dockerImageTag}`;
       tl.debug(`Running docker container -> '${dockerImage}' ...`);
       dockerRunner.arg([dockerImage]);

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -44,6 +44,14 @@
       "helpMarkDown": "Determines if the task will pick config values specified from the yaml file located at `.azuredevops/dependabot.yml`"
     },
     {
+      "name": "forwardHostSshSocket",
+      "type": "boolean",
+      "label": "Forward the host ssh socket",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "Ensure that the host ssh socket is forwarded to the container to authenticate with ssh"
+    },
+    {
       "name": "packageManager",
       "type": "pickList",
       "label": "Package Ecosystem",

--- a/src/extension/task/utils/getSharedVariables.ts
+++ b/src/extension/task/utils/getSharedVariables.ts
@@ -49,6 +49,8 @@ interface ISharedVariables {
   ignoreOvr: string;
   /** Flag used to check if to use dependabot.yml or task inputs */
   useConfigFile: boolean;
+  /** Flag used to forward the host ssh socket */
+  forwardHostSshSocket: boolean;
   /** Semicolon delimited list of environment variables */
   extraEnvironmentVariables: string[];
 }
@@ -94,6 +96,9 @@ export default function getSharedVariables(): ISharedVariables {
   // Check if to use dependabot.yml or task inputs
   let useConfigFile: boolean = getBoolInput("useConfigFile", false);
 
+  // Check if the host ssh socket needs to be forwarded to the container
+  let forwardHostSshSocket: boolean = getBoolInput("forwardHostSshSocket", false);
+
   // prepare extra env variables
   let extraEnvironmentVariables = getDelimitedInput(
     "extraEnvironmentVariables",
@@ -122,6 +127,7 @@ export default function getSharedVariables(): ISharedVariables {
     allowOvr,
     ignoreOvr,
     useConfigFile,
+    forwardHostSshSocket,
     extraEnvironmentVariables,
   };
 }


### PR DESCRIPTION
Added a new argument `forwardHostSshSocket` that adds 2 extra arguments to the container start. With this feature you can forward the host ssh socket which enables authentication on private composer registries. 

I havent included a test with this PR since i have no idea what the best way is to do this. However i ran the container in below context which resulted in proper auth:

```Dockerfile
FROM tingle/dependabot-azure-devops:latest

RUN mkdir -p /home/dependabot/.ssh && \
    ssh-keyscan vs-ssh.visualstudio.com >> ~/.ssh/known_hosts 
```

```sh
docker run --rm -t \
    -e GITHUB_ACCESS_TOKEN=<mytoken> \
    -e AZURE_HOSTNAME=dev.azure.com \
    -e AZURE_ACCESS_TOKEN=<mytoken> \
    -e AZURE_ORGANIZATION=<my-org> \
    -e AZURE_PROJECT=<my-project> \
    -e AZURE_REPOSITORY=<my-repo \
    -e DEPENDABOT_PACKAGE_MANAGER=composer \
    -e DEPENDABOT_DIRECTORY=/ \
    -e DEPENDABOT_TARGET_BRANCH=main \
    -e DEPENDABOT_VERSIONING_STRATEGY=auto \
    -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=300 \
    -e AZURE_SET_AUTO_COMPLETE=true \
    -e AZURE_AUTO_APPROVE_PR=false \
    -e SSH_AUTH_SOCK=/ssh-agent \
    --volume $SSH_AUTH_SOCK:/ssh-agent \
    dependabot:local
```

Fixes: #174 