### PR TITLE
Support for custom labels

### DIFF
--- a/cronjob-template.yaml
+++ b/cronjob-template.yaml
@@ -66,5 +66,7 @@ spec:
               value: '{{dependabot_allow_conditions}}'
             - name: DEPENDABOT_IGNORE_CONDITIONS
               value: '{{dependabot_ignore_conditions}}'
+            - name: DEPENDABOT_LABELS
+              value: '{{dependabot_labels}}'
             - name: DEPENDABOT_FAIL_ON_EXCEPTION
               value: '{{dependabot_fail_on_exception}}'

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -99,6 +99,7 @@ variables:
   DEPENDABOT_EXTRA_CREDENTIALS: '[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' # put the credentials for private registries and feeds
   DEPENDABOT_ALLOW_CONDITIONS: '[{\"dependency-name\":"django*",\""dependency-type\":\"direct\"}]' # packages allowed to be updated
   DEPENDABOT_IGNORE_CONDITIONS: '[{\""dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored
+  DEPENDABOT_LABELS: '[\"npm dependencies\",\"triage-board\"]' # labels to be used
 
 pool:
   vmImage: 'ubuntu-latest' # requires macos or ubuntu (windows is not supported)

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -90,6 +90,12 @@ async function run() {
         dockerRunner.arg(["-e", `DEPENDABOT_IGNORE_CONDITIONS=${ignore}`]);
       }
 
