### PR TITLE
Registries fix regex

### DIFF
--- a/extension/task/IDependabotConfig.ts
+++ b/extension/task/IDependabotConfig.ts
@@ -3,21 +3,21 @@
  *
  * https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml
  */
- export interface IDependabotConfig {
+export interface IDependabotConfig {
   /**
    *  Mandatory. configuration file version.
    **/
   version: number;
- /**
-  *  Mandatory. Configure how Dependabot updates the versions or project dependencies.
-  *  Each entry configures the update settings for a particular package manager.
-  */
+  /**
+   *  Mandatory. Configure how Dependabot updates the versions or project dependencies.
+   *  Each entry configures the update settings for a particular package manager.
+   */
   updates: IDependabotUpdate[];
   /**
    *  Optional. Specify authentication details to access private package registries.
    */
   registries?: IDependabotRegistry[];
- }
+}
 
 export interface IDependabotUpdate {
   /**
@@ -90,35 +90,35 @@ export interface IDependabotRegistry {
   /**
    * Identifies the type of registry
    */
-   type: string;
+  type: string;
   /**
    * The URL to use to access the dependencies in this registry.
    * The protocol is optional. If not specified, `https://` is assumed.
    * Dependabot adds or ignores trailing slashes as required.
    */
-   url: string;
+  url: string;
   /**
    * The username to access the registry
    */
-   username?: string;
+  username?: string;
   /**
    *  A password for the username to access this registry
    */
-   password?: string;
+  password?: string;
   /**
    *  An access key for this registry
    */
-   key?: string;
+  key?: string;
   /**
    *  An access token for this registry
    */
-   token?: string;
+  token?: string;
   /**
    * 	For registries with type: python-index,
    *  if the boolean value is `true`, pip resolves dependencies by using the specified URL
    *  rather than the base URL of the Python Package Index (by default https://pypi.org/simple).
    */
-   "replaces-base"?: string;
+  "replaces-base"?: string;
 }
 
 export type DependabotDependencyType =

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -122,6 +122,9 @@ async function run() {
       }
 
       // Set the extra credentials
