### PR TITLE
Pull security vulnerabilities from GitHub's GraphQL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ When working with Azure Artifacts, some extra permission steps need to be done:
 
 ## Security Advisories, Vulnerabilities, and Updates
 
-Security-only updates ia a mechanism to only create pull requests for dependencies with vulnerabilities by updating them to the earliest available non-vulnerable version. Security updates are supported in the same way as the GitHub-hosted version with an exception to how the vulnerabilities are sourced. Currently, these can only be provided in a JSON file via the `securityAdvisoriesFile` input e.g. `securityAdvisoriesFile: '$(Pipeline.Workspace)/advisories.json'`. A file example is available [here](./advisories-example.json).
+Security-only updates ia a mechanism to only create pull requests for dependencies with vulnerabilities by updating them to the earliest available non-vulnerable version. Security updates are supported in the same way as the GitHub-hosted version. In addition, you can provide extra advisories, such as those for an internal dependency, in a JSON file via the `securityAdvisoriesFile` input e.g. `securityAdvisoriesFile: '$(Pipeline.Workspace)/advisories.json'`. A file example is available [here](./advisories-example.json).
 
-Except for when you are using the hosted version, you are responsible for keeping the data up to date using GitHub's GraphQL API for `securityAdvisories`. Querying in the pipeline delays the update process.
+A GitHub access token with `public_repo` access is required to perform the GitHub GraphQL for `securityVulnerabilities`.
 
 ## Kubernetes CronJob
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When working with Azure Artifacts, some extra permission steps need to be done:
 
 ## Security Advisories, Vulnerabilities, and Updates
 
-Security-only updates ia a mechanism to only create pull requests for dependencies with vulnerabilities by updating them to the earliest available non-vulnerable version. Security updates are supported in the same way as the GitHub-hosted version with an exception to how the vulnerabilities are sourced. Currently, these can only be provided in a JSON file via the `securityAdvisoriesFile` input e.g. `securityAdvisoriesFile: '$(Pipeline.Workspace)/advisories.json'`. A file example is available [here](./security_advisories-example.json).
+Security-only updates ia a mechanism to only create pull requests for dependencies with vulnerabilities by updating them to the earliest available non-vulnerable version. Security updates are supported in the same way as the GitHub-hosted version with an exception to how the vulnerabilities are sourced. Currently, these can only be provided in a JSON file via the `securityAdvisoriesFile` input e.g. `securityAdvisoriesFile: '$(Pipeline.Workspace)/advisories.json'`. A file example is available [here](./advisories-example.json).
 
 Except for when you are using the hosted version, you are responsible for keeping the data up to date using GitHub's GraphQL API for `securityAdvisories`. Querying in the pipeline delays the update process.
 

--- a/advisories-example.json
+++ b/advisories-example.json
@@ -1,12 +1,12 @@
 [
     {
-        "dependency-name": "Newtonsoft.Json",
+        "dependency-name": "Contoso.Utils",
         "patched-versions": [
-            "13.0.1"
+            "3.0.1"
         ],
         "unaffected-versions": [],
         "affected-versions": [
-            "< 13.0.1"
+            "< 3.0.1"
         ]
     }
 ]

--- a/script/Gemfile
+++ b/script/Gemfile
@@ -3,3 +3,4 @@
 source "https://rubygems.org"
 
 gem "dependabot-omnibus", "~> 0.215.0"
+gem "graphql-client", "~> 0.18.0"

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
     gitlab (4.19.0)
       httparty (~> 0.20)
       terminal-table (>= 1.5.1)
+    graphql (2.0.15)
+    graphql-client (0.18.0)
+      activesupport (>= 3.0)
+      graphql
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -161,6 +165,7 @@ PLATFORMS
 
 DEPENDENCIES
   dependabot-omnibus (~> 0.215.0)
