### PR TITLE
Reduce env passed from task extension to docker container

### DIFF
--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -49,7 +49,6 @@ async function run() {
 
       // Set env variables in the runner
       dockerRunner.arg(["-e", `DEPENDABOT_PACKAGE_MANAGER=${update.packageEcosystem}`]);
-      dockerRunner.arg(["-e", `DEPENDABOT_FAIL_ON_EXCEPTION=${variables.failOnException}`]); // Set exception behaviour
       dockerRunner.arg(["-e", `DEPENDABOT_REJECT_EXTERNAL_CODE=${update.rejectExternalCode}`]);
       dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${variables.excludeRequirementsToUnlock}`]);
       dockerRunner.arg(["-e", `AZURE_ORGANIZATION=${variables.organization}`]); // Set the organization
@@ -128,6 +127,11 @@ async function run() {
       } else if (config.registries != undefined) {
         let extraCredentials = JSON.stringify(config.registries);
         dockerRunner.arg(["-e", `DEPENDABOT_EXTRA_CREDENTIALS=${extraCredentials}`]);
+      }
+
+      // Set exception behaviour if true
+      if (variables.failOnException === true) {
+        dockerRunner.arg(["-e", 'DEPENDABOT_FAIL_ON_EXCEPTION=true']);
       }
 
       // Set the github token, if one is provided

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -153,7 +153,7 @@ async function run() {
         dockerRunner.arg(["-e", `AZURE_VIRTUAL_DIRECTORY=${variables.virtualDirectory}`]);
       }
 
-      // Set auto complete
+      // Set auto approve
       dockerRunner.arg(["-e", `AZURE_AUTO_APPROVE_PR=${variables.autoApprove}`]);
       if (variables.autoApproveUserEmail) {
         dockerRunner.arg(["-e", `AZURE_AUTO_APPROVE_USER_EMAIL=${variables.autoApproveUserEmail}`]);

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -52,8 +52,6 @@ async function run() {
       dockerRunner.arg(["-e", `DEPENDABOT_FAIL_ON_EXCEPTION=${variables.failOnException}`]); // Set exception behaviour
       dockerRunner.arg(["-e", `DEPENDABOT_REJECT_EXTERNAL_CODE=${update.rejectExternalCode}`]);
       dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${variables.excludeRequirementsToUnlock}`]);
-      dockerRunner.arg(["-e", `AZURE_PROTOCOL=${variables.protocol}`]);
-      dockerRunner.arg(["-e", `AZURE_HOSTNAME=${variables.hostname}`]);
       dockerRunner.arg(["-e", `AZURE_ORGANIZATION=${variables.organization}`]); // Set the organization
       dockerRunner.arg(["-e", `AZURE_PROJECT=${variables.project}`]); // Set the project
       dockerRunner.arg(["-e", `AZURE_REPOSITORY=${variables.repository}`]);
