### PR TITLE
Correct property/element name for serialized registries

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -86,7 +86,6 @@ schedules:
 
 # variables declared below can be put in one or more Variable Groups for sharing across pipelines
 variables:
-  DEPENDABOT_EXTRA_CREDENTIALS: '[{\"type\":\"npm_registry\",\"token\":\"<redacted>\",\"registry\":\"npm.fontawesome.com\"}]' # put the credentials for private registries and feeds
   DEPENDABOT_ALLOW_CONDITIONS: '[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]' # packages allowed to be updated
 
 pool:

--- a/extension/task/IDependabotConfig.ts
+++ b/extension/task/IDependabotConfig.ts
@@ -96,7 +96,13 @@ export interface IDependabotRegistry {
    * The protocol is optional. If not specified, `https://` is assumed.
    * Dependabot adds or ignores trailing slashes as required.
    */
-  url: string;
+  url?: string;
+  /**
+   * The URL of the registry to use to access the dependencies in this registry.
+   * The protocol is optional. If not specified, `https://` is assumed.
+   * Dependabot adds or ignores trailing slashes as required.
+   */
+  registry?: string;
   /**
    * The username to access the registry
    */

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -150,9 +150,24 @@ function parseRegistries(config: any): IDependabotRegistry[] {
   Object.entries(rawRegistries).forEach((item) => {
     var registryConfigKey = item[0];
     var registryConfig = item[1];
+    var type = registryConfig["type"]?.replace("-", "_");
+    if (!type) { // Consider checking against known values for the field
+      throw new Error(
+        `The value for 'type' in dependency registry config '${registryConfigKey}' is missing`
+      );
+    }
+
+    var url = registryConfig["url"];
+    if (!url) {
+      throw new Error(
+        `The value 'url' in dependency registry config '${registryConfigKey}' is missing`
+      );
+    }
+
+
     var dependabotRegistry: IDependabotRegistry = {
-      type: registryConfig["type"]?.replace("-", "_"),
-      url: registryConfig["url"],
+      type: type,
+      url: url,
 
       username: registryConfig["username"],
       password: convertPlaceholder(registryConfig["password"]),
@@ -161,18 +176,6 @@ function parseRegistries(config: any): IDependabotRegistry[] {
 
       "replaces-base": registryConfig["replaces-base"]
     };
-
-    if (!dependabotRegistry.type) {
-      throw new Error(
-        `The value for 'type' in dependency registry config '${registryConfigKey}' is missing`
-      );
-    }
-
-    if (!dependabotRegistry.url) {
-      throw new Error(
-        `The value 'url' in dependency registry config '${registryConfigKey}' is missing`
-      );
-    }
 
     registries.push(dependabotRegistry);
   });

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -164,10 +164,14 @@ function parseRegistries(config: any): IDependabotRegistry[] {
       );
     }
 
+    // In Ruby, the some credentials use 'registry' property/field name instead of 'url'
+    var useRegistryProperty = type.includes("npm") || type.includes("docker"); // This may also apply for terraform but we don't have enough tests to know
 
     var dependabotRegistry: IDependabotRegistry = {
       type: type,
-      url: url,
+
+      url: useRegistryProperty ? null : url,
+      registry: useRegistryProperty ? url : null,
 
       username: registryConfig["username"],
       password: convertPlaceholder(registryConfig["password"]),


### PR DESCRIPTION
When converting registries for npm and docker, the `url` property/element should be replaced with `registry` so as to match the expectation in the Ruby baseline/logic code.

Other:
- Remove `DEPENDABOT_EXTRA_CREDENTIALS` from advanced sample to discourage its use.