+  graphql-client (~> 0.18.0)
 
 BUNDLED WITH
    2.3.26

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -21,6 +21,7 @@ require_relative "azure_helpers"
 $options = {
   credentials: [],
   provider: "azure",
+  github_token: nil,
 
   directory: ENV["DEPENDABOT_DIRECTORY"] || "/", # Directory where the base dependency files are.
   branch: ENV["DEPENDABOT_TARGET_BRANCH"] || nil, # Branch against which to create PRs
@@ -117,11 +118,12 @@ $options[:credentials] << {
 }
 unless ENV["GITHUB_ACCESS_TOKEN"].to_s.strip.empty?
   puts "GitHub access token has been provided."
+  $options[:github_token] = ENV["GITHUB_ACCESS_TOKEN"] # A GitHub access token with read access to public repos
   $options[:credentials] << {
     "type" => "git_source",
     "host" => "github.com",
     "username" => "x-access-token",
-    "password" => ENV["GITHUB_ACCESS_TOKEN"] # A GitHub access token with read access to public repos
+    "password" => $options[:github_token]
   }
 end
 # DEPENDABOT_EXTRA_CREDENTIALS, for example:

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -275,6 +275,9 @@ def security_advisories_for(dep)
     $options[:security_advisories].
       select { |adv| adv.fetch("dependency-name").casecmp(dep.name).zero? }
 
+  # add relevant advisories from GitHub's GraphQL if present
+  relevant_advisories += vulnerabilities_fetcher&.fetch(dep.name)
+
   relevant_advisories.map do |adv|
     vulnerable_versions = adv["affected-versions"] || []
     safe_versions = (adv["patched-versions"] || []) +

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -276,7 +276,7 @@ def security_advisories_for(dep)
       select { |adv| adv.fetch("dependency-name").casecmp(dep.name).zero? }
 
   # add relevant advisories from GitHub's GraphQL if present
-  relevant_advisories += vulnerabilities_fetcher&.fetch(dep.name)
+  relevant_advisories += vulnerabilities_fetcher&.fetch(dep.name) || []
 
   relevant_advisories.map do |adv|
     vulnerable_versions = adv["affected-versions"] || []

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -31,7 +31,6 @@ $options = {
   allow_conditions: [],
   reject_external_code: ENV['DEPENDABOT_REJECT_EXTERNAL_CODE'] == "true",
   requirements_update_strategy: nil,
-  security_advisories_graphql: ENV['DEPENDABOT_SECURITY_ADVISORIES_GRAPHQL'] == "true",
   security_advisories: [],
   security_updates_only: false,
   ignore_conditions: [],
@@ -265,7 +264,6 @@ end
 
 def vulnerabilities_fetcher
   return nil unless $options[:github_token]
-  return nil unless $options[:security_advisories_graphql]
   $options[:vulnerabilities_fetcher] ||=
     Dependabot::Vulnerabilities::Fetcher.new($package_manager, $options[:github_token])
 end
@@ -275,7 +273,7 @@ def security_advisories_for(dep)
     $options[:security_advisories].
       select { |adv| adv.fetch("dependency-name").casecmp(dep.name).zero? }
 
-  # add relevant advisories from GitHub's GraphQL if present
+  # add relevant advisories from the fetcher if present
   relevant_advisories += vulnerabilities_fetcher&.fetch(dep.name) || []
 
   relevant_advisories.map do |adv|

--- a/script/vulnerabilities.rb
+++ b/script/vulnerabilities.rb
@@ -1,0 +1,72 @@
+require "graphql/client"
+require "graphql/client/http"
+
+module Dependabot
+  module Vulnerabilities
+    class Fetcher
+      include Graphql
+
+      class QueryError < StandardError; end
+
+      GITHUB_GQL_API_ENDPOINT = "https://api.github.com/graphql"
+
+      PACKAGE_MANAGER_LOOKUP = { # [Hash<String, String>]
+        "github_actions" => "ACTIONS",
+        "composer" => "COMPOSER",
+        "elm" => "ERLANG",
+        "go_modules" => "GO",
+        "maven" => "MAVEN",
+        "npm_and_yarn" => "NPM",
+        "nuget" => "NUGET",
+        "pip" => "PIP",
+        "pub" => "PUB",
+        "bundler" => "RUBYGEMS",
+        "cargo" => "RUST",
+      }.freeze
+
+      def initialize(package_manager, github_token)
+        @ecosystem = PACKAGE_MANAGER_LOOKUP.fetch(package_manager, nil)
+        @github_token = github_token
+
+        # Configure GraphQL endpoint using the basic HTTP network adapter.
+        @http_adapter = GraphQL::Client::HTTP.new(GITHUB_GQL_API_ENDPOINT) do
+            def headers(_context)
+                { "Authorization" => "Bearer #{@github_token}" }
+                # {
+                #   "Authorization" => "Bearer #{@github_token}",
+                #   "User-Agent": "dependabot-azure-devops/1.0"
+                # }
+            end
+        end
+
+        # Fetch latest schema on init, this will make a network request
+        @schema = GraphQL::Client.load_schema(@http_adapter)
+
+        # Parse the query that will be used
+        @parsed_query = client.parse <<~GRAPHQL
+          query($ecosystem: SecurityAdvisoryEcosystem, $package: String) {
+            securityVulnerabilities(ecosystem: $ecosystem, package: $package) {
+              nodes {
+                firstPatchedVersion {
+                  identifier
+                }
+                package {
+                  name
+                }
+                vulnerableVersionRange
+              }
+            }
+          }
+          GRAPHQL
+
+      end
+
+      private
+
+      def client
+        @client ||= GraphQL::Client.new(schema: @schema, execute: @http_adapter)
+      end
+
+    end
+  end
+end

--- a/script/vulnerabilities.rb
+++ b/script/vulnerabilities.rb
@@ -61,6 +61,16 @@ module Dependabot
 
       end
 
+      def fetch(dependency_name)
+        [] unless @ecosystem
+
+        variables = { ecosystem: @ecosystem, package: dependency_name }.compact_blank
+        response = client.query(@parsed_query, variables: variables)
+        raise(QueryError, response.errors[:data].join(", ")) if response.errors.any?
+
+        [] # TODO parse the response
+      end
+
       private
 
       def client

--- a/script/vulnerabilities.rb
+++ b/script/vulnerabilities.rb
@@ -54,7 +54,19 @@ module Dependabot
         response = client.query(@parsed_query, variables: variables)
         raise(QueryError, response.errors[:data].join(", ")) if response.errors.any?
 
-        [] # TODO parse the response
+        vulnerabilities = []
+        response.data.security_vulnerabilities.nodes.map do |node|
+          vulnerable_version_range = node.vulnerable_version_range
+          first_patched_version = node.first_patched_version&.identifier
+          vulnerabilities << {
+            "dependency-name" => dependency_name,
+            "affected-versions" => [vulnerable_version_range],
+            "patched-versions" => [first_patched_version],
+            "unaffected-versions" => [],
+          }
+        end
+
+        vulnerabilities
       end
 
       private

--- a/script/vulnerabilities.rb
+++ b/script/vulnerabilities.rb
@@ -84,7 +84,6 @@ module Dependabot
         end
 
         def headers(context)
-          # { "Authorization" => "Bearer #{@token}" }
           {
             "Authorization" => "Bearer #{@token}",
             "User-Agent" => "dependabot-azure-devops/1.0"

--- a/script/vulnerabilities.rb
+++ b/script/vulnerabilities.rb
@@ -1,6 +1,7 @@
 require "graphql/client"
 require "graphql/client/http"
 
+# Absolutely zero clue if the code in this file is written as per standard but first let it work
 module Dependabot
   module Vulnerabilities
     class Fetcher
@@ -27,6 +28,7 @@ module Dependabot
         @http_adapter = CustomHttp.new(GITHUB_GQL_API_ENDPOINT, github_token)
 
         # Fetch latest schema on init, this will make a network request
+        puts "Fetching GitHub's GraphQL schema (should only happen once per run)"
         @schema = GraphQL::Client.load_schema(@http_adapter)
 
         # Parse the query that will be used

--- a/script/vulnerabilities.rb
+++ b/script/vulnerabilities.rb
@@ -4,13 +4,11 @@ require "graphql/client/http"
 module Dependabot
   module Vulnerabilities
     class Fetcher
-      include Graphql
-
       class QueryError < StandardError; end
 
       GITHUB_GQL_API_ENDPOINT = "https://api.github.com/graphql"
 
-      PACKAGE_MANAGER_LOOKUP = { # [Hash<String, String>]
+      ECOSYSTEM_LOOKUP = { # [Hash<String, String>]
         "github_actions" => "ACTIONS",
         "composer" => "COMPOSER",
         "elm" => "ERLANG",
@@ -25,19 +23,8 @@ module Dependabot
       }.freeze
 
       def initialize(package_manager, github_token)
-        @ecosystem = PACKAGE_MANAGER_LOOKUP.fetch(package_manager, nil)
-        @github_token = github_token
-
-        # Configure GraphQL endpoint using the basic HTTP network adapter.
-        @http_adapter = GraphQL::Client::HTTP.new(GITHUB_GQL_API_ENDPOINT) do
-            def headers(_context)
-                { "Authorization" => "Bearer #{@github_token}" }
-                # {
-                #   "Authorization" => "Bearer #{@github_token}",
-                #   "User-Agent": "dependabot-azure-devops/1.0"
-                # }
-            end
-        end
+        @ecosystem = ECOSYSTEM_LOOKUP.fetch(package_manager, nil)
+        @http_adapter = CustomHttp.new(GITHUB_GQL_API_ENDPOINT, github_token)
 
         # Fetch latest schema on init, this will make a network request
         @schema = GraphQL::Client.load_schema(@http_adapter)
@@ -45,13 +32,10 @@ module Dependabot
         # Parse the query that will be used
         @parsed_query = client.parse <<~GRAPHQL
           query($ecosystem: SecurityAdvisoryEcosystem, $package: String) {
-            securityVulnerabilities(ecosystem: $ecosystem, package: $package) {
+            securityVulnerabilities(first: 100, ecosystem: $ecosystem, package: $package) {
               nodes {
                 firstPatchedVersion {
                   identifier
-                }
-                package {
-                  name
                 }
                 vulnerableVersionRange
               }
@@ -59,12 +43,14 @@ module Dependabot
           }
           GRAPHQL
 
+        client.allow_dynamic_queries = true
+
       end
 
       def fetch(dependency_name)
         [] unless @ecosystem
 
-        variables = { ecosystem: @ecosystem, package: dependency_name }.compact_blank
+        variables = { ecosystem: @ecosystem, package: dependency_name }#.compact_blank
         response = client.query(@parsed_query, variables: variables)
         raise(QueryError, response.errors[:data].join(", ")) if response.errors.any?
 
@@ -75,6 +61,21 @@ module Dependabot
 
       def client
         @client ||= GraphQL::Client.new(schema: @schema, execute: @http_adapter)
+      end
+
+      class CustomHttp < GraphQL::Client::HTTP
+        def initialize(uri, token)
+          super(uri)
+          @token = token
+        end
+
+        def headers(context)
+          # { "Authorization" => "Bearer #{@token}" }
+          {
+            "Authorization" => "Bearer #{@token}",
+            "User-Agent" => "dependabot-azure-devops/1.0"
+          }
+        end
       end
 
     end


### PR DESCRIPTION
This is a continuation of #430 but now introduces support for querying vulnerabilities from the GraphQL endpoint just for the given ecosystem and package hence smaller payload bodies and no longer need to maintain local data. No additional setup is required except for a GitHub access token with `public_repo` scope.

The query:
```graphql
query($ecosystem: SecurityAdvisoryEcosystem, $package: String) {
  securityVulnerabilities(first: 100, ecosystem: $ecosystem, package: $package) {
    nodes {
      firstPatchedVersion {
        identifier
      }
      vulnerableVersionRange
    }
  }
}
```

Example variables:
```json
{ "ecosystem": "NUGET", "package": "Newtonsoft.Json" }
```

Example response:

```json
{
  "data": {
    "securityVulnerabilities": {
      "nodes": [
        {
          "firstPatchedVersion": {
            "identifier": "13.0.1"
          },
          "vulnerableVersionRange": "< 13.0.1"
        }
      ]
    }
  }
}
```

---

Fixes: #161
Fixes: #325
Fixes: #360
