### PR TITLE
Extension fixes

### DIFF
--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -121,15 +121,11 @@ async function run() {
         dockerRunner.arg(['--volume', '${SSH_AUTH_SOCK}:/ssh-agent']);
       }
 
+      // Form the docker image based on the repository and the tag, e.g. tingle/dependabot-azure-devops
+      // For custom/enterprise registries, prefix with the registry, e.g. contoso.azurecr.io/tingle/dependabot-azure-devops
       let dockerImage : string = `${variables.dockerImageRepository}:${variables.dockerImageTag}`;
-
       if (variables.dockerImageRegistry) {
-        if (variables.dockerImageRegistry[variables.dockerImageRegistry - 1] === "/") {
-          dockerImage = `${variables.dockerImageRegistry}${dockerImage}`;
-        }
-        else {
-          dockerImage = `${variables.dockerImageRegistry}/${dockerImage}`;
-        }
+        dockerImage = `${variables.dockerImageRegistry}/${dockerImage}`.replace("//", "/");
       }
 
       tl.debug(`Running docker container -> '${dockerImage}' ...`);

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -236,7 +236,8 @@
       "label": "Container registry override",
       "groupName": "advanced",
       "helpMarkDown": "The docker registry to use when pulling the docker container used by the task if needed. By default this will use docker hub. This can be useful if the container needs to come from an internal docker registry mirror or alternative source for testing. If the mirror requires authentication add a `docker login` task before this task. Example: `contoso.azurecr.io`",
-      "required": false
+      "required": false,
+      "groupName": "advanced"
     },
     {
       "name": "dockerImageRepository",

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -235,7 +235,7 @@
       "type": "string",
       "label": "Container registry override",
       "groupName": "advanced",
-      "helpMarkDown": "The docker registry to use when pulling the docker container used by the task if needed. By default this will use the docker engine default as configured on the host. This can be useful if the container needs to come from an internal docker registry mirror or alternative source for testing. If the mirror requires authentication add a `docker login` task before this task.",
+      "helpMarkDown": "The docker registry to use when pulling the docker container used by the task if needed. By default this will use docker hub. This can be useful if the container needs to come from an internal docker registry mirror or alternative source for testing. If the mirror requires authentication add a `docker login` task before this task. Example: `contoso.azurecr.io`",
       "required": false
     },
     {

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -231,7 +231,7 @@
       "helpMarkDown": "Exclude certain dependency updates requirements. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement."
     },
     {
-      "name": "containerRegistry",
+      "name": "dockerImageRegistry",
       "type": "string",
       "label": "Container registry override",
       "groupName": "advanced",

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -239,10 +239,10 @@
       "required": false
     },
     {
-      "name": "containerRepository",
-      "label": "Container repository",
+      "name": "dockerImageRepository",
+      "label": "Docker Container repository",
       "type": "string",
-      "helpMarkDown": "The container repository to use when pulling the docker container used by the task if needed. This can be useful if the default container requires customizations such as custom certs.",
+      "helpMarkDown": "The docker container repository to use when pulling the docker container used by the task if needed. This can be useful if the default container requires customizations such as custom certs.",
       "defaultValue": "tingle/dependabot-azure-devops",
       "required": true,
       "groupName": "advanced"

--- a/src/extension/task/utils/getSharedVariables.ts
+++ b/src/extension/task/utils/getSharedVariables.ts
@@ -86,7 +86,7 @@ export default function getSharedVariables(): ISharedVariables {
   let autoApproveUserEmail: string = getInput("autoApproveUserEmail");
   let autoApproveUserToken: string = getInput("autoApproveUserToken");
   let extraCredentials = getVariable("DEPENDABOT_EXTRA_CREDENTIALS");
-  let dockerImageRegistry: string | undefined = getInput('containerRegistry');
+  let dockerImageRegistry: string | undefined = getInput('dockerImageRegistry');
   let dockerImageRepository: string = getInput('dockerImageRepository', true);
   let dockerImageTag: string = getInput("dockerImageTag"); // TODO: get the latest version to use from a given url
 

--- a/src/extension/task/utils/getSharedVariables.ts
+++ b/src/extension/task/utils/getSharedVariables.ts
@@ -87,7 +87,7 @@ export default function getSharedVariables(): ISharedVariables {
   let autoApproveUserToken: string = getInput("autoApproveUserToken");
   let extraCredentials = getVariable("DEPENDABOT_EXTRA_CREDENTIALS");
   let dockerImageRegistry: string | undefined = getInput('containerRegistry');
-  let dockerImageRepository: string = getInput('containerRepository', true);
+  let dockerImageRepository: string = getInput('dockerImageRepository', true);
   let dockerImageTag: string = getInput("dockerImageTag"); // TODO: get the latest version to use from a given url
 
   // Prepare the github token, if one is provided


### PR DESCRIPTION
- Rename `containerRegistry` to `dockerImageRegistry` and `containerRepository` to `dockerImageRepository`.
- `dockerImageRegistry` input should be in the advanced group.
- Fix error forming `dockerImage` variable when appending `dockerImageRegistry`.