### PR TITLE
Quick updates

### DIFF
--- a/cronjob-template.yaml
+++ b/cronjob-template.yaml
@@ -36,7 +36,7 @@ spec:
           activeDeadlineSeconds: 3600
           containers:
           - name: dependabot
-            image: 'tingle/dependabot-azure-devops:0.8.4' # Use a specific tag otherwise the image may be cached already
+            image: 'tingle/dependabot-azure-devops:0.10' # Use a specific tag otherwise the image may be cached already
             resources: {} # decide based on your usage
             env:
             - name: GITHUB_ACCESS_TOKEN

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -261,7 +261,7 @@
       "groupName": "advanced",
       "label": "Tag of the docker image to be pulled.",
       "required": false,
-      "defaultValue": "0.9",
+      "defaultValue": "0.10",
       "helpMarkDown": "The image tag to use when pulling the docker container used by the task. A tag also defines the version. By default, the task decides which tag/version to use. This can be the latest or most stable version. You can also use `major.minor` format to get the latest patch"
     },
     {

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -135,13 +135,6 @@
       "helpMarkDown": "The identifier of the work item to be linked to the Pull Requests that dependabot creates."
     },
     {
-      "name": "updaterOptions",
-      "type": "string",
-      "label": "Comma separated list of updater options.",
-      "required": false,
-      "helpMarkDown": "Set a list of updater options in CSV format. Available options depend on the ecosystem. Example: `goprivate=true,kubernetes_updates=true`."
-    },
-    {
       "name": "setAutoComplete",
       "type": "boolean",
       "groupName": "approval_completion",
@@ -228,6 +221,14 @@
       "label": "Target Repository Name",
       "required": false,
       "helpMarkDown": "The name of the repository to target for processing. If this value is not supplied then the Build Repository Name is used. Supplying this value allows creation of a single pipeline that runs Dependablot against multiple repositories."
+    },
+    {
+      "name": "updaterOptions",
+      "type": "string",
+      "groupName": "advanced",
+      "label": "Comma separated list of updater options.",
+      "required": false,
+      "helpMarkDown": "Set a list of updater options in CSV format. Available options depend on the ecosystem. Example: `goprivate=true,kubernetes_updates=true`."
     },
     {
       "name": "excludeRequirementsToUnlock",

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -243,8 +243,7 @@
       "label": "Container registry override",
       "groupName": "advanced",
       "helpMarkDown": "The docker registry to use when pulling the docker container used by the task if needed. By default this will use docker hub. This can be useful if the container needs to come from an internal docker registry mirror or alternative source for testing. If the mirror requires authentication add a `docker login` task before this task. Example: `contoso.azurecr.io`",
-      "required": false,
-      "groupName": "advanced"
+      "required": false
     },
     {
       "name": "dockerImageRepository",

--- a/script/README.md
+++ b/script/README.md
@@ -3,7 +3,7 @@
 First, you need to pull the image locally to your machine:
 
 ```bash
-docker pull tingle/dependabot-azure-devops:0.4.0
+docker pull tingle/dependabot-azure-devops:0.10
 ```
 
 Next create and run a container from the image:
@@ -35,7 +35,7 @@ docker run --rm -t \
            -e AZURE_AUTO_APPROVE_PR=<true/false> \
            -e AZURE_AUTO_APPROVE_USER_EMAIL=<approving-user-email> \
            -e AZURE_AUTO_APPROVE_USER_TOKEN=<approving-user-token-here> \
-           tingle/dependabot-azure-devops:0.4.0
+           tingle/dependabot-azure-devops:0.10
 ```
 
 An example, for Azure DevOps Services:
@@ -64,7 +64,7 @@ docker run --rm -t \
            -e AZURE_AUTO_APPROVE_PR=true \
            -e AZURE_AUTO_APPROVE_USER_EMAIL=supervisor@contoso.com \
            -e AZURE_AUTO_APPROVE_USER_TOKEN=ijkl..mnop \
-           tingle/dependabot-azure-devops:0.4.0
+           tingle/dependabot-azure-devops:0.10
 ```
 
 An example, for Azure DevOps Server:
@@ -96,7 +96,7 @@ docker run --rm -t \
            -e AZURE_AUTO_APPROVE_PR=true \
            -e AZURE_AUTO_APPROVE_USER_EMAIL=supervisor@contoso.com \
            -e AZURE_AUTO_APPROVE_USER_TOKEN=ijkl..mnop \
-           tingle/dependabot-azure-devops:0.4.0
+           tingle/dependabot-azure-devops:0.10
 ```
 
 ## Environment Variables


### PR DESCRIPTION
- Change default value for dockerImageRepository from 0.9 to 0.10
- Update tag versions in the examples to 0.10
- Remove duplicate `groupName`.
- Move `updaterOptions` to the `advanced` group.

