### PR TITLE
Limit fetched pull requests to those for the current user (token owner)

### DIFF
--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -77,15 +77,17 @@ module Dependabot
                     "/pullrequests/#{pull_request_id}?api-version=6.0", content.to_json)
             end
 
-            def get_user_id_for_token(token)
+            def get_user_id(token = nil)
               # https://learn.microsoft.com/en-us/javascript/api/azure-devops-extension-api/connectiondata
               # https://stackoverflow.com/a/53227325
-              response = get_with_token(source.api_endpoint + source.organization + "/_apis/connectionData", token)
+              response = token ?
+                   get_with_token(source.api_endpoint + source.organization + "/_apis/connectionData", token) :
+                   get(source.api_endpoint + source.organization + "/_apis/connectionData")
               JSON.parse(response.body).fetch("authenticatedUser")['id']
             end
 
             def pull_request_approve(pull_request_id, reviewer_token)
-                user_id = get_user_id_for_token(token)
+                user_id = get_user_id(token)
 
                 # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-reviewers/create-pull-request-reviewers?view=azure-devops-rest-6.0
                 content = {

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -6,11 +6,12 @@ module Dependabot
     module Clients
         class Azure
 
-            def pull_requests_active(default_branch)
+            def pull_requests_active(user_id, default_branch)
                 response = get(source.api_endpoint +
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +
                     "/pullrequests?api-version=6.0&searchCriteria.status=active" \
+                    "&searchCriteria.creatorId=#{user_id}" \
                     "&searchCriteria.targetRefName=refs/heads/#{default_branch}")
 
                 JSON.parse(response.body).fetch("value")

--- a/script/azure_helpers.rb
+++ b/script/azure_helpers.rb
@@ -7,6 +7,7 @@ module Dependabot
         class Azure
 
             def pull_requests_active(user_id, default_branch)
+              # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/get-pull-requests?view=azure-devops-rest-6.0&tabs=HTTP
                 response = get(source.api_endpoint +
                     source.organization + "/" + source.project +
                     "/_apis/git/repositories/" + source.unscoped_repo +

--- a/script/update-script.rb
+++ b/script/update-script.rb
@@ -465,8 +465,9 @@ azure_client = Dependabot::Clients::Azure.for_source(
   source: $source,
   credentials: $options[:credentials],
 )
+user_id = azure_client.get_user_id
 default_branch_name = azure_client.fetch_default_branch($source.repo)
-active_pull_requests = azure_client.pull_requests_active(default_branch_name)
+active_pull_requests = azure_client.pull_requests_active(user_id, default_branch_name)
 
 pull_requests_count = 0
 


### PR DESCRIPTION
When fetching active pull requests, filter by those created by the current user (owner of the access token). The identifier of the current token is fetched from the `connectionData` API added in #441 .