### PR TITLE
Support custom config file location

### DIFF
--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -16,7 +16,7 @@ async function run() {
 
     var updates: IDependabotUpdate[];
 
-    if (variables.useConfigFile) updates = parseConfigFile();
+    if (variables.useConfigFile) updates = parseConfigFile(variables.configFilePath);
     else {
       tl.warning(
         `

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -44,6 +44,14 @@
       "helpMarkDown": "Determines if the task will pick config values specified from the yaml file located at `.github/dependabot.yml`"
     },
     {
+      "name": "confgiFilePath",
+      "type": "boolean",
+      "label": "Use Dependabot YAML file",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "Determines where the task will find the config file located. If not set `.github/dependabot.yml` is used"
+    },
+    {
       "name": "forwardHostSshSocket",
       "type": "boolean",
       "label": "Forward the host ssh socket",

--- a/src/extension/task/task.json
+++ b/src/extension/task/task.json
@@ -44,7 +44,7 @@
       "helpMarkDown": "Determines if the task will pick config values specified from the yaml file located at `.github/dependabot.yml`"
     },
     {
-      "name": "confgiFilePath",
+      "name": "configFilePath",
       "type": "boolean",
       "label": "Use Dependabot YAML file",
       "defaultValue": "false",

--- a/src/extension/task/utils/getSharedVariables.ts
+++ b/src/extension/task/utils/getSharedVariables.ts
@@ -57,6 +57,8 @@ interface ISharedVariables {
   labelsOvr: string;
   /** Flag used to check if to use dependabot.yml or task inputs */
   useConfigFile: boolean;
+  /** override value for configPath */
+  configFilePath: string;
   /** Flag used to forward the host ssh socket */
   forwardHostSshSocket: boolean;
   /** Semicolon delimited list of environment variables */
@@ -111,6 +113,7 @@ export default function getSharedVariables(): ISharedVariables {
 
   // Check if to use dependabot.yml or task inputs
   let useConfigFile: boolean = getBoolInput("useConfigFile", false);
+  let configFilePath = getInput("configFilePath")
 
   // Check if the host ssh socket needs to be forwarded to the container
   let forwardHostSshSocket: boolean = getBoolInput("forwardHostSshSocket", false);
@@ -150,6 +153,7 @@ export default function getSharedVariables(): ISharedVariables {
     ignoreOvr,
     labelsOvr,
     useConfigFile,
+    configFilePath,
     forwardHostSshSocket,
     extraEnvironmentVariables,
     mergeStrategy

--- a/src/extension/task/utils/parseConfigFile.ts
+++ b/src/extension/task/utils/parseConfigFile.ts
@@ -15,7 +15,7 @@ import { getVariable } from "azure-pipelines-task-lib/task";
  *
  * @returns {IDependabotUpdate[]} updates - array of dependency update configurations
  */
-export default function parseConfigFile(): IDependabotUpdate[] {
+export default function parseConfigFile(configFilePath: string): IDependabotUpdate[] {
 
   /*
    * If the file under the .github folder does not exist, check for one under the .azuredevops folder.
@@ -30,12 +30,20 @@ export default function parseConfigFile(): IDependabotUpdate[] {
   // Find configuration file
   let filePath: string;
   let rootDir = getVariable("Build.SourcesDirectory");
-  possibleFilePaths.forEach(fp => {
-    var fullPath = path.join(rootDir, fp);
+  if(configFilePath) {
+    var fullPath = path.join(rootDir, configFilePath);
     if (fs.existsSync(fullPath)) {
       filePath = fullPath;
     }
-  });
+  }
+  else {
+    possibleFilePaths.forEach(fp => {
+      var fullPath = path.join(rootDir, fp);
+      if (fs.existsSync(fullPath)) {
+        filePath = fullPath;
+      }
+    });
+  }
 
   // Ensure we have the file. Otherwise throw a well readable error.
   if (filePath) {
@@ -51,7 +59,7 @@ export default function parseConfigFile(): IDependabotUpdate[] {
       );
     }
   } else {
-    throw new Error(`Configuration file not found at possible locations: ${possibleFilePaths.join(', ')}`);
+    throw new Error(`Configuration file not found at possible locations: ${configFilePath ?? possibleFilePaths.join(', ')}`);
   }
 
   let config: any;


### PR DESCRIPTION
Currently the configuration file can only be located in the following folders

```
- "/.github/dependabot.yml",
- "/.github/dependabot.yaml",
- "/.azuredevops/dependabot.yml",
- "/.azuredevops/dependabot.yaml",
```

This is rather limiting if you wish to have a common config across multiple projects by using git sub modules as part of a wider standardised pipeline programme. 

This PR adds a complimentary parameter `configFilePath` which would be used instead of the set of default locations. 