### PR TITLE
Deprecate explicit inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In this repository you'll find:
 
 ## Using a configuration file
 
-Similar to the GitHub native version where you add a `.github/dependabot.yml` file, this repository adds support for the same official [configuration options](https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates) via a file located at `.azuredevops/dependabot.yml`. This support is only available in the Azure DevOps extension and the hosted version. However, the extension does not currently support automatically picking up the file, a pipeline is still required. See [docs](./src/extension/README.md#usage).
+Similar to the GitHub native version where you add a `.github/dependabot.yml` file, this repository adds support for the same official [configuration options](https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates) via a file located at `.azuredevops/dependabot.yml` or `.github/dependabot.yml`. This support is only available in the Azure DevOps extension and the hosted version. However, the extension does not currently support automatically picking up the file, a pipeline is still required. See [docs](./src/extension/README.md#usage).
 
 ## Credentials for private registries and feeds
 
@@ -48,7 +48,7 @@ Use the [template provided](./cronjob-template.yaml) and replace the parameters 
 
 The hosted version ([source code](https://github.com/tinglesoftware/zote)) for Azure DevOps work almost similar to the native version of dependabot on GitHub, hosted in your own Kubernetes cluster. It supports:
 
-1. Pulling configuration from a file located at `.azuredevops/dependabot.yml`.
+1. Pulling configuration from a file located at `.azuredevops/dependabot.yml` or `.github/dependabot.yml`.
 2. Adding/updating the file, triggers a run.
 3. Extra credentials for private registries, feeds and package repositories.
 4. Hosted on Kubernetes; easier compared to using Azure build agents.

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -12,7 +12,7 @@ To use in a YAML pipeline:
     packageManager: 'nuget'
 ```
 
-You can also use a configuration file stored at `.azuredevops/dependabot.yml` conforming to the [official spec](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates).
+You can also use a configuration file stored at `.azuredevops/dependabot.yml` or `.github/dependabot.yml` conforming to the [official spec](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates).
 
 ```yaml
 - task: dependabot@1

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -17,7 +17,16 @@ async function run() {
     var updates: IDependabotUpdate[];
 
     if (variables.useConfigFile) updates = parseConfigFile();
-    else updates = getConfigFromInputs();
+    else {
+      tl.warning(
+        `
+        Using explicit inputs instead of a configuration file will be deprecated in the next minor release.\r\n
+        Migrate to using a config file at .azuredevops/dependabot.yml or .github/dependabot.yml.\r\n
+        See https://github.com/tinglesoftware/dependabot-azure-devops/tree/main/src/extension#usage for more information.
+        `
+      );
+      updates = getConfigFromInputs();
+    }
 
     // For each update run docker container
     for (const update of updates) {

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -41,7 +41,7 @@
       "label": "Use Dependabot YAML file",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Determines if the task will pick config values specified from the yaml file located at `.azuredevops/dependabot.yml`"
+      "helpMarkDown": "Determines if the task will pick config values specified from the yaml file located at `.azuredevops/dependabot.yml` or `.github/dependabot.yml`"
     },
     {
       "name": "forwardHostSshSocket",


### PR DESCRIPTION
Added warning when using explicit inputs instead of a configuration file