@@ -136,6 +134,13 @@ async function run() {
       // Set the github token, if one is provided
       if (variables.githubAccessToken) {
         dockerRunner.arg(["-e", `GITHUB_ACCESS_TOKEN=${variables.githubAccessToken}`]);
+      }
+
+      if (variables.protocol !== 'https') {
+        dockerRunner.arg(["-e", `AZURE_PROTOCOL=${variables.protocol}`]);
+      }
+      if (variables.hostname !== "dev.azure.com") {
+        dockerRunner.arg(["-e", `AZURE_HOSTNAME=${variables.hostname}`]);
       }
 
       // Set the port

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -49,7 +49,6 @@ async function run() {
 
       // Set env variables in the runner
       dockerRunner.arg(["-e", `DEPENDABOT_PACKAGE_MANAGER=${update.packageEcosystem}`]);
-      dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${variables.excludeRequirementsToUnlock}`]);
       dockerRunner.arg(["-e", `AZURE_ORGANIZATION=${variables.organization}`]); // Set the organization
       dockerRunner.arg(["-e", `AZURE_PROJECT=${variables.project}`]); // Set the project
       dockerRunner.arg(["-e", `AZURE_REPOSITORY=${variables.repository}`]);
@@ -100,6 +99,11 @@ async function run() {
       let allow = update.allow || variables.allowOvr;
       if (allow) {
         dockerRunner.arg(["-e", `DEPENDABOT_ALLOW_CONDITIONS=${allow}`]);
+      }
+
+      // Set the requirements that should not be unlocked
+      if (variables.excludeRequirementsToUnlock) {
+        dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${variables.excludeRequirementsToUnlock}`]);
       }
 
       // Set the dependencies to ignore only when not using the config file

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -57,7 +57,6 @@ async function run() {
       dockerRunner.arg(["-e", `AZURE_REPOSITORY=${variables.repository}`]);
       dockerRunner.arg(["-e", `AZURE_ACCESS_TOKEN=${variables.systemAccessToken}`]);
       dockerRunner.arg(["-e", `AZURE_SET_AUTO_COMPLETE=${variables.setAutoComplete}`]); // Set auto complete, if set
-      dockerRunner.arg(["-e", `AZURE_AUTO_COMPLETE_IGNORE_CONFIG_IDS=${JSON.stringify(variables.autoCompleteIgnoreConfigIds)}`]);
       dockerRunner.arg(["-e", `AZURE_MERGE_STRATEGY=${variables.mergeStrategy}`]);
 
       // Set Username
@@ -136,11 +135,19 @@ async function run() {
         dockerRunner.arg(["-e", `GITHUB_ACCESS_TOKEN=${variables.githubAccessToken}`]);
       }
 
+      // Set the protocol if not the default value
       if (variables.protocol !== 'https') {
         dockerRunner.arg(["-e", `AZURE_PROTOCOL=${variables.protocol}`]);
       }
+
+      // Set the host name if not the default value
       if (variables.hostname !== "dev.azure.com") {
         dockerRunner.arg(["-e", `AZURE_HOSTNAME=${variables.hostname}`]);
+      }
+
+      // Set the ignore config IDs for auto complete if not the default value
+      if (variables.autoCompleteIgnoreConfigIds.length > 0) {
+        dockerRunner.arg(["-e", `AZURE_AUTO_COMPLETE_IGNORE_CONFIG_IDS=${JSON.stringify(variables.autoCompleteIgnoreConfigIds)}`]);
       }
 
       // Set the port

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -49,7 +49,6 @@ async function run() {
 
       // Set env variables in the runner
       dockerRunner.arg(["-e", `DEPENDABOT_PACKAGE_MANAGER=${update.packageEcosystem}`]);
-      dockerRunner.arg(["-e", `DEPENDABOT_REJECT_EXTERNAL_CODE=${update.rejectExternalCode}`]);
       dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${variables.excludeRequirementsToUnlock}`]);
       dockerRunner.arg(["-e", `AZURE_ORGANIZATION=${variables.organization}`]); // Set the organization
       dockerRunner.arg(["-e", `AZURE_PROJECT=${variables.project}`]); // Set the project
@@ -90,6 +89,11 @@ async function run() {
       // Set the PR branch separator
       if (update.branchNameSeparator) {
         dockerRunner.arg(["-e", `DEPENDABOT_BRANCH_NAME_SEPARATOR=${update.branchNameSeparator}`]);
+      }
+
+      // Set exception behaviour if true
+      if (update.rejectExternalCode === true) {
+        dockerRunner.arg(["-e", 'DEPENDABOT_REJECT_EXTERNAL_CODE=true']);
       }
 
       // Set the dependencies to allow


### PR DESCRIPTION
Some ENV variables do not need to be passed over from the task extension unless they do not have their default values. These include:

- `DEPENDABOT_REJECT_EXTERNAL_CODE` which defaults to `false`.
- `DEPENDABOT_FAIL_ON_EXCEPTION` which defaults to `true`.
- `AZURE_AUTO_COMPLETE_IGNORE_CONFIG_IDS` which defaults to an empty array.
- `AZURE_PROTOCOL` which defaults to `https`.
- `AZURE_HOSTNAME` which defaults to `dev.azure.com`.
- `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK` which defaults to `null`.

Other changes:
- Update comment for auto approve
