### PR TITLE
Fix hostname detection for old url formats

### DIFF
--- a/extension/task/utils/extractHostname.ts
+++ b/extension/task/utils/extractHostname.ts
@@ -4,7 +4,7 @@
  * @returns The hostname component of the {@see organizationUrl} parameter or `dev.azure.com` if the parameter points to an old `*.visualstudio.com` URL.
  */
 export default function extractHostname(organizationUrl: URL): string {
-  const visualStudioUrlRegex = /^(?<prefix>\S)\.visualstudio\.com$/iu;
+  const visualStudioUrlRegex = /^(?<prefix>\S+)\.visualstudio\.com$/iu;
   let hostname = organizationUrl.hostname;
   if (visualStudioUrlRegex.test(hostname)) {
     return 'dev.azure.com';


### PR DESCRIPTION
Our organization is still on the old url format of *.visualstudio.com. The task isn't detecting the hostname correctly and not changing it to dev.azure.com. I believe there is a bug in the following line:

https://github.com/tinglesoftware/dependabot-azure-devops/blob/76e56ef265e8289f1e4a78308f587919e4f6f847/extension/task/utils/extractHostname.ts#L7

The regex test should probably be: /^(?<prefix>\S+)\.visualstudio\.com$/iu

Without the +, the test would fail for hostnames with more than one character in the subdomain (ie `https://a.visualstudio.com` works but `https://abc.visualstudio.com` doesn't).

Because it wasn't detecting our hostname correctly, it would fail trying to find the repository with the error of `Dependabot::RepoNotFound (Dependabot::RepoNotFound)`