### PR TITLE
Configuration file preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Using `.github/dependabot.yml` or `.github/dependabot.yaml` instead of `.azurede
 1. Intellisense support in VS Code (and may be other IDEs).
 2. The docker container checks for the configuration file in this location to configure `commit-message` and `ignore` options.
 
+> Using the .azuredevops folder is deprecated and will be removed in version `0.10.0`.
+
 ## Credentials for private registries and feeds
 
 Besides accessing the repository, sometimes, private feeds/registries may need to be accessed. For example a private NuGet feed or a company internal docker registry. Adding credentials is currently done via the `DEPENDABOT_EXTRA_CREDENTIALS` environment variable. The value is supplied in JSON hence allowing any type of credentials even if they are not for private feeds/registries.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ In this repository you'll find:
 
 ## Using a configuration file
 
-Similar to the GitHub native version where you add a `.github/dependabot.yml` file, this repository adds support for the same official [configuration options](https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates) via a file located at `.azuredevops/dependabot.yml` or `.github/dependabot.yml`. This support is only available in the Azure DevOps extension and the hosted version. However, the extension does not currently support automatically picking up the file, a pipeline is still required. See [docs](./src/extension/README.md#usage).
+Similar to the GitHub native version where you add a `.github/dependabot.yml` file, this repository adds support for the same official [configuration options](https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates) via a file located at `.github/dependabot.yml`. This support is only available in the Azure DevOps extension and the [managed version](https://managed-dependabot.com). However, the extension does not currently support automatically picking up the file, a pipeline is still required. See [docs](./src/extension/README.md#usage).
+
+Using `.github/dependabot.yml` or `.github/dependabot.yaml` instead of `.azuredevops/dependabot.yml` is better for 2 reasons:
+
+1. Intellisense support in VS Code (and may be other IDEs).
+2. The docker container checks for the configuration file in this location to configure `commit-message` and `ignore` options.
 
 ## Credentials for private registries and feeds
 
@@ -48,7 +53,7 @@ Use the [template provided](./cronjob-template.yaml) and replace the parameters 
 
 The hosted version ([source code](https://github.com/tinglesoftware/zote)) for Azure DevOps work almost similar to the native version of dependabot on GitHub, hosted in your own Kubernetes cluster. It supports:
 
-1. Pulling configuration from a file located at `.azuredevops/dependabot.yml` or `.github/dependabot.yml`.
+1. Pulling configuration from a file located at `.github/dependabot.yml`.
 2. Adding/updating the file, triggers a run.
 3. Extra credentials for private registries, feeds and package repositories.
 4. Hosted on Kubernetes; easier compared to using Azure build agents.

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -12,7 +12,7 @@ To use in a YAML pipeline:
     packageManager: 'nuget'
 ```
 
-You can also use a configuration file stored at `.azuredevops/dependabot.yml` or `.github/dependabot.yml` conforming to the [official spec](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates).
+You can also use a configuration file stored at `.github/dependabot.yml` conforming to the [official spec](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates).
 
 ```yaml
 - task: dependabot@1

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -41,7 +41,7 @@
       "label": "Use Dependabot YAML file",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Determines if the task will pick config values specified from the yaml file located at `.azuredevops/dependabot.yml` or `.github/dependabot.yml`"
+      "helpMarkDown": "Determines if the task will pick config values specified from the yaml file located at `.github/dependabot.yml`"
     },
     {
       "name": "forwardHostSshSocket",

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -44,6 +44,7 @@ export default function parseConfigFile(): IDependabotUpdate[] {
       tl.warning(
         `
         The docker container used to run this task checks for a configuration file in the .github folder. Migrate to it.
+        Using the .azuredevops folder is deprecated and will be removed in version 0.10.0.\r\n
 
         See https://github.com/tinglesoftware/dependabot-azure-devops#using-a-configuration-file for more information.
         `

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -39,18 +39,19 @@ export default function parseConfigFile(): IDependabotUpdate[] {
   });
 
   // Ensure we have the file. Otherwise throw a well readable error.
-  if (!filePath) {
+  if (filePath) {
+    tl.debug(`Found configuration file at ${filePath}`);
+    if (filePath.includes(".azuredevops/dependabot")) {
+      tl.warning(
+        `
+        The docker container used to run this task checks for a configuration file in the .github folder. Migrate to it.
+
+        See https://github.com/tinglesoftware/dependabot-azure-devops#using-a-configuration-file for more information.
+        `
+      );
+    }
+  } else {
     throw new Error(`Configuration file not found at possible locations: ${possibleFilePaths.join(', ')}`);
-  }
-
-  if (filePath.includes(".azuredevops/dependabot")) {
-    tl.warning(
-      `
-      The docker container used to run this task checks for a configuration file in the .github folder. Migrate to it.
-
-      See https://github.com/tinglesoftware/dependabot-azure-devops#using-a-configuration-file for more information.
-      `
-    );
   }
 
   let config: any;

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -18,14 +18,13 @@ import { getVariable } from "azure-pipelines-task-lib/task";
 export default function parseConfigFile(): IDependabotUpdate[] {
 
   /*
-   * If the file under the .azuredevops folder does not exist, check for one under the .github folder.
-   * Advantage of using the file under .github is support for intellisense.
+   * If the file under the .github folder does not exist, check for one under the .azuredevops folder.
    */
   const possibleFilePaths = [
-    "/.azuredevops/dependabot.yml",
-    "/.azuredevops/dependabot.yaml",
     "/.github/dependabot.yml",
     "/.github/dependabot.yaml",
+    "/.azuredevops/dependabot.yml",
+    "/.azuredevops/dependabot.yaml",
   ];
 
   // Find configuration file

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -2,12 +2,13 @@ import { IDependabotUpdate } from "../models/IDependabotUpdate";
 import { load } from "js-yaml";
 import * as fs from "fs";
 import * as path from "path";
+import * as tl from "azure-pipelines-task-lib/task"
 import { getVariable } from "azure-pipelines-task-lib/task";
 
 /**
  * Parse the dependabot config YAML file to specify update(s) configuration
  *
- * The file should be located in '/.azuredevops/dependabot.yml' at the root of your repository
+ * The file should be located in '/.github/dependabot.yml' at the root of your repository
  *
  * To view YAML file format, visit
  * https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#allow
@@ -40,6 +41,16 @@ export default function parseConfigFile(): IDependabotUpdate[] {
   // Ensure we have the file. Otherwise throw a well readable error.
   if (!filePath) {
     throw new Error(`Configuration file not found at possible locations: ${possibleFilePaths.join(', ')}`);
+  }
+
+  if (filePath.includes(".azuredevops/dependabot")) {
+    tl.warning(
+      `
+      The docker container used to run this task checks for a configuration file in the .github folder. Migrate to it.
+
+      See https://github.com/tinglesoftware/dependabot-azure-devops#using-a-configuration-file for more information.
+      `
+    );
   }
 
   let config: any;


### PR DESCRIPTION
Changes to support for the configuration file in the extension:
- Support configuration file paths ending in `.yaml` in addition to `.yml`.
- Recommend use of `.github` folder instead of `.azuredevops` folder for the configuration file hence log a warning.