+      if (variables.useConfigFile && variables.extraCredentials) {
+        tl.warning(`Using 'DEPENDABOT_EXTRA_CREDENTIALS' is not recommended when using a config file. Specify the same values in the registries section of .github/dependabot.yml file.`);
+      }
       if (variables.extraCredentials) {
         //TODO remove variables.extraCredentials in future in favor default yml configuration.
         dockerRunner.arg(["-e", `DEPENDABOT_EXTRA_CREDENTIALS=${variables.extraCredentials}`]);

--- a/extension/task/utils/convertPlaceholder.ts
+++ b/extension/task/utils/convertPlaceholder.ts
@@ -1,7 +1,7 @@
 import { getVariable } from "azure-pipelines-task-lib/task";
 
 export default function convertPlaceholder(input: string): string {
-  const regexp: RegExp = new RegExp("\\${{\\s*([a-zA-Z_]+[a-zA-Z0-9_]*)\\s*}}", 'g');
+  const regexp: RegExp = new RegExp("\\${{\\s*([a-zA-Z_]+[a-zA-Z0-9_-]*)\\s*}}", 'g');
 
   let result: string = input;
   const matches = matchAll(input, regexp);

--- a/extension/task/utils/convertPlaceholder.ts
+++ b/extension/task/utils/convertPlaceholder.ts
@@ -1,10 +1,7 @@
 import { getVariable } from "azure-pipelines-task-lib/task";
 
 export default function convertPlaceholder(input: string): string {
-  const variableNameExp : string = "[a-zA-Z_]+[a-zA-Z0-9_]*"
-  const variableLeftExp : string = "\\${{"
-  const variableRightExp : string = "}}"
-  const regexp : RegExp = new RegExp(variableLeftExp + "\\s*(" + variableNameExp + ")\\s*" + variableRightExp, 'g');
+  const regexp: RegExp = new RegExp("\\${{\\s*([a-zA-Z_]+[a-zA-Z0-9_]*)\\s*}}", 'g');
 
   let result: string = input;
   const matches = matchAll(input, regexp);

--- a/extension/task/utils/convertPlaceholder.ts
+++ b/extension/task/utils/convertPlaceholder.ts
@@ -1,25 +1,25 @@
 import { getVariable } from "azure-pipelines-task-lib/task";
 
 export default function convertPlaceholder(input: string): string {
-    const variableNameExp : string = "[a-zA-Z_]+[a-zA-Z0-9_]*"
-    const variableLeftExp : string = "\\${{"
-    const variableRightExp : string = "}}"
-    const regexp : RegExp = new RegExp(variableLeftExp + "\\s*(" + variableNameExp + ")\\s*" + variableRightExp, 'g');
+  const variableNameExp : string = "[a-zA-Z_]+[a-zA-Z0-9_]*"
+  const variableLeftExp : string = "\\${{"
+  const variableRightExp : string = "}}"
+  const regexp : RegExp = new RegExp(variableLeftExp + "\\s*(" + variableNameExp + ")\\s*" + variableRightExp, 'g');
 
-    let result : string = input;
-    const matches = matchAll(input, regexp);
+  let result: string = input;
+  const matches = matchAll(input, regexp);
 
-    for (const match of matches) {
-        var placeholder = match[0];
-        var name = match[1];
-        var value = getVariable(name) ?? placeholder;
-        result = result.replace(placeholder, value);
-    }
-    return result;
+  for (const match of matches) {
+    var placeholder = match[0];
+    var name = match[1];
+    var value = getVariable(name) ?? placeholder;
+    result = result.replace(placeholder, value);
+  }
+  return result;
 }
 
-function matchAll( target : string, rExp : RegExp, matches : Array<RegExpExecArray> = []) {
-    const matchIfAny  = rExp.exec(target);
-    matchIfAny && matches.push(matchIfAny) && matchAll(target, rExp, matches);
-    return matches;
+function matchAll(target: string, rExp: RegExp, matches: Array<RegExpExecArray> = []) {
+  const matchIfAny = rExp.exec(target);
+  matchIfAny && matches.push(matchIfAny) && matchAll(target, rExp, matches);
+  return matches;
 }

--- a/extension/task/utils/extractVirtualDirectory.ts
+++ b/extension/task/utils/extractVirtualDirectory.ts
@@ -11,7 +11,7 @@
 export default function extractVirtualDirectory(organizationUrl: URL): string {
   let path = organizationUrl.pathname.split("/");
   // Virtual Directories are sometimes used in on-premises
-  // URLs tipically are like this: https://server.domain.com/tfs/x/
+  // URLs typically are like this: https://server.domain.com/tfs/x/
   if (path.length == 4) {
     return path[1];
   }

--- a/extension/task/utils/getConfigFromInputs.ts
+++ b/extension/task/utils/getConfigFromInputs.ts
@@ -9,7 +9,7 @@ import { IDependabotConfig } from "../IDependabotConfig";
  *
  * @returns {IDependabotConfig} update configuration
  */
-export default function getConfigFromInputs() : IDependabotConfig {
+export default function getConfigFromInputs(): IDependabotConfig {
   var dependabotConfig: IDependabotConfig = {
     version: 2,
     updates: [{

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -67,18 +67,18 @@ export default function parseConfigFile(): IDependabotConfig {
   let version = -1;
 
   // Ensure the version has been specified
-  if(!!!rawVersion) throw new Error("The version must be specified in dependabot.yml");
+  if (!!!rawVersion) throw new Error("The version must be specified in dependabot.yml");
 
   // Try convert the version to integer
-  try{
+  try {
     version = parseInt(rawVersion, 10);
   }
-  catch(e) {
+  catch (e) {
     throw new Error("Dependabot version specified must be a valid integer");
   }
 
   // Ensure the version is == 2
-  if(version !== 2) throw new Error("Only version 2 of dependabot is supported. Version specified: " + version);
+  if (version !== 2) throw new Error("Only version 2 of dependabot is supported. Version specified: " + version);
 
   var dependabotConfig: IDependabotConfig = {
     version: version,
@@ -90,7 +90,7 @@ export default function parseConfigFile(): IDependabotConfig {
 }
 
 
-function parseUpdates(config: any) : IDependabotUpdate[] {
+function parseUpdates(config: any): IDependabotUpdate[] {
   var updates: IDependabotUpdate[] = [];
 
   // Check the updates parsed
@@ -138,8 +138,8 @@ function parseUpdates(config: any) : IDependabotUpdate[] {
   return updates;
 }
 
-function parseRegistries(config: any) : IDependabotRegistry[] {
-  var registries : IDependabotRegistry[] = [];
+function parseRegistries(config: any): IDependabotRegistry[] {
+  var registries: IDependabotRegistry[] = [];
 
   var rawRegistries = config["registries"];
 


### PR DESCRIPTION
Update Regex for placeholder/token replacement for registries to support hyphens and be more readable.

Other commits:
- Added warning when using `DEPENDABOT_EXTRA_CREDENTIALS` and a config file.
- Fix spacing, indentation and typos in a couple of files.