### PR TITLE
Branch name separator

### DIFF
--- a/cronjob-template.yaml
+++ b/cronjob-template.yaml
@@ -68,5 +68,7 @@ spec:
               value: '{{dependabot_ignore_conditions}}'
             - name: DEPENDABOT_LABELS
               value: '{{dependabot_labels}}'
+            - name: DEPENDABOT_BRANCH_NAME_SEPARATOR
+              value: '{{dependabot_branch_name_separator}}'
             - name: DEPENDABOT_FAIL_ON_EXCEPTION
               value: '{{dependabot_fail_on_exception}}'

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -100,6 +100,7 @@ variables:
   DEPENDABOT_ALLOW_CONDITIONS: '[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' # packages allowed to be updated
   DEPENDABOT_IGNORE_CONDITIONS: '[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored
   DEPENDABOT_LABELS: '[\"npm dependencies\",\"triage-board\"]' # labels to be used
+  # DEPENDABOT_BRANCH_NAME_SEPARATOR: '/' # You can change the default separator here
 
 pool:
   vmImage: 'ubuntu-latest' # requires macos or ubuntu (windows is not supported)

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -99,8 +99,6 @@ variables:
   DEPENDABOT_EXTRA_CREDENTIALS: '[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' # put the credentials for private registries and feeds
   DEPENDABOT_ALLOW_CONDITIONS: '[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' # packages allowed to be updated
   DEPENDABOT_IGNORE_CONDITIONS: '[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored
-  DEPENDABOT_LABELS: '[\"npm dependencies\",\"triage-board\"]' # labels to be used
-  # DEPENDABOT_BRANCH_NAME_SEPARATOR: '/' # You can change the default separator here
 
 pool:
   vmImage: 'ubuntu-latest' # requires macos or ubuntu (windows is not supported)

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -90,10 +90,15 @@ async function run() {
         dockerRunner.arg(["-e", `DEPENDABOT_IGNORE_CONDITIONS=${ignore}`]);
       }
 
-      // Set the dependencies to ignore
+      // Set the custom labels/tags
       let labels = update.labels || variables.labelsOvr;
       if (labels) {
         dockerRunner.arg(["-e", `DEPENDABOT_LABELS=${labels}`]);
+      }
+
+      // Set the PR branch separator
+      if (update.branchNameSeparator) {
+        dockerRunner.arg(["-e", `DEPENDABOT_BRANCH_NAME_SEPARATOR=${update.branchNameSeparator}`]);
       }
 
       // Set the extra credentials

--- a/src/extension/task/models/IDependabotUpdate.ts
+++ b/src/extension/task/models/IDependabotUpdate.ts
@@ -22,13 +22,17 @@ export interface IDependabotUpdate {
    */
   ignore?: string;
   /**
-   * Ignore certain dependencies or versions.
+   * Custom labels/tags.
    */
   labels?: string;
   /**
    * The milestone to associate pull requests with.
    */
   milestone?: string;
+  /**
+   * Separator for the branches created.
+   */
+  branchNameSeparator?: string;
   /**
    * 	Limit number of open pull requests for version updates.
    */

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -78,6 +78,7 @@ export default function parseConfigFile(): IDependabotUpdate[] {
       targetBranch: update["target-branch"],
       versioningStrategy: update["versioning-strategy"],
       milestone: update["milestone"],
+      branchNameSeparator: update["pull-request-branch-name"] ? update["pull-request-branch-name"]["separator"] : undefined,
 
       // Convert to JSON and shorten the names as required by the script
       allow: update["allow"] ? JSON.stringify(update["allow"]) : undefined,

--- a/src/script/README.md
+++ b/src/script/README.md
@@ -28,6 +28,7 @@ docker run --rm -t \
            -e DEPENDABOT_ALLOW_CONDITIONS=<your-allowed-packages> \
            -e DEPENDABOT_IGNORE_CONDITIONS=<your-ignore-packages> \
            -e DEPENDABOT_LABELS=<your-custom-labels> \
+           -e DEPENDABOT_BRANCH_NAME_SEPARATOR=<your-custom-separator> \
            -e DEPENDABOT_MILESTONE=<your-work-item-id> \
            -e AZURE_SET_AUTO_COMPLETE=<true/false> \
            -e AZURE_AUTO_APPROVE_PR=<true/false> \
@@ -55,6 +56,7 @@ docker run --rm -t \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
            -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e DEPENDABOT_LABELS='[\"npm dependencies\",\"triage-board\"]' \
+           -e DEPENDABOT_BRANCH_NAME_SEPARATOR='/' \
            -e DEPENDABOT_MILESTONE=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
@@ -85,6 +87,7 @@ docker run --rm -t \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
            -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e DEPENDABOT_LABELS='[\"npm dependencies\",\"triage-board\"]' \
+           -e DEPENDABOT_BRANCH_NAME_SEPARATOR='/' \
            -e DEPENDABOT_MILESTONE=123 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
@@ -118,6 +121,7 @@ To run the script, some environment variables are required.
 |DEPENDABOT_ALLOW_CONDITIONS|**_Optional_**. The dependencies whose updates are allowed, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow) for more.|
 |DEPENDABOT_IGNORE_CONDITIONS|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
 |DEPENDABOT_LABELS|**_Optional_**. The custom labels to be used, in JSON format. This can be used to override the default values. For example: `[\"npm dependencies\",\"triage-board\"]`. See [official docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#setting-custom-labels) for more.|
+|DEPENDABOT_BRANCH_NAME_SEPARATOR|**_Optional_**. The separator to use in created branches. For example: `-`. See [official docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pull-request-branch-nameseparator) for more.|
 |DEPENDABOT_FAIL_ON_EXCEPTION|**_Optional_**. Determines if the execution should fail when an exception occurs. Defaults to `true`.|
 |DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK|**_Optional_**. Exclude certain dependency updates requirements. See list of allowed values [here](https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103). Useful if you have lots of dependencies and the update script too slow. The values provided are space-separated. Example: `own all` to only use the `none` version requirement.|
 |DEPENDABOT_MILESTONE|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -31,6 +31,7 @@ $options = {
   fail_on_exception: ENV['DEPENDABOT_FAIL_ON_EXCEPTION'] == "true", # Stop the job if an exception occurs
   pull_requests_limit: ENV["DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT"].to_i || 5,
   custom_labels: nil, # nil instead of empty array to ensure default labels are passed
+  branch_name_separator: ENV["DEPENDABOT_BRANCH_NAME_SEPARATOR"] || "/", # Separator used for created branches.
 
   # See description of requirements here:
   # https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103
@@ -448,6 +449,7 @@ dependencies.select(&:top_level?).each do |dep|
         },
         custom_labels: $options[:custom_labels],
         milestone: milestone,
+        branch_name_separator: $options[:branch_name_separator],
         label_language: true,
         automerge_candidate: $options[:set_auto_complete],
         provider_metadata: {


### PR DESCRIPTION
This PR adds support for a branch name separator set in the config file (`/.azuredevops/dependabot.yml` or `/.github/dependabot.yml`).

Example config file using it:

```yaml
version: 2
updates:
  - package-ecosystem: "npm"
    directory: "/"
    pull-request-branch-name:
      separator: "-" # can only be "-", _, or / (hyphen, underscore or forward slash)
```


For more information see the [official documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pull-request-branch-nameseparator).