### PR TITLE
Remove support for .azuredevops folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ Similar to the GitHub native version where you add a `.github/dependabot.yml` fi
 
 > Using a configuration file over explicit inputs will not work with repositories other than the one in the pipeline. This means no shared pipeline. Instead consider the [managed version](https://managed-dependabot.com).
 
-Using `.github/dependabot.yml` or `.github/dependabot.yaml` instead of `.azuredevops/dependabot.yml` is better for 2 reasons:
-
-1. Intellisense support in VS Code (and may be other IDEs).
-2. The docker container checks for the configuration file in this location to configure `commit-message` and `ignore` options.
-
-> Using the .azuredevops folder is deprecated and will be removed in version `0.13.0`.
-
 ## Credentials for private registries and feeds
 
 Besides accessing the repository only, sometimes private feeds/registries may need to be accessed.

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -18,14 +18,9 @@ import convertPlaceholder from "./convertPlaceholder";
  */
 export default function parseConfigFile(): IDependabotConfig {
 
-  /*
-   * If the file under the .github folder does not exist, check for one under the .azuredevops folder.
-   */
   const possibleFilePaths = [
     "/.github/dependabot.yml",
     "/.github/dependabot.yaml",
-    "/.azuredevops/dependabot.yml",
-    "/.azuredevops/dependabot.yaml",
   ];
 
   // Find configuration file
@@ -41,16 +36,6 @@ export default function parseConfigFile(): IDependabotConfig {
   // Ensure we have the file. Otherwise throw a well readable error.
   if (filePath) {
     tl.debug(`Found configuration file at ${filePath}`);
-    if (filePath.includes(".azuredevops/dependabot")) {
-      tl.warning(
-        `
-        The docker container used to run this task checks for a configuration file in the .github folder. Migrate to it.
-        Using the .azuredevops folder is deprecated and will be removed in version 0.13.0.
-
-        See https://github.com/tinglesoftware/dependabot-azure-devops#using-a-configuration-file for more information.
-        `
-      );
-    }
   } else {
     throw new Error(`Configuration file not found at possible locations: ${possibleFilePaths.join(', ')}`);
   }


### PR DESCRIPTION
Remove supports for `.azuredevops` folder in the extension.