### PR TITLE
Use root directory to fetch configuration file in Ruby script

### DIFF
--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -276,7 +276,12 @@ fetcher_args = {
 }
 puts "Looking for configuration file in the repository ..."
 $config_file = begin
-  cfg_file = Dependabot::Config::FileFetcher.new(**fetcher_args).config_file
+  cfg_source = $source.clone
+  cfg_file = Dependabot::Config::FileFetcher.new(
+    source: cfg_source,
+    credentials: $options[:credentials],
+    options: $options[:updater_options],
+  ).config_file
   puts "Using configuration file at '#{cfg_file.path}' 😎"
   Dependabot::Config::File.parse(cfg_file.content)
 rescue Dependabot::RepoNotFound, Dependabot::DependencyFileNotFound

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -276,7 +276,18 @@ fetcher_args = {
 }
 puts "Looking for configuration file in the repository ..."
 $config_file = begin
+  # Using fetcher_args as before or in the examples will result in the
+  # config file not being found if the directory specified is not the root.
+  # This happens because the files are checked relative to the supplied directory.
+  # https://github.com/dependabot/dependabot-core/blob/c5cd618812b07ece4a4b53ea18d80ad213b077e7/common/lib/dependabot/config/file_fetcher.rb#L29
+  #
+  # To solve this, the FileFetcher for the Config should have its own source
+  # with the directory pointing to the root. Cloning makes it much easier
+  # since we are only making the change for fetching the config file.
+  #
+  # See https://github.com/tinglesoftware/dependabot-azure-devops/issues/399
   cfg_source = $source.clone
+  cfg_source.directory = "/"
   cfg_file = Dependabot::Config::FileFetcher.new(
     source: cfg_source,
     credentials: $options[:credentials],


### PR DESCRIPTION
Instead of `fetcher_args`, use specific values when fetching configuration file in Ruby script hence set the directory for its fetcher to the root (`/`).

Context:
Internally `Dependabot::Config::FileFetcher` takes a possible path and makes it relative to the directory before checking for existence. See https://github.com/dependabot/dependabot-core/blob/c5cd618812b07ece4a4b53ea18d80ad213b077e7/common/lib/dependabot/config/file_fetcher.rb#L29

#422 added logs so we can now tell when the configuration file loads or not.

Fixes: #399

---
Tested against repo at https://dev.azure.com/tingle/dependabot/_git/repro-399

Log for first update

```txt
GitHub access token has been provided.
Using 'https://dev.azure.com:443/' as API endpoint
Reading configuration file from repository...
Read configuration file at '/.github/dependabot.yml' 😎
Fetching nuget dependency files for tingle/dependabot/_git/repro-399
Targeting 'default' branch under '/' directory
Fetching dependency files ...
Found 1 dependency file(s) at commit 113d7caa79bddd8aff069300f15cc8f8fdc21bdf
 - /Root.csproj
Parsing dependencies information
Found 2 dependencies
 - System.Text.Json (6.0.0)
 - Newtonsoft.Json (13.0.0)
Checking if System.Text.Json 6.0.0 needs updating
Requirements to unlock update_not_possible
Checking if Newtonsoft.Json 13.0.0 needs updating
Requirements to unlock own
Updating Newtonsoft.Json from 13.0.0 to 13.0.2
Skipping creating/updating Pull Request as instructed.
Done
```

Log for second update
```txt
GitHub access token has been provided.
Using 'https://dev.azure.com:443/' as API endpoint
Reading configuration file from repository...
Read configuration file at '/.github/dependabot.yml' 😎
Fetching nuget dependency files for tingle/dependabot/_git/repro-399
Targeting 'default' branch under '/app1' directory
Fetching dependency files ...
Found 1 dependency file(s) at commit 113d7caa79bddd8aff069300f15cc8f8fdc21bdf
 - /app1csproj
Parsing dependencies information
Found 2 dependencies
 - System.Text.Json (6.0.0)
 - Newtonsoft.Json (13.0.0)
Checking if System.Text.Json 6.0.0 needs updating
Requirements to unlock own
Updating System.Text.Json from 6.0.0 to 7.0.0
Skipping creating/updating Pull Request as instructed.
Checking if Newtonsoft.Json 13.0.0 needs updating
Requirements to unlock update_not_possible
Done
```