+      // Set the dependencies to ignore
+      let labels = update.labels || variables.labelsOvr;
+      if (labels) {
+        dockerRunner.arg(["-e", `DEPENDABOT_LABELS=${labels}`]);
+      }
+
       // Set the extra credentials
       if (variables.extraCredentials) {
         dockerRunner.arg(["-e", `DEPENDABOT_EXTRA_CREDENTIALS=${variables.extraCredentials}`]);

--- a/src/extension/task/models/IDependabotUpdate.ts
+++ b/src/extension/task/models/IDependabotUpdate.ts
@@ -22,6 +22,10 @@ export interface IDependabotUpdate {
    */
   ignore?: string;
   /**
+   * Ignore certain dependencies or versions.
+   */
+   labels?: string;
+  /**
    * 	Limit number of open pull requests for version updates.
    */
   openPullRequestLimit?: number;

--- a/src/extension/task/utils/getSharedVariables.ts
+++ b/src/extension/task/utils/getSharedVariables.ts
@@ -53,6 +53,8 @@ interface ISharedVariables {
   allowOvr: string;
   /** override value for ignore */
   ignoreOvr: string;
+  /** override value for labels */
+  labelsOvr: string;
   /** Flag used to check if to use dependabot.yml or task inputs */
   useConfigFile: boolean;
   /** Flag used to forward the host ssh socket */
@@ -102,9 +104,10 @@ export default function getSharedVariables(): ISharedVariables {
   // Prepare the repository
   let repository: string = getTargetRepository();
 
-  // Get the override values for allow and ignore
+  // Get the override values for allow, ignore, and labels
   let allowOvr = getVariable("DEPENDABOT_ALLOW_CONDITIONS");
   let ignoreOvr = getVariable("DEPENDABOT_IGNORE_CONDITIONS");
+  let labelsOvr = getVariable("DEPENDABOT_LABELS");
 
   // Check if to use dependabot.yml or task inputs
   let useConfigFile: boolean = getBoolInput("useConfigFile", false);
@@ -145,6 +148,7 @@ export default function getSharedVariables(): ISharedVariables {
     repository,
     allowOvr,
     ignoreOvr,
+    labelsOvr,
     useConfigFile,
     forwardHostSshSocket,
     extraEnvironmentVariables,

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -82,6 +82,7 @@ export default function parseConfigFile(): IDependabotUpdate[] {
       // Convert to JSON and shorten the names as required by the script
       allow: update["allow"] ? JSON.stringify(update["allow"]) : undefined,
       ignore: update["ignore"] ? JSON.stringify(update["ignore"]) : undefined,
+      labels: update["labels"] ? JSON.stringify(update["labels"]) : undefined,
     };
 
     if (!dependabotUpdate.packageEcosystem) {

--- a/src/script/README.md
+++ b/src/script/README.md
@@ -27,6 +27,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS=<your-extra-credentials> \
            -e DEPENDABOT_ALLOW_CONDITIONS=<your-allowed-packages> \
            -e DEPENDABOT_IGNORE_CONDITIONS=<your-ignore-packages> \
+           -e DEPENDABOT_LABELS=<your-custom-labels> \
            -e DEPENDABOT_MILESTONE=<your-work-item-id> \
            -e AZURE_SET_AUTO_COMPLETE=<true/false> \
            -e AZURE_AUTO_APPROVE_PR=<true/false> \
@@ -53,6 +54,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
            -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
+           -e DEPENDABOT_LABELS='[\"npm dependencies\",\"triage-board\"]' \
            -e DEPENDABOT_MILESTONE=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
@@ -82,6 +84,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
            -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
+           -e DEPENDABOT_LABELS='[\"npm dependencies\",\"triage-board\"]' \
            -e DEPENDABOT_MILESTONE=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
@@ -114,6 +117,7 @@ To run the script, some environment variables are required.
 |DEPENDABOT_EXTRA_CREDENTIALS|**_Optional_**. The extra credentials in JSON format. Extra credentials can be used to access private NuGet feeds, docker registries, maven repositories, etc. For example a private registry authentication (For example FontAwesome Pro: `[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]`)|
 |DEPENDABOT_ALLOW_CONDITIONS|**_Optional_**. The dependencies whose updates are allowed, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow) for more.|
 |DEPENDABOT_IGNORE_CONDITIONS|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
+|DEPENDABOT_LABELS|**_Optional_**. The custom labels to be used, in JSON format. This can be used to override the default values. For example: `[\"npm dependencies\",\"triage-board\"]`. See [official docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#setting-custom-labels) for more.|
 |DEPENDABOT_FAIL_ON_EXCEPTION|**_Optional_**. Determines if the execution should fail when an exception occurs. Defaults to `true`.|
 |DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK|**_Optional_**. Exclude certain dependency updates requirements. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement.|
 |DEPENDABOT_MILESTONE|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -30,7 +30,7 @@ $options = {
   ignore_conditions: [],
   fail_on_exception: ENV['DEPENDABOT_FAIL_ON_EXCEPTION'] == "true", # Stop the job if an exception occurs
   pull_requests_limit: ENV["DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT"].to_i || 5,
-  custom_labels: ENV["DEPENDABOT_CUSTOM_LABELS"]&.split(",") || [],
+  custom_labels: [],
 
   # See description of requirements here:
   # https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103
@@ -200,6 +200,15 @@ unless ENV["DEPENDABOT_IGNORE_CONDITIONS"].to_s.strip.empty?
   # For example:
   # [{"dependency-name":"ruby","versions":[">= 3.a", "< 4"]}]
   $options[:ignore_conditions] = JSON.parse(ENV["DEPENDABOT_IGNORE_CONDITIONS"])
+end
+
+###########################
+# Setup Labels #
+###########################
+unless ENV["DEPENDABOT_LABELS"].to_s.strip.empty?
+  # For example:
+  # ["npm dependencies","triage-board"]
+  $options[:custom_labels] = JSON.parse(ENV["DEPENDABOT_LABELS"])
 end
 
 # Get ignore versions for a dependency

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -234,7 +234,7 @@ $api_endpoint = "#{$options[:azure_protocol]}://#{$options[:azure_hostname]}:#{$
 $api_endpoint = $api_endpoint + "#{$options[:azure_virtual_directory]}/" if !$options[:azure_virtual_directory].empty?
 puts "Using '#{$api_endpoint}' as API endpoint"
 puts "Pull Requests shall be linked to work item #{$options[:work_item_id]}" if $options[:work_item_id]
-puts "Pull Requests shall be labelled #{$options[:custom_labels]}" if $options[:custom_labels].length > 0
+puts "Pull Requests shall be labeled #{$options[:custom_labels]}" if $options[:custom_labels].length > 0
 
 # Full name of the repo targeted.
 $repo_name = "#{$options[:azure_organization]}/#{$options[:azure_project]}/_git/#{$options[:azure_repository]}"
@@ -447,7 +447,7 @@ dependencies.select(&:top_level?).each do |dep|
           name: "dependabot[bot]"
         },
         custom_labels: $options[:custom_labels],
-        label_language: $options[:custom_labels].length > 0 ? false : true,
+        label_language: true,
         provider_metadata: {
           work_item: $options[:work_item_id],
         }

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -30,7 +30,7 @@ $options = {
   ignore_conditions: [],
   fail_on_exception: ENV['DEPENDABOT_FAIL_ON_EXCEPTION'] == "true", # Stop the job if an exception occurs
   pull_requests_limit: ENV["DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT"].to_i || 5,
-  custom_labels: [],
+  custom_labels: nil, # nil instead of empty array to ensure default labels are passed
 
   # See description of requirements here:
   # https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103
@@ -234,7 +234,7 @@ $api_endpoint = "#{$options[:azure_protocol]}://#{$options[:azure_hostname]}:#{$
 $api_endpoint = $api_endpoint + "#{$options[:azure_virtual_directory]}/" if !$options[:azure_virtual_directory].empty?
 puts "Using '#{$api_endpoint}' as API endpoint"
 puts "Pull Requests shall be linked to work item #{$options[:work_item_id]}" if $options[:work_item_id]
-puts "Pull Requests shall be labeled #{$options[:custom_labels]}" if $options[:custom_labels].length > 0
+puts "Pull Requests shall be labeled #{$options[:custom_labels]}" if $options[:custom_labels]
 
 # Full name of the repo targeted.
 $repo_name = "#{$options[:azure_organization]}/#{$options[:azure_project]}/_git/#{$options[:azure_repository]}"

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -225,7 +225,7 @@ $api_endpoint = "#{$options[:azure_protocol]}://#{$options[:azure_hostname]}:#{$
 $api_endpoint = $api_endpoint + "#{$options[:azure_virtual_directory]}/" if !$options[:azure_virtual_directory].empty?
 puts "Using '#{$api_endpoint}' as API endpoint"
 puts "Pull Requests shall be linked to work item #{$options[:work_item_id]}" if $options[:work_item_id]
-puts "Pull Requests shall be labelled #{$options[:custom_labels]}" if $options[:custom_labels]
+puts "Pull Requests shall be labelled #{$options[:custom_labels]}" if $options[:custom_labels].length > 0
 
 # Full name of the repo targeted.
 $repo_name = "#{$options[:azure_organization]}/#{$options[:azure_project]}/_git/#{$options[:azure_repository]}"
@@ -437,8 +437,8 @@ dependencies.select(&:top_level?).each do |dep|
           email: "noreply@github.com",
           name: "dependabot[bot]"
         },
-        label_language: true,
         custom_labels: $options[:custom_labels],
+        label_language: $options[:custom_labels].length > 0 ? false : true,
         provider_metadata: {
           work_item: $options[:work_item_id],
         }

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -30,6 +30,7 @@ $options = {
   ignore_conditions: [],
   fail_on_exception: ENV['DEPENDABOT_FAIL_ON_EXCEPTION'] == "true", # Stop the job if an exception occurs
   pull_requests_limit: ENV["DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT"].to_i || 5,
+  custom_labels: ENV["DEPENDABOT_CUSTOM_LABELS"]&.split(",") || [],
 
   # See description of requirements here:
   # https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103
@@ -224,6 +225,7 @@ $api_endpoint = "#{$options[:azure_protocol]}://#{$options[:azure_hostname]}:#{$
 $api_endpoint = $api_endpoint + "#{$options[:azure_virtual_directory]}/" if !$options[:azure_virtual_directory].empty?
 puts "Using '#{$api_endpoint}' as API endpoint"
 puts "Pull Requests shall be linked to work item #{$options[:work_item_id]}" if $options[:work_item_id]
+puts "Pull Requests shall be labelled #{$options[:custom_labels]}" if $options[:custom_labels]
 
 # Full name of the repo targeted.
 $repo_name = "#{$options[:azure_organization]}/#{$options[:azure_project]}/_git/#{$options[:azure_repository]}"
@@ -436,6 +438,7 @@ dependencies.select(&:top_level?).each do |dep|
           name: "dependabot[bot]"
         },
         label_language: true,
+        custom_labels: $options[:custom_labels],
         provider_metadata: {
           work_item: $options[:work_item_id],
         }


### PR DESCRIPTION
Fixes #317 

While the labels are passed as expected, the labels may not appear on Azure DevOps because it does not have centralized labels/tags. As at now [dependabot-core](https://github.com/dependabot/dependabot-core) filters out any custom labels that you add except `security`, `dependencies`, and the language label e.g.`.NET`.

To understand why, follow the call chain for getting the labels:
[`labels_for_pr`](https://github.com/dependabot/dependabot-core/blob/252cb9a123e82391995797fdac45cb8b6f49cbe7/common/lib/dependabot/pull_request_creator/labeler.rb#L47-L54) -> [`default_labels_for_pr`](https://github.com/dependabot/dependabot-core/blob/252cb9a123e82391995797fdac45cb8b6f49cbe7/common/lib/dependabot/pull_request_creator/labeler.rb#L176-L184) -> [`labels`](https://github.com/dependabot/dependabot-core/blob/252cb9a123e82391995797fdac45cb8b6f49cbe7/common/lib/dependabot/pull_request_creator/labeler.rb#L237-L245) -> [`fetch_labels_for_azure`](https://github.com/dependabot/dependabot-core/blob/252cb9a123e82391995797fdac45cb8b6f49cbe7/common/lib/dependabot/pull_request_creator/labeler.rb#L273-L284). The labels resulting from `labels` or `fetch_labels_for_azure` must be present in `custom_labels` for them to be passed as seen [here](https://github.com/dependabot/dependabot-core/blob/252cb9a123e82391995797fdac45cb8b6f49cbe7/common/lib/dependabot/pull_request_creator/labeler.rb#L177).

The behaviour is different for GitLab and GitHub because both have centralized labels that must be created prior to usage. As such, we so solve this issue, a PR in [dependabot-code](https://github.com/dependabot/dependabot-core) is required that will not alter the logic.