### PR TITLE
Fix logic for passing open PRs limit

### DIFF
--- a/extension/task/IDependabotConfig.ts
+++ b/extension/task/IDependabotConfig.ts
@@ -60,7 +60,7 @@ export interface IDependabotUpdate {
   /**
    * 	Limit number of open pull requests for version updates.
    */
-  openPullRequestLimit?: number;
+  openPullRequestsLimit?: number;
   /**
    * Branch to create pull requests against.
    */

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -72,8 +72,8 @@ async function run() {
         dockerRunner.arg(["-e", `DEPENDABOT_VERSIONING_STRATEGY=${update.versioningStrategy}`]);
       }
       // Set the open pull requests limit
-      if (update.openPullRequestLimit) {
-        dockerRunner.arg(["-e", `DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=${update.openPullRequestLimit}`]);
+      if (update.openPullRequestsLimit) {
+        dockerRunner.arg(["-e", `DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=${update.openPullRequestsLimit}`]);
       }
 
       // Set the milestone, if provided

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -56,6 +56,7 @@ async function run() {
        * Set env variables in the runner for Dependabot
        */
       dockerRunner.arg(["-e", `DEPENDABOT_PACKAGE_MANAGER=${update.packageEcosystem}`]);
+      dockerRunner.arg(["-e", `DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=${update.openPullRequestsLimit}`]); // always has a value
 
       // Set the directory
       if (update.directory) {
@@ -70,10 +71,6 @@ async function run() {
       // Set the versioning strategy
       if (update.versioningStrategy) {
         dockerRunner.arg(["-e", `DEPENDABOT_VERSIONING_STRATEGY=${update.versioningStrategy}`]);
-      }
-      // Set the open pull requests limit
-      if (update.openPullRequestsLimit) {
-        dockerRunner.arg(["-e", `DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT=${update.openPullRequestsLimit}`]);
       }
 
       // Set the milestone, if provided

--- a/extension/task/utils/getConfigFromInputs.ts
+++ b/extension/task/utils/getConfigFromInputs.ts
@@ -16,7 +16,7 @@ export default function getConfigFromInputs(): IDependabotConfig {
       packageEcosystem: getInput("packageManager", true),
       directory: getInput("directory", false),
 
-      openPullRequestLimit: parseInt(getInput("openPullRequestsLimit", true)),
+      openPullRequestsLimit: parseInt(getInput("openPullRequestsLimit", true)),
 
       targetBranch: getInput("targetBranch", false),
       versioningStrategy: getInput("versioningStrategy", true),

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -93,7 +93,7 @@ function parseUpdates(config: any): IDependabotUpdate[] {
       packageEcosystem: update["package-ecosystem"],
       directory: update["directory"],
 
-      openPullRequestsLimit: update["open-pull-requests-limit"] || 5,
+      openPullRequestsLimit: update["open-pull-requests-limit"],
 
       targetBranch: update["target-branch"],
       versioningStrategy: update["versioning-strategy"],
@@ -111,6 +111,12 @@ function parseUpdates(config: any): IDependabotUpdate[] {
     if (!dependabotUpdate.packageEcosystem) {
       throw new Error(
         "The value 'package-ecosystem' in dependency update config is missing"
+      );
+    }
+
+    if (!dependabotUpdate.openPullRequestsLimit) {
+      throw new Error(
+        "The value 'open-pull-requests-limit' in dependency update config is missing"
       );
     }
 

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -93,7 +93,7 @@ function parseUpdates(config: any): IDependabotUpdate[] {
       packageEcosystem: update["package-ecosystem"],
       directory: update["directory"],
 
-      openPullRequestLimit: update["open-pull-requests-limit"] || 5,
+      openPullRequestsLimit: update["open-pull-requests-limit"] || 5,
 
       targetBranch: update["target-branch"],
       versioningStrategy: update["versioning-strategy"],


### PR DESCRIPTION
Make changes to handling limits for open PRs:
- `DEPENDABOT_OPEN_PULL_REQUESTS_LIMIT` always has a value and hence should always be passed from the task to the container.
- Parsed value for `open-pull-requests-limit` should be validated and not default to `5`.
