### PR TITLE
Adjust requirements_update_strategy to fix pub crashes

### DIFF
--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -128,23 +128,36 @@ end
 ##########################################
 # GitHub native implementation modifies some of the names in the config file
 unless ENV["DEPENDABOT_VERSIONING_STRATEGY"].to_s.strip.empty?
-  VERSIONING_STRATEGIES = { # [Hash<String, String>]
-    "auto" => "auto",
-    "lockfile-only" => "lockfile_only",
-    "widen" => "widen_ranges",
-    "increase" => "bump_versions",
-    "increase-if-necessary" => "bump_versions_if_necessary"
+  VERSIONING_STRATEGIES = { # [Hash<String, Symbol>]
+    "auto" => :auto,
+    "lockfile-only" => :lockfile_only,
+    "widen" => :widen_ranges,
+    "increase" => :bump_versions,
+    "increase-if-necessary" => :bump_versions_if_necessary
   }.freeze
   requirements_update_strategy_raw = ENV["DEPENDABOT_VERSIONING_STRATEGY"] || "auto"
   $options[:requirements_update_strategy] = VERSIONING_STRATEGIES.fetch(requirements_update_strategy_raw)
 
-  # For npm_and_yarn, we must correct the strategy to one allowed
+  # For npm_and_yarn & composer, we must correct the strategy to one allowed
   # https://github.com/dependabot/dependabot-core/blob/5ec858331d11253a30aa15fab25ae22fbdecdee0/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb#L18-L19
   # https://github.com/dependabot/dependabot-core/blob/5926b243b2875ad0d8c0a52c09210c4f5f274c5e/composer/lib/dependabot/composer/update_checker/requirements_updater.rb#L23-L24
   if $package_manager == "npm_and_yarn" || $package_manager == "composer"
     strategy = $options[:requirements_update_strategy]
-    if strategy == "auto" || strategy == "lockfile_only"
+    if strategy == :auto || strategy == :lockfile_only
+      $options[:requirements_update_strategy] = :bump_versions
+    end
+  end
+
+  # For pub, we also correct the strategy
+  # https://github.com/dependabot/dependabot-core/blob/ca9f236591ba49fa6e2a8d5f06e538614033a628/pub/lib/dependabot/pub/update_checker.rb#L110
+  if $package_manager == "pub"
+    strategy = $options[:requirements_update_strategy]
+    if strategy == :auto
+      $options[:requirements_update_strategy] = nil
+    elsif strategy == :lockfile_only
       $options[:requirements_update_strategy] = "bump_versions"
+    else
+      $options[:requirements_update_strategy] = strategy.to_s
     end
   end
 end

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -128,12 +128,12 @@ end
 ##########################################
 # GitHub native implementation modifies some of the names in the config file
 unless ENV["DEPENDABOT_VERSIONING_STRATEGY"].to_s.strip.empty?
-  VERSIONING_STRATEGIES = { # [Hash<String, Symbol>]
-    "auto" => :auto,
-    "lockfile-only" => :lockfile_only,
-    "widen" => :widen_ranges,
-    "increase" => :bump_versions,
-    "increase-if-necessary" => :bump_versions_if_necessary
+  VERSIONING_STRATEGIES = { # [Hash<String, String>]
+    "auto" => "auto",
+    "lockfile-only" => "lockfile_only",
+    "widen" => "widen_ranges",
+    "increase" => "bump_versions",
+    "increase-if-necessary" => "bump_versions_if_necessary"
   }.freeze
   requirements_update_strategy_raw = ENV["DEPENDABOT_VERSIONING_STRATEGY"] || "auto"
   $options[:requirements_update_strategy] = VERSIONING_STRATEGIES.fetch(requirements_update_strategy_raw)
@@ -143,8 +143,8 @@ unless ENV["DEPENDABOT_VERSIONING_STRATEGY"].to_s.strip.empty?
   # https://github.com/dependabot/dependabot-core/blob/5926b243b2875ad0d8c0a52c09210c4f5f274c5e/composer/lib/dependabot/composer/update_checker/requirements_updater.rb#L23-L24
   if $package_manager == "npm_and_yarn" || $package_manager == "composer"
     strategy = $options[:requirements_update_strategy]
-    if strategy == :auto || strategy == :lockfile_only
-      $options[:requirements_update_strategy] = :bump_versions
+    if strategy == "auto" || strategy == "lockfile_only"
+      $options[:requirements_update_strategy] = "bump_versions"
     end
   end
 end


### PR DESCRIPTION
Dependabot's pub package manager only supports string values for requirements_update_strategy, not symbols

Adjust update script to pass in strings instead of symbols for pub only, so that dependabot pub can work

Addresses crashes documented in issue #297. Testing the docker file on my own Flutter repos now works successfully.