### PR TITLE
Support configuration options for private registries in dependabot.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,44 @@ Using `.github/dependabot.yml` or `.github/dependabot.yaml` instead of `.azurede
 
 ## Credentials for private registries and feeds
 
-Besides accessing the repository, sometimes, private feeds/registries may need to be accessed. For example a private NuGet feed or a company internal docker registry. Adding credentials is currently done via the `DEPENDABOT_EXTRA_CREDENTIALS` environment variable. The value is supplied in JSON hence allowing any type of credentials even if they are not for private feeds/registries.
+Besides accessing the repository only, sometimes private feeds/registries may need to be accessed.
+For example a private NuGet feed or a company internal docker registry.
 
-When working with Azure Artifacts, some extra steps need to be done:
+Adding configuration options for private registries is setup in `dependabot.yml`
+according to the dependabot [description](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-private-registries).
+
+Example:
+
+```yml
+version: 2
+registries:
+  my-Extern@Release:
+    type: nuget-feed
+    url: https://dev.azure.com/organization1/_packaging/my-Extern@Release/nuget/v3/index.json
+    token: PAT:${{MY_DEPENDABOT_ADO_PAT}}
+  my-analyzers:
+    type: nuget-feed
+    url: https://dev.azure.com/organization2/_packaging/my-analyzers/nuget/v3/index.json
+    token: PAT:${{ANOTHER_PAT}}
+  artifactory:
+    type: nuget-feed
+    url: https://artifactory.com/api/nuget/v3/myfeed
+    token: PAT:${{DEPENDABOT_ARTIFACTORY_PAT}}
+updates:
+...
+```
+
+Note:
+
+1. `${{VARIABLE_NAME}}` notation is used liked described [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-encrypted-secrets-for-dependabot)
+BUT the values will be used from Environment Variables.
+
+2. When using a token see the special notation of `PAT:${{..`. Otherwise the wrong authentication mechanism is used by dependabot, see [here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/50).
+
+Adding credentials via the `DEPENDABOT_EXTRA_CREDENTIALS` environment variable overwrites the yml configuration, this option will be removed in future releases. 
+The value is supplied in JSON hence allowing any type of credentials even if they are not for private feeds/registries.
+
+When working with Azure Artifacts, some extra permission steps need to be done:
 
 1. The PAT should have *Packaging Read* permission.
 2. The user owning the PAT must be granted permissions to access the feed either directly or via a group. An easy way for this is to give `Contributor` permissions the `[{project_name}]\Contributors` group under the `Feed Settings -> Permissions` page. The page has the url format: `https://dev.azure.com/{organization}/{project}/_packaging?_a=settings&feed={feed-name}&view=permissions`.

--- a/extension/task/IDependabotConfig.ts
+++ b/extension/task/IDependabotConfig.ts
@@ -3,10 +3,21 @@
  *
  * https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml
  */
-export interface IDependabotConfig {
+ export interface IDependabotConfig {
+  /**
+   *  Mandatory. configuration file version.
+   **/
   version: number;
+ /**
+  *  Mandatory. Configure how Dependabot updates the versions or project dependencies.
+  *  Each entry configures the update settings for a particular package manager.
+  */
   updates: IDependabotUpdate[];
-}
+  /**
+   *  Optional. Specify authentication details to access private package registries.
+   */
+  registries?: IDependabotRegistry[];
+ }
 
 export interface IDependabotUpdate {
   /**
@@ -77,6 +88,41 @@ export interface IDependabotUpdateSchedule {
    * 	How often to check for updates
    */
   interval: string;
+}
+
+export interface IDependabotRegistry {
+  /**
+   * Identifies the type of registry
+   */
+   type: string;
+  /**
+   * The URL to use to access the dependencies in this registry.
+   * The protocol is optional. If not specified, `https://` is assumed.
+   * Dependabot adds or ignores trailing slashes as required.
+   */
+   url: string;
+  /**
+   * The username to access the registry
+   */
+   username?: string;
+  /**
+   *  A password for the username to access this registry
+   */
+   password?: string;
+  /**
+   *  An access key for this registry
+   */
+   key?: string;
+  /**
+   *  An access token for this registry
+   */
+   token?: string;
+  /**
+   * 	For registries with type: python-index,
+   *  if the boolean value is `true`, pip resolves dependencies by using the specified URL
+   *  rather than the base URL of the Python Package Index (by default https://pypi.org/simple).
+   */
+   "replaces-base"?: string;
 }
 
 export type DependabotDependencyType =

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -15,9 +15,9 @@ async function run() {
     const variables = getSharedVariables();
 
     var config: IDependabotConfig;
-
-    if (variables.useConfigFile) config = parseConfigFile();
-    else {
+    if (variables.useConfigFile) {
+      config = parseConfigFile();
+    } else {
       tl.warning(
         `
         Using explicit inputs instead of a configuration file is deprecated and will be removed in version 0.11.0.
@@ -121,6 +121,9 @@ async function run() {
       // Set the extra credentials
       if (variables.extraCredentials) {
         dockerRunner.arg(["-e", `DEPENDABOT_EXTRA_CREDENTIALS=${variables.extraCredentials}`]);
+      } else if (config.registries != undefined) {
+        let extraCredentials = JSON.stringify(config.registries);
+        dockerRunner.arg(["-e", `DEPENDABOT_EXTRA_CREDENTIALS=${extraCredentials}`]);
       }
 
       // Set the github token, if one is provided

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -120,6 +120,7 @@ async function run() {
 
       // Set the extra credentials
       if (variables.extraCredentials) {
+        //TODO remove variables.extraCredentials in future in favor default yml configuration.
         dockerRunner.arg(["-e", `DEPENDABOT_EXTRA_CREDENTIALS=${variables.extraCredentials}`]);
       } else if (config.registries != undefined) {
         let extraCredentials = JSON.stringify(config.registries);

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -170,7 +170,7 @@ async function run() {
       }
 
       tl.debug(`Running docker container -> '${dockerImage}' ...`);
-      dockerRunner.arg([dockerImage]);
+      dockerRunner.arg(dockerImage);
 
       // Now execute using docker
       await dockerRunner.exec();

--- a/extension/task/utils/convertPlaceholder.ts
+++ b/extension/task/utils/convertPlaceholder.ts
@@ -1,0 +1,25 @@
+import { getVariable } from "azure-pipelines-task-lib/task";
+
+export default function convertPlaceholder(input: string): string {
+    const variableNameExp : string = "[a-zA-Z_]+[a-zA-Z0-9_]*"
+    const variableLeftExp : string = "\\${{"
+    const variableRightExp : string = "}}"
+    const regexp : RegExp = new RegExp(variableLeftExp + "\\s*(" + variableNameExp + ")\\s*" + variableRightExp, 'g');
+
+    let result : string = input;
+    const matches = matchAll(input, regexp);
+
+    for (const match of matches) {
+        var placeholder = match[0];
+        var name = match[1];
+        var value = getVariable(name) ?? placeholder;
+        result = result.replace(placeholder, value);
+    }
+    return result;
+}
+
+function matchAll( target : string, rExp : RegExp, matches : Array<RegExpExecArray> = []) {
+    const matchIfAny  = rExp.exec(target);
+    matchIfAny && matches.push(matchIfAny) && matchAll(target, rExp, matches);
+    return matches;
+}

--- a/extension/task/utils/getConfigFromInputs.ts
+++ b/extension/task/utils/getConfigFromInputs.ts
@@ -9,7 +9,7 @@ import { IDependabotConfig } from "../IDependabotConfig";
  *
  * @returns {IDependabotConfig} update configuration
  */
-export default function getConfigFromInputs() : IDependabotConfig{
+export default function getConfigFromInputs() : IDependabotConfig {
   var dependabotConfig: IDependabotConfig = {
     version: 2,
     updates: [{


### PR DESCRIPTION
Add support for the top-level `registries` key in `dependabot.yml`. 
To be able to specify authentication details that Dependabot can use to access private package registries.

solves #50