### PR TITLE
Set automerge_candidate if AZURE_SET_AUTO_COMPLETE is set to true

### DIFF
--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -448,6 +448,7 @@ dependencies.select(&:top_level?).each do |dep|
         },
         custom_labels: $options[:custom_labels],
         label_language: true,
+        automerge_candidate: $options[:set_auto_complete],
         provider_metadata: {
           work_item: $options[:work_item_id],
         }


### PR DESCRIPTION
Set `automerge_candidate` in `PullRequestCreator` to the value of `AZURE_SET_AUTO_COMPLETE` so that the label is added accordingly.