### PR TITLE
Cloning and vendor support

### DIFF
--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -55,6 +55,11 @@ async function run() {
         dockerRunner.arg(["-e", `DEPENDABOT_TARGET_BRANCH=${update.targetBranch}`]);
       }
 
+      // Set vendored if true
+      if (update.vendor === true) {
+        dockerRunner.arg(["-e", 'DEPENDABOT_VENDOR=true']);
+      }
+
       // Set the versioning strategy
       if (update.versioningStrategy) {
         dockerRunner.arg(["-e", `DEPENDABOT_VERSIONING_STRATEGY=${update.versioningStrategy}`]);

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -161,6 +161,7 @@ function parseUpdates(config: any): IDependabotUpdate[] {
       openPullRequestsLimit: update["open-pull-requests-limit"],
 
       targetBranch: update["target-branch"],
+      vendor: update["vendor"] ? JSON.parse(update["vendor"]) : null,
       versioningStrategy: update["versioning-strategy"],
       milestone: update["milestone"],
       branchNameSeparator: update["pull-request-branch-name"]


### PR DESCRIPTION
Added support for cloning and `vendor` in config. Without cloning some ecosystems like `terraform` and `npm_and_yarn` may fail in the file update process.

Fixes: #459 