### PR TITLE
Set author details when updating a pull request

### DIFF
--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -409,6 +409,10 @@ dependencies.select(&:top_level?).each do |dep|
         files: updated_files,
         credentials: $options[:credentials],
         pull_request_number: conflict_pull_request_id,
+        author_details: {
+          email: "noreply@github.com",
+          name: "dependabot[bot]"
+        }
       )
 
       print "Submitting pull request (##{conflict_pull_request_id}) update for #{dep.name}. "


### PR DESCRIPTION
Avoid API error when updating a Pull request when [Commit author email validation](https://docs.microsoft.com/en-us/azure/devops/repos/git/repository-settings?view=azure-devops&tabs=browser#commit-author-email) is enabled.
Should be merged once this [Pull request(dependabot/dependabot-core)](https://github.com/dependabot/dependabot-core/pull/5557) is released (#336, #337 ).