### PR TITLE
Allow customizing of dependabot author email/name

### DIFF
--- a/src/script/README.md
+++ b/src/script/README.md
@@ -102,6 +102,8 @@ To run the script, some environment variables are required.
 
 |Variable Name|Description|
 |--|--|
+|GIT_AUTHOR_EMAIL|**_Optional_**. The email address to use for the change commit author, can be used e.g. in private Azure DevOps Server deployments to associate the committer with an existing account, to provide a profile picture.|
+|GIT_AUTHOR_NAME|**_Optional_**. The display name to use for the change commit author.|
 |GITHUB_ACCESS_TOKEN|**_Optional_**. The GitHub token for authenticating requests against GitHub public repositories. This is useful to avoid rate limiting errors. The token must include permissions to read public repositories. See the [documentation](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) for more on Personal Access Tokens.|
 |AZURE_PROTOCOL|**_Optional_**. The transport protocol (`http` or `https`) used by your Azure DevOps installation. Defaults to `https`.|
 |AZURE_HOSTNAME|**_Optional_**. The hostname of the where the organization is hosted. Defaults to `dev.azure.com` but for older organizations this may have the format `xxx.visualstudio.com`. Check the url on the browser. For Azure DevOps Server, this may be the unexposed one e.g. `localhost` or one that you have exposed publicly via DNS.|

--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -422,6 +422,8 @@ dependencies.select(&:top_level?).each do |dep|
 
     pull_request = nil
     pull_request_id = nil
+    pull_request_author_email = ENV["GIT_AUTHOR_EMAIL"] || "noreply@github.com"
+    pull_request_author_name = ENV["GIT_AUTHOR_NAME"] || "dependabot[bot]"
     if conflict_pull_request_commit_id && conflict_pull_request_id
       ##############################################
       # Update pull request with conflict resolved #
@@ -434,8 +436,8 @@ dependencies.select(&:top_level?).each do |dep|
         credentials: $options[:credentials],
         pull_request_number: conflict_pull_request_id,
         author_details: {
-          email: "noreply@github.com",
-          name: "dependabot[bot]"
+          email: pull_request_author_email,
+          name: pull_request_author_name
         }
       )
 
@@ -456,8 +458,8 @@ dependencies.select(&:top_level?).each do |dep|
         credentials: $options[:credentials],
         # assignees: assignees,
         author_details: {
-          email: "noreply@github.com",
-          name: "dependabot[bot]"
+          email: pull_request_author_email,
+          name: pull_request_author_name
         },
         commit_message_options: $update_config.commit_message_options.to_h,
         custom_labels: $options[:custom_labels],


### PR DESCRIPTION
With default configuration the commit is authored with email `noreply@github.com` 
in our ADO Server (OnPrem) installation there is no account with this email, therefore the commit cannot be linked with an ADO account and no profile Icon is shown.
Whereas the PR is correctly linked with the Account:

![image](https://user-images.githubusercontent.com/13506173/196888430-ada576c2-e507-4fd3-840e-1bb623c9c6f1.png)

This PR allows the configuration of the committer author email and account, with these variables
```env
GIT_AUTHOR_EMAIL=myemail@provider.com
GIT_AUTHOR_NAME=ownname
```
within the pipeline task `extraEnvironmentVariables`
