### PR TITLE
Support selecting update identifiers

### DIFF
--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -1,6 +1,6 @@
 import * as tl from "azure-pipelines-task-lib/task"
 import { ToolRunner } from "azure-pipelines-task-lib/toolrunner"
-import { IDependabotConfig } from "./IDependabotConfig";
+import { IDependabotConfig, IDependabotUpdate } from "./IDependabotConfig";
 import getSharedVariables from "./utils/getSharedVariables";
 import parseConfigFile from "./utils/parseConfigFile";
 
@@ -24,10 +24,22 @@ async function run() {
     // prepare the shared variables
     const variables = getSharedVariables();
 
-    var config = await parseConfigFile(variables);
+    // parse the configuration file
+    const config = await parseConfigFile(variables);
+
+    // if update identifiers are specified, select then otherwise handle all
+    var updates: IDependabotUpdate[] = [];
+    const targetIds = variables.targetUpdateIds;
+    if (targetIds && targetIds.length > 0) {
+      for (const id of targetIds) {
+        updates.push(config.updates[id])
+      }
+    } else {
+      updates = config.updates;
+    }
 
     // For each update run docker container
-    for (const update of config.updates) {
+    for (const update of updates) {
       // Prepare the docker task
       let dockerRunner: ToolRunner = tl.tool(tl.which("docker", true));
       dockerRunner.arg(["run"]); // run command

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -172,7 +172,16 @@
       "groupName": "advanced",
       "label": "Target Repository Name",
       "required": false,
-      "helpMarkDown": "The name of the repository to target for processing. If this value is not supplied then the Build Repository Name is used. Supplying this value allows creation of a single pipeline that runs Dependablot against multiple repositories."
+      "helpMarkDown": "The name of the repository to target for processing. If this value is not supplied then the Build Repository Name is used. Supplying this value allows creation of a single pipeline that runs Dependabot against multiple repositories."
+    },
+    {
+      "name": "targetUpdateIds",
+      "type": "string",
+      "groupName": "advanced",
+      "label": "Semicolon delimited list of update identifiers to run.",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "A semicolon (`;`) delimited list of update identifiers run. Index are zero-based and in the order written in the configuration file. When not present, all the updates are run. This is meant to be used in scenarios where you want to run updates a different times from teh same configuration file given you cannot schedule them independently in the pipeline."
     },
     {
       "name": "updaterOptions",

--- a/extension/task/utils/getSharedVariables.ts
+++ b/extension/task/utils/getSharedVariables.ts
@@ -54,6 +54,9 @@ export interface ISharedVariables {
   /** override value for allow */
   allowOvr: string; // TODO: remove this in 0.16.0
 
+  /** List of update identifiers to run */
+  targetUpdateIds: number[];
+
   securityAdvisoriesFile: string | undefined;
   /** Determines whether to skip creating/updating pull requests */
   skipPullRequests: boolean;
@@ -126,6 +129,11 @@ export default function getSharedVariables(): ISharedVariables {
   // Get the override values for allow, and ignore
   let allowOvr = tl.getVariable("DEPENDABOT_ALLOW_CONDITIONS");
 
+  // Get the target identifiers
+  let targetUpdateIds = tl
+    .getDelimitedInput("targetUpdateIds", ";", false)
+    .map(Number);
+
   // Prepare other variables
   let securityAdvisoriesFile: string | undefined = tl.getInput(
     "securityAdvisoriesFile"
@@ -181,6 +189,7 @@ export default function getSharedVariables(): ISharedVariables {
 
     allowOvr,
 
+    targetUpdateIds,
     securityAdvisoriesFile,
     skipPullRequests,
     abandonUnwantedPullRequests,


### PR DESCRIPTION
Allow selection of which updates to run based on their index in the configuration file.

Sample pipeline:

```yml
steps:
- task: dependabot@1
  inputs:
    targetUpdateIds: '0;2'  # managed by team 1
```

Sample configuration file:

```yml
version: 2
updates:
- ecosystem: nuget
  directory: /service1 # managed by team 1
- ecosystem: nuget
  directory: /service2 # managed by team 2
- ecosystem: nuget
  directory: /service3 # managed by team 1
```