### PR TITLE
Ruby updates

### DIFF
--- a/script/Gemfile
+++ b/script/Gemfile
@@ -3,5 +3,4 @@
 source "https://rubygems.org"
 ruby "3.1.3"
 
-gem "irb"
 gem "dependabot-omnibus", "~> 0.214.0"

--- a/script/Gemfile
+++ b/script/Gemfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-ruby "3.1.3"
 
 gem "dependabot-omnibus", "~> 0.214.0"

--- a/script/Gemfile
+++ b/script/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
+ruby "3.1.3"
 
 gem "irb"
 gem "dependabot-omnibus", "~> 0.214.0"

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -162,8 +162,5 @@ PLATFORMS
 DEPENDENCIES
   dependabot-omnibus (~> 0.214.0)
 
-RUBY VERSION
-   ruby 3.1.3p185
-
 BUNDLED WITH
    2.3.26

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -165,5 +165,8 @@ DEPENDENCIES
   dependabot-omnibus (~> 0.214.0)
   irb
 
+RUBY VERSION
+   ruby 3.1.3p185
+
 BUNDLED WITH
    2.3.22

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
     minitest (5.16.3)
     multi_xml (0.6.0)
     netrc (0.11.0)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     octokit (6.0.1)
@@ -154,6 +156,7 @@ GEM
     unicode-display_width (2.3.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -169,4 +169,4 @@ RUBY VERSION
    ruby 3.1.3p185
 
 BUNDLED WITH
-   2.3.22
+   2.3.26

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -116,9 +116,6 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    io-console (0.5.11)
-    irb (1.5.1)
-      reline (>= 0.3.0)
     jmespath (1.6.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -136,8 +133,6 @@ GEM
       ast (~> 2.4.1)
     public_suffix (5.0.0)
     racc (1.6.0)
-    reline (0.3.1)
-      io-console (~> 0.5)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -163,7 +158,6 @@ PLATFORMS
 
 DEPENDENCIES
   dependabot-omnibus (~> 0.214.0)
-  irb
 
 RUBY VERSION
    ruby 3.1.3p185


### PR DESCRIPTION
- Fix Ruby version in Gemfile.
- Update bundler version.
- Uninstall unused `irb` gem.
- Add ARM64 for Darwin in PLATFORMS