### PR TITLE
Filter out nil/blank and empty values in security advisories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ dist
 *.log
 .idea
 .DS_Store
+
+# local caching
+script/tmp
+*git.store


### PR DESCRIPTION
Filter out nil (blank objects) and empty strings which is necessary for situations where the GitHub API response contains null that is converted to nil, or it is an empty string.

For example, npm package named `faker` does not have a patched version as of today; see https://github.com/advisories/GHSA-5w9c-rv96-fr7g