### PR TITLE
Standardize API version for REST API

### DIFF
--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -53,7 +53,7 @@ module Dependabot
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +
                     "/pullrequests/" + "#{pull_request_id}" +
-                    "/commits")
+                    "/commits?api-version=6.0")
 
                 JSON.parse(response.body).fetch("value")
             end

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -11,7 +11,7 @@ module Dependabot
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +
                     "/pullrequests?api-version=6.0&searchCriteria.status=active" \
-                    "&searchCriteria.targetRefName=refs/heads/" + default_branch)
+                    "&searchCriteria.targetRefName=refs/heads/#{default_branch}")
 
                 JSON.parse(response.body).fetch("value")
             end
@@ -52,8 +52,7 @@ module Dependabot
                 response = get(source.api_endpoint +
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +
-                    "/pullrequests/" + "#{pull_request_id}" +
-                    "/commits?api-version=6.0")
+                    "/pullrequests/#{pull_request_id}/commits?api-version=6.0")
 
                 JSON.parse(response.body).fetch("value")
             end
@@ -80,7 +79,9 @@ module Dependabot
 
             def pull_request_approve(pull_request_id, reviewer_email, reviewer_token)
                 # https://learn.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user-entitlements/search-user-entitlements?view=azure-devops-rest-6.0
-                response = get("https://vsaex.dev.azure.com/" + source.organization + "/_apis/userentitlements?$filter=name eq '#{reviewer_email}'&api-version=6.0-preview.3")
+                response = get("https://vsaex.dev.azure.com/" +
+                     source.organization +
+                     "/_apis/userentitlements?$filter=name eq '#{reviewer_email}'&api-version=6.0-preview.3")
 
                 user_id = JSON.parse(response.body).fetch("members")[0]['id']
 
@@ -91,9 +92,10 @@ module Dependabot
                 }
 
                 response = put_with_token(source.api_endpoint +
-                    source.organization + "/" + source.project +
-                    "/_apis/git/repositories/" + source.unscoped_repo +
-                    "/pullrequests/#{pull_request_id}/reviewers/#{user_id}?api-version=6.0", content.to_json, reviewer_token)
+                      source.organization + "/" + source.project +
+                      "/_apis/git/repositories/" + source.unscoped_repo +
+                      "/pullrequests/#{pull_request_id}/reviewers/#{user_id}?api-version=6.0",
+                    content.to_json, reviewer_token)
             end
 
             def put_with_token(url, json, token)

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -10,7 +10,7 @@ module Dependabot
                 response = get(source.api_endpoint +
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +
-                    "/pullrequests?searchCriteria.status=active" \
+                    "/pullrequests?api-version=6.0&searchCriteria.status=active" \
                     "&searchCriteria.targetRefName=refs/heads/" + default_branch)
 
                 JSON.parse(response.body).fetch("value")

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -24,7 +24,7 @@ module Dependabot
                 response = patch(source.api_endpoint +
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +
-                    "/pullrequests/#{pull_request_id}?api-version=5.0", content.to_json)
+                    "/pullrequests/#{pull_request_id}?api-version=6.0", content.to_json)
             end
 
             def branch_delete(name)
@@ -45,7 +45,7 @@ module Dependabot
                 response = post(source.api_endpoint +
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +
-                    "/refs?api-version=5.0", content.to_json)
+                    "/refs?api-version=6.0", content.to_json)
             end
 
             def pull_request_commits(pull_request_id)


### PR DESCRIPTION
Use version 6.0 of the REST API for all requests outside of `dependabot-core`.