### PR TITLE
Allow private feeds only - Do not add nuget.org feed if extra credentials are used

### DIFF
--- a/src/script/update-script.rb
+++ b/src/script/update-script.rb
@@ -112,20 +112,9 @@ unless ENV["GITHUB_ACCESS_TOKEN"].to_s.strip.empty?
     "password" => ENV["GITHUB_ACCESS_TOKEN"] # A GitHub access token with read access to public repos
   }
 end
-unless ENV["DEPENDABOT_EXTRA_CREDENTIALS"].to_s.strip.empty?
-  # For example:
-  # "[{\"type\":\"npm_registry\",\"registry\":\
-  #     "registry.npmjs.org\",\"token\":\"123\"}]"
-  $options[:credentials].concat(JSON.parse(ENV["DEPENDABOT_EXTRA_CREDENTIALS"]))
-
-  # Adding custom private feed removes the public onces so we have to create it
-  if $package_manager == "nuget"
-    $options[:credentials] << {
-      "type" => "nuget_feed",
-      "url" => "https://api.nuget.org/v3/index.json",
-    }
-  end
-end
+# DEPENDABOT_EXTRA_CREDENTIALS, for example:
+# "[{\"type\":\"npm_registry\",\"registry\":\"registry.npmjs.org\",\"token\":\"123\"}]"
+$options[:credentials] += JSON.parse(ENV["DEPENDABOT_EXTRA_CREDENTIALS"]) unless ENV["DEPENDABOT_EXTRA_CREDENTIALS"].to_s.strip.empty?
 
 ##########################################
 # Setup the requirements update strategy #


### PR DESCRIPTION
Allow using only private nuget feeds and do not force adding the public `nuget.org` feed
which will be used anyway, if `nuget.config` in repository root is correctly configured.

see:
https://github.com/dependabot/dependabot-core/blob/49b849af53d72f4e6641b0779372c6bda76df375/nuget/lib/dependabot/nuget/update_checker/repository_finder.rb#L128-L138

where `credential_repositories` from `.github/dependabot.yml` (or in our case here from `DEPENDABOT_EXTRA_CREDENTIALS`) 
and `config_file_repositories` from `nuget.config` 
gets added as `known_repositories`.