### PR TITLE
Respect ignore from config

### DIFF
--- a/cronjob-template.yaml
+++ b/cronjob-template.yaml
@@ -65,8 +65,6 @@ spec:
               value: '{{dependabot_extra_credentials}}'
             - name: DEPENDABOT_ALLOW_CONDITIONS
               value: '{{dependabot_allow_conditions}}'
-            - name: DEPENDABOT_IGNORE_CONDITIONS
-              value: '{{dependabot_ignore_conditions}}'
             - name: DEPENDABOT_LABELS
               value: '{{dependabot_labels}}'
             - name: DEPENDABOT_BRANCH_NAME_SEPARATOR

--- a/extension/README.md
+++ b/extension/README.md
@@ -88,7 +88,6 @@ schedules:
 variables:
   DEPENDABOT_EXTRA_CREDENTIALS: '[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' # put the credentials for private registries and feeds
   DEPENDABOT_ALLOW_CONDITIONS: '[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' # packages allowed to be updated
-  DEPENDABOT_IGNORE_CONDITIONS: '[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' # packages to be ignored
 
 pool:
   vmImage: 'ubuntu-latest' # requires macos or ubuntu (windows is not supported)

--- a/extension/task/IDependabotConfig.ts
+++ b/extension/task/IDependabotConfig.ts
@@ -34,10 +34,6 @@ export interface IDependabotUpdate {
    */
   allow?: string;
   /**
-   * Ignore certain dependencies or versions.
-   */
-  ignore?: string;
-  /**
    * Custom labels/tags.
    */
   labels?: string;

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -102,10 +102,9 @@ async function run() {
         dockerRunner.arg(["-e", `DEPENDABOT_ALLOW_CONDITIONS=${allow}`]);
       }
 
-      // Set the dependencies to ignore
-      let ignore = update.ignore || variables.ignoreOvr;
-      if (ignore) {
-        dockerRunner.arg(["-e", `DEPENDABOT_IGNORE_CONDITIONS=${ignore}`]);
+      // Set the dependencies to ignore only when not using the config file
+      if (!variables.useConfigFile && variables.ignoreOvr) {
+        dockerRunner.arg(["-e", `DEPENDABOT_IGNORE_CONDITIONS=${variables.ignoreOvr}`]);
       }
 
       // Set the custom labels/tags

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -118,7 +118,6 @@ function parseUpdates(config: any) : IDependabotUpdate[] {
 
       // Convert to JSON and shorten the names as required by the script
       allow: update["allow"] ? JSON.stringify(update["allow"]) : undefined,
-      ignore: update["ignore"] ? JSON.stringify(update["ignore"]) : undefined,
       labels: update["labels"] ? JSON.stringify(update["labels"]) : undefined,
     };
 

--- a/script/README.md
+++ b/script/README.md
@@ -26,7 +26,6 @@ docker run --rm -t \
            -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=10 \
            -e DEPENDABOT_EXTRA_CREDENTIALS=<your-extra-credentials> \
            -e DEPENDABOT_ALLOW_CONDITIONS=<your-allowed-packages> \
-           -e DEPENDABOT_IGNORE_CONDITIONS=<your-ignore-packages> \
            -e DEPENDABOT_LABELS=<your-custom-labels> \
            -e DEPENDABOT_BRANCH_NAME_SEPARATOR=<your-custom-separator> \
            -e DEPENDABOT_MILESTONE=<your-work-item-id> \
@@ -55,7 +54,6 @@ docker run --rm -t \
            -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=10 \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
-           -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e DEPENDABOT_LABELS='[\"npm dependencies\",\"triage-board\"]' \
            -e DEPENDABOT_BRANCH_NAME_SEPARATOR='/' \
            -e DEPENDABOT_MILESTONE=123 \
@@ -87,7 +85,6 @@ docker run --rm -t \
            -e DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=10 \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' \
-           -e DEPENDABOT_IGNORE_CONDITIONS='[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]' \
            -e DEPENDABOT_LABELS='[\"npm dependencies\",\"triage-board\"]' \
            -e DEPENDABOT_BRANCH_NAME_SEPARATOR='/' \
            -e DEPENDABOT_MILESTONE=123 \


### PR DESCRIPTION
When using a config file, the `DEPENDABOT_IGNORE_CONDITIONS` env should not be supplied because the Ruby code reads the config appropriately.

Discourage the use of `DEPENDABOT_IGNORE_CONDITIONS` by removing it from samples.