### PR TITLE
Feature/host ssh forward

### DIFF
--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -112,7 +112,7 @@ async function run() {
       // Forward the host ssh socket
       if (variables.forwardHostSshSocket) {
         dockerRunner.arg(['-e', 'SSH_AUTH_SOCK=/ssh-agent']);
-        dockerRunner.arg(['--volume', '$SSH_AUTH_SOCK:/ssh-agent']);
+        dockerRunner.arg(['--volume', '${SSH_AUTH_SOCK}:/ssh-agent']);
       }
 
       const dockerImage = `tingle/dependabot-azure-devops:${variables.dockerImageTag}`;


### PR DESCRIPTION
In this PR #213 we added the SSH_AUTH_SOCK. It seems that the current task is running in a different type of shell where the variable is not known. Therefor an error is thrown that the volume name is invalid.

When running it in a script take all is valid:
```
  - script: |
      docker run --rm -i \
      -e SSH_AUTH_SOCK=/ssh-agent \
      --volume $SSH_AUTH_SOCK:/ssh-agent \
      tingle/dependabot-azure-devops:latest
```

I now moved it to the different syntax where it should be picked up. More info on this can be read here:
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch