### PR TITLE
Align PR naming with default Azure DevOps AutoComplete naming

### DIFF
--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -58,7 +58,7 @@ module Dependabot
                 JSON.parse(response.body).fetch("value")
             end
 
-            def pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
+            def pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
                 # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-6.0
                 content = {
                     autoCompleteSetBy: {
@@ -66,6 +66,7 @@ module Dependabot
                     },
                     completionOptions: {
                         autoCompleteIgnoreConfigIds: auto_complete_ignore_config_ids,
+                        mergeCommitMessage: "Merged PR #{pull_request_id}: #{pull_request_title}",
                         mergeStrategy: merge_strategy,
                         deleteSourceBranch: true,
                         transitionWorkItems: false

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -520,10 +520,11 @@ dependencies.select(&:top_level?).each do |dep|
     # Pull requests that pass all policies will be merged automatically.
     if $options[:set_auto_complete]
       auto_complete_user_id = pull_request['createdBy']['id']
+      pull_request_title = pull_request['title']
       merge_strategy = $options[:merge_strategy]
       auto_complete_ignore_config_ids = $options[:auto_complete_ignore_config_ids]
       puts "Setting auto complete on ##{pull_request_id}."
-      azure_client.pull_request_auto_complete(pull_request_id, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
+      azure_client.pull_request_auto_complete(pull_request_id, pull_request_title, auto_complete_user_id, merge_strategy, auto_complete_ignore_config_ids)
     end
 
   rescue StandardError => e


### PR DESCRIPTION
See discussion in #370
extracted title alignment to this PR

Solves #321 

When `AutoComplete` is activated in pipeline, the merge commit was named differently than when ` Set AutoComplete` was activated manually on PR, see #321 .