### PR TITLE
Fix deprecation note

### DIFF
--- a/src/extension/task/index.ts
+++ b/src/extension/task/index.ts
@@ -22,7 +22,7 @@ async function run() {
         `
         Using explicit inputs instead of a configuration file is deprecated and will be removed in version 0.11.0.\r\n
         No new features will be added to the use of explicit inputs that can also be specified in the configuration file.\r\n\r\n
-        Migrate to using a config file at .azuredevops/dependabot.yml or .github/dependabot.yml.\r\n
+        Migrate to using a config file at .github/dependabot.yml.\r\n
         See https://github.com/tinglesoftware/dependabot-azure-devops/tree/main/src/extension#usage for more information.
         `
       );


### PR DESCRIPTION
I removed the 
The deprecation asks the developer to use a configuration file within the `.azuredevops` folder from v0.11 onwards. As of my understanding `.azuredevops` is deprecated and planned to be not supported in v0.11 as well. 