### PR TITLE
Switch Vulnerabilities Fetcher to use Octokit

### DIFF
--- a/script/Gemfile
+++ b/script/Gemfile
@@ -3,4 +3,3 @@
 source "https://rubygems.org"
 
 gem "dependabot-omnibus", "~> 0.215.0"
-gem "graphql-client", "~> 0.18.0"

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -108,10 +108,6 @@ GEM
     gitlab (4.19.0)
       httparty (~> 0.20)
       terminal-table (>= 1.5.1)
-    graphql (2.0.15)
-    graphql-client (0.18.0)
-      activesupport (>= 3.0)
-      graphql
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -165,7 +161,6 @@ PLATFORMS
 
 DEPENDENCIES
   dependabot-omnibus (~> 0.215.0)
-  graphql-client (~> 0.18.0)
 
 BUNDLED WITH
    2.3.26

--- a/script/vulnerabilities.rb
+++ b/script/vulnerabilities.rb
@@ -47,7 +47,7 @@ module Dependabot
         vulnerabilities = []
         response.data[:securityVulnerabilities][:nodes].map do | node |
           vulnerable_version_range = node[:vulnerableVersionRange]
-          first_patched_version = node[:firstPatchedVersion] && node[:firstPatchedVersion][:identifier]
+          first_patched_version = node.dig :firstPatchedVersion, :identifier
           vulnerabilities << {
             "dependency-name" => dependency_name,
             "affected-versions" => [vulnerable_version_range],


### PR DESCRIPTION
Switch Vulnerabilities Fetcher to use Octokit hence no longer need `graphql-client`