### PR TITLE
Allow configuration of optional policies for `AutoComplete`

### DIFF
--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -59,6 +59,7 @@ async function run() {
       dockerRunner.arg(["-e", `AZURE_REPOSITORY=${variables.repository}`]);
       dockerRunner.arg(["-e", `AZURE_ACCESS_TOKEN=${variables.systemAccessToken}`]);
       dockerRunner.arg(["-e", `AZURE_SET_AUTO_COMPLETE=${variables.setAutoComplete}`]); // Set auto complete, if set
+      dockerRunner.arg(["-e", `AZURE_AUTO_COMPLETE_IGNORE_CONFIG_IDS=${JSON.stringify(variables.autoCompleteIgnoreConfigIds)}`]); 
       dockerRunner.arg(["-e", `AZURE_MERGE_STRATEGY=${variables.mergeStrategy}`]);
 
       // Set Username

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -153,6 +153,15 @@
       "helpMarkDown": "Learn more [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#insecure-external-code-execution)."
     },
     {
+      "name": "autoCompleteIgnoreConfigIds",
+      "type": "string",
+      "groupName": "approval_completion",
+      "label": "Semicolon delimited list of any policy configuration Id's which auto-complete should not wait for.",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "A semicolon (`;`) delimited list of any policy configuration Id's which auto-complete should not wait for. Only applies to optional policies (isBlocking == false). Auto-complete always waits for required policies (isBlocking == true)."
+    },
+    {
       "name": "mergeStrategy",
       "type": "pickList",
       "groupName": "approval_completion",

--- a/extension/task/utils/getSharedVariables.ts
+++ b/extension/task/utils/getSharedVariables.ts
@@ -26,6 +26,8 @@ interface ISharedVariables {
   project: string;
   /** Determines if the pull requests that dependabot creates should have auto complete set */
   setAutoComplete: boolean;
+  /** List of any policy configuration Id's which auto-complete should not wait for */
+  autoCompleteIgnoreConfigIds: number[];
   /** Determines if the execution should fail when an exception occurs */
   failOnException: boolean;
   excludeRequirementsToUnlock: string;
@@ -61,7 +63,7 @@ interface ISharedVariables {
   useConfigFile: boolean;
   /** Flag used to forward the host ssh socket */
   forwardHostSshSocket: boolean;
-  /** Semicolon delimited list of environment variables */
+  /** List of extra environment variables */
   extraEnvironmentVariables: string[];
   /** Merge strategies which can be used to complete a pull request */
   mergeStrategy: string;
@@ -83,6 +85,11 @@ export default function getSharedVariables(): ISharedVariables {
   let organization: string = extractOrganization(organizationUrl);
   let project: string = encodeURI(getVariable("System.TeamProject")); // encode special characters like spaces
   let setAutoComplete = getBoolInput("setAutoComplete", false);
+  let autoCompleteIgnoreConfigIds = getDelimitedInput(
+    "autoCompleteIgnoreConfigIds",
+    ";",
+    false
+  ).map(Number);
   let failOnException = getBoolInput("failOnException", true);
   let excludeRequirementsToUnlock = getInput("excludeRequirementsToUnlock") || "";
   let updaterOptions = getInput("updaterOptions");
@@ -135,6 +142,7 @@ export default function getSharedVariables(): ISharedVariables {
     organization,
     project,
     setAutoComplete,
+    autoCompleteIgnoreConfigIds,
     failOnException,
     excludeRequirementsToUnlock,
     updaterOptions: updaterOptions,

--- a/script/README.md
+++ b/script/README.md
@@ -133,6 +133,7 @@ To run the script, some environment variables are required.
 |DEPENDABOT_MILESTONE|**_Optional_**. The identifier of the work item to be linked to the Pull Requests that dependabot creates.|
 |DEPENDABOT_UPDATER_OPTIONS|**_Optional_**. Comma separated list of updater options; available options depend on PACKAGE_MANAGER. Example: `goprivate=true,kubernetes_updates=true`.|
 |AZURE_SET_AUTO_COMPLETE|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically|
+|AZURE_AUTO_COMPLETE_IGNORE_CONFIG_IDS|**_Optional_**. List of any policy configuration Id's which auto-complete should not wait for. Only applies to optional policies. Auto-complete always waits for required (blocking) policies.|
 |AZURE_AUTO_APPROVE_PR|**_Optional_**. Determines if the pull requests that dependabot creates should be automatically completed. When set to `true`, pull requests will be approved automatically by the user specified in the `AZURE_AUTO_APPROVE_USER_EMAIL` environment variable.|
 |AZURE_AUTO_APPROVE_USER_EMAIL|**_Optional_**. Email of the user that should be used to automatically approve pull requests. Required if `AZURE_AUTO_APPROVE_PR` is set to `true`.|
 |AZURE_AUTO_APPROVE_USER_TOKEN|**_Optional_**. A personal access token that is assigned to the user specified in `AZURE_AUTO_APPROVE_USER_EMAIL` to automatically approve the created PR. Required if `AZURE_AUTO_APPROVE_PR` is set to `true`.|

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -58,13 +58,15 @@ module Dependabot
                 JSON.parse(response.body).fetch("value")
             end
 
-            def pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy)
+            def pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy)
                 # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-6.0
                 content = {
                     autoCompleteSetBy: {
                         id: auto_complete_user_id
                     },
                     completionOptions: {
+                        autoCompleteIgnoreConfigIds: [93], # ignore optional "work items must be linked" policy
+                        mergeCommitMessage: "Merged PR #{pull_request_id}: #{pull_request_title}",
                         mergeStrategy: merge_strategy,
                         deleteSourceBranch: true,
                         transitionWorkItems: false

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -59,7 +59,7 @@ module Dependabot
             end
 
             def pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy)
-                # https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20requests/update?view=azure-devops-rest-6.0
+                # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-6.0
                 content = {
                     autoCompleteSetBy: {
                         id: auto_complete_user_id
@@ -74,16 +74,16 @@ module Dependabot
                 response = patch(source.api_endpoint +
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +
-                    "/pullrequests/#{pull_request_id}?api-version=5.0", content.to_json)
+                    "/pullrequests/#{pull_request_id}?api-version=6.0", content.to_json)
             end
 
             def pull_request_approve(pull_request_id, reviewer_email, reviewer_token)
-                # https://docs.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user%20entitlements/search%20user%20entitlements?view=azure-devops-rest-6.0
+                # https://learn.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user-entitlements/search-user-entitlements?view=azure-devops-rest-6.0
                 response = get("https://vsaex.dev.azure.com/" + source.organization + "/_apis/userentitlements?$filter=name eq '#{reviewer_email}'&api-version=6.0-preview.3")
 
                 user_id = JSON.parse(response.body).fetch("members")[0]['id']
 
-                # https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20request%20reviewers/create%20pull%20request%20reviewer?view=azure-devops-rest-6.0
+                # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-reviewers/create-pull-request-reviewers?view=azure-devops-rest-6.0
                 content = {
                     # 10 - approved 5 - approved with suggestions 0 - no vote -5 - waiting for author -10 - rejected
                     vote: 10

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -58,14 +58,14 @@ module Dependabot
                 JSON.parse(response.body).fetch("value")
             end
 
-            def pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy)
+            def pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
                 # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-6.0
                 content = {
                     autoCompleteSetBy: {
                         id: auto_complete_user_id
                     },
                     completionOptions: {
-                        autoCompleteIgnoreConfigIds: [93], # ignore optional "work items must be linked" policy
+                        autoCompleteIgnoreConfigIds: auto_complete_ignore_config_ids,
                         mergeCommitMessage: "Merged PR #{pull_request_id}: #{pull_request_title}",
                         mergeStrategy: merge_strategy,
                         deleteSourceBranch: true,

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -58,7 +58,7 @@ module Dependabot
                 JSON.parse(response.body).fetch("value")
             end
 
-            def pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
+            def pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
                 # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-6.0
                 content = {
                     autoCompleteSetBy: {
@@ -66,7 +66,6 @@ module Dependabot
                     },
                     completionOptions: {
                         autoCompleteIgnoreConfigIds: auto_complete_ignore_config_ids,
-                        mergeCommitMessage: "Merged PR #{pull_request_id}: #{pull_request_title}",
                         mergeStrategy: merge_strategy,
                         deleteSourceBranch: true,
                         transitionWorkItems: false

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -56,6 +56,7 @@ $options = {
   milestone: ENV['DEPENDABOT_MILESTONE'] || nil, # Get the work item to attach
 
   set_auto_complete: ENV["AZURE_SET_AUTO_COMPLETE"] == "true", # Set auto complete on created pull requests
+  auto_complete_ignore_config_ids: JSON.parse(ENV['AZURE_AUTO_COMPLETE_IGNORE_CONFIG_IDS'] || '[]'), # default to empty array
   merge_strategy: ENV["AZURE_MERGE_STRATEGY"] || "2", # default to squash merge
 
   # Automatically Approve the PR
@@ -518,11 +519,12 @@ dependencies.select(&:top_level?).each do |dep|
     # Set auto complete for this Pull Request
     # Pull requests that pass all policies will be merged automatically.
     if $options[:set_auto_complete]
-      auto_complete_user_id = pull_request["createdBy"]["id"]
-      pull_request_title = pull_request["title"]
+      auto_complete_user_id = pull_request['createdBy']['id']
+      pull_request_title = pull_request['title']
       merge_strategy = $options[:merge_strategy]
+      auto_complete_ignore_config_ids = $options[:auto_complete_ignore_config_ids]
       puts "Setting auto complete on ##{pull_request_id}."
-      azure_client.pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy)
+      azure_client.pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
     end
 
   rescue StandardError => e

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -520,11 +520,10 @@ dependencies.select(&:top_level?).each do |dep|
     # Pull requests that pass all policies will be merged automatically.
     if $options[:set_auto_complete]
       auto_complete_user_id = pull_request['createdBy']['id']
-      pull_request_title = pull_request['title']
       merge_strategy = $options[:merge_strategy]
       auto_complete_ignore_config_ids = $options[:auto_complete_ignore_config_ids]
       puts "Setting auto complete on ##{pull_request_id}."
-      azure_client.pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
+      azure_client.pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
     end
 
   rescue StandardError => e

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -519,9 +519,10 @@ dependencies.select(&:top_level?).each do |dep|
     # Pull requests that pass all policies will be merged automatically.
     if $options[:set_auto_complete]
       auto_complete_user_id = pull_request["createdBy"]["id"]
+      pull_request_title = pull_request["title"]
       merge_strategy = $options[:merge_strategy]
       puts "Setting auto complete on ##{pull_request_id}."
-      azure_client.pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy)
+      azure_client.pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy)
     end
 
   rescue StandardError => e


### PR DESCRIPTION
If an optional Branch Policy is enabled (e.g. Check for linked work items) the api call for enabling `AutoComplete` needs to provide the policy config id. Otherwise the policy is set to required (by default) and the auto complete will not work 