### PR TITLE
Softer deprecation and better warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ In this repository you'll find:
 
 Similar to the GitHub native version where you add a `.github/dependabot.yml` file, this repository adds support for the same official [configuration options](https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates) via a file located at `.github/dependabot.yml`. This support is only available in the Azure DevOps extension and the [managed version](https://managed-dependabot.com). However, the extension does not currently support automatically picking up the file, a pipeline is still required. See [docs](./src/extension/README.md#usage).
 
+> Using a configuration file over explicit inputs will not work with repositories other than the one in the pipeline. This means no shared pipeline.
+
 Using `.github/dependabot.yml` or `.github/dependabot.yaml` instead of `.azuredevops/dependabot.yml` is better for 2 reasons:
 
 1. Intellisense support in VS Code (and may be other IDEs).
 2. The docker container checks for the configuration file in this location to configure `commit-message` and `ignore` options.
 
-> Using the .azuredevops folder is deprecated and will be removed in version `0.10.0`.
+> Using the .azuredevops folder is deprecated and will be removed in version `0.11.0`.
 
 ## Credentials for private registries and feeds
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ In this repository you'll find:
 2. Dockerfile and build/image for running the script via Docker [here](./src/script/Dockerfile).
 3. Azure DevOps [Extension](https://marketplace.visualstudio.com/items?itemName=tingle-software.dependabot) and [source](./src/extension).
 4. Kubernetes CronJob [template](#kubernetes-cronjob).
-5. Hosted versions: [fully hosted](#hosted-version), self hosted (source code and instructions coming soon).
 
 ## Using a configuration file
 
@@ -51,17 +50,6 @@ Use the [template provided](./cronjob-template.yaml) and replace the parameters 
 3. Jobs run duration is capped at 1 hour (`activeDeadlineSeconds: 3600`). This should be enough time.
 4. Labels can be used to find cronjobs created.
 5. Annotations can be used to store extra data for comparison but not searching/finding e.g. package ecosystem.
-
-## Hosted version
-
-The hosted version ([source code](https://github.com/tinglesoftware/zote)) for Azure DevOps work almost similar to the native version of dependabot on GitHub, hosted in your own Kubernetes cluster. It supports:
-
-1. Pulling configuration from a file located at `.github/dependabot.yml`.
-2. Adding/updating the file, triggers a run.
-3. Extra credentials for private registries, feeds and package repositories.
-4. Hosted on Kubernetes; easier compared to using Azure build agents.
-5. Auto resolving of merge conflicts using webhooks.
-6. Viewing the most recent runs for each repository, project and organization configured.
 
 ### Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In this repository you'll find:
 
 Similar to the GitHub native version where you add a `.github/dependabot.yml` file, this repository adds support for the same official [configuration options](https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates) via a file located at `.github/dependabot.yml`. This support is only available in the Azure DevOps extension and the [managed version](https://managed-dependabot.com). However, the extension does not currently support automatically picking up the file, a pipeline is still required. See [docs](./src/extension/README.md#usage).
 
-> Using a configuration file over explicit inputs will not work with repositories other than the one in the pipeline. This means no shared pipeline.
+> Using a configuration file over explicit inputs will not work with repositories other than the one in the pipeline. This means no shared pipeline. Instead consider the [managed version](https://managed-dependabot.com).
 
 Using `.github/dependabot.yml` or `.github/dependabot.yaml` instead of `.azuredevops/dependabot.yml` is better for 2 reasons:
 

--- a/cronjob-template.yaml
+++ b/cronjob-template.yaml
@@ -36,7 +36,7 @@ spec:
           activeDeadlineSeconds: 3600
           containers:
           - name: dependabot
-            image: 'tingle/dependabot-azure-devops:0.4.0' # Use a specific tag otherwise the image may be cached already
+            image: 'tingle/dependabot-azure-devops:0.8.4' # Use a specific tag otherwise the image may be cached already
             resources: {} # decide based on your usage
             env:
             - name: GITHUB_ACCESS_TOKEN

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -20,7 +20,7 @@ async function run() {
     else {
       tl.warning(
         `
-        Using explicit inputs instead of a configuration file is deprecated and will be removed in version 0.10.0.\r\n
+        Using explicit inputs instead of a configuration file is deprecated and will be removed in version 0.11.0.\r\n
         No new features will be added to the use of explicit inputs that can also be specified in the configuration file.\r\n\r\n
         Migrate to using a config file at .azuredevops/dependabot.yml or .github/dependabot.yml.\r\n
         See https://github.com/tinglesoftware/dependabot-azure-devops/tree/main/src/extension#usage for more information.

--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -29,6 +29,17 @@ async function run() {
       updates = getConfigFromInputs();
     }
 
+    if (variables.useConfigFile && tl.getInput("targetRepositoryName")) {
+      tl.warning(
+        `
+        Using targetRepositoryName input does not work when useConfigFile is set to true.
+        This is not a bug, but a feature limitation.
+        Either use a pipeline for each repository or consider using the [managed version](https://managed-dependabot.com).
+        Using targetRepositoryName will be deprecated and removed in a future minor release.\r\n
+        `
+      );
+    }
+
     // For each update run docker container
     for (const update of updates) {
       // Prepare the docker task

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -44,7 +44,7 @@ export default function parseConfigFile(): IDependabotUpdate[] {
       tl.warning(
         `
         The docker container used to run this task checks for a configuration file in the .github folder. Migrate to it.
-        Using the .azuredevops folder is deprecated and will be removed in version 0.10.0.\r\n
+        Using the .azuredevops folder is deprecated and will be removed in version 0.11.0.\r\n
 
         See https://github.com/tinglesoftware/dependabot-azure-devops#using-a-configuration-file for more information.
         `


### PR DESCRIPTION
- Set deprecation to be in version `0.11.0` instead of `0.10.0`.
- When `useConfigFile=true` and `targetRepositoryName` input is present, produce a warning.
- Remove hosted version in README.md
- Update tag used in `cronjob-template.yaml`.
