### PR TITLE
provide a workaround for ruby/resolv/issues/23

### DIFF
--- a/src/script/Dockerfile
+++ b/src/script/Dockerfile
@@ -21,6 +21,8 @@ RUN bundle config set --local path "vendor" \
 # Copy the Ruby scripts
 COPY --chown=dependabot:dependabot update-script.rb ${CODE_DIR}
 COPY --chown=dependabot:dependabot azure_helpers.rb ${CODE_DIR}
+COPY --chown=dependabot:dependabot entrypoint.sh ${CODE_DIR}
 
 # Run update script
-ENTRYPOINT ["bundle", "exec", "ruby", "./update-script.rb"]
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["bundle", "exec", "ruby", "./update-script.rb"]

--- a/src/script/entrypoint.sh
+++ b/src/script/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ -n "$WORKAROUND_CMD" ]; then
+    eval "$WORKAROUND_CMD"
+fi
+
+# This will exec the CMD from Dockerfile
+exec "$@"


### PR DESCRIPTION
Hi, 

I would like to ask you to add this tiny possibility/workaround to execute a command before running dependabot.
As I would like to directly use you docker image, but currently I cannot, due to a [Ruby `Resolv` bug](https://github.com/ruby/resolv/issues/23).

**Background**
The issue I have is that within my network environment the docker host itself cannot resolve any network name, therefore some nameservers are configured, but unfortunately due to the bug (ruby/resolv/issues/23) I need to "patch" the `/etc/resolv.conf` before the image runs.
Currently I create an own docker image which is exactly the same as your images, with just one additional line during startup:
`sed -i 1' s/^/#/' /etc/resolv.conf`
in order to comment out the first nameserver entry which I am having issues with.

I would like to ask you if this change can be added, as it is completely backward compatible.
The only thing it allows me (and maybe others), to define an environment variable with my required `sed` command, which will be executed before dependabot run.

I can also rename the Variable `WORKAROUND_CMD` if you like.

The other idea would be instead of this here, to provide a possibility to pass a docker cmd via the extension, but as it should be a workaround until the ruby resolv bug gets fixed it can be quite hidden in the docker image itself.
