### PR TITLE
Switch dependabot-omnibus gem to be installed from git source

### DIFF
--- a/script/Gemfile
+++ b/script/Gemfile
@@ -2,4 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "dependabot-omnibus", "~> 0.215.0"
+# The tagged versions are currently slow (sometimes it takes months)
+# We temporarily switch to getting the gem from git.
+# When the changes to this repository are no longer many/major,
+# we can switch back to using the tagged versions.
+
+# gem "dependabot-omnibus", "~> 0.215.0"
+gem 'dependabot-omnibus', github: 'dependabot/dependabot-core', ref: '25f4de8'

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -1,32 +1,8 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/dependabot/dependabot-core.git
+  revision: 25f4de8b6d429566d1167baace6322aa071203f1
+  ref: 25f4de8
   specs:
-    activesupport (7.0.4)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.1)
-      public_suffix (>= 2.0.2, < 6.0)
-    ast (2.4.2)
-    aws-eventstream (1.2.0)
-    aws-partitions (1.674.0)
-    aws-sdk-codecommit (1.52.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.168.4)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.5)
-      jmespath (~> 1, >= 1.6.1)
-    aws-sdk-ecr (1.57.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
-      aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.5.2)
-      aws-eventstream (~> 1, >= 1.0.2)
-    citrus (3.0.2)
-    commonmarker (0.23.6)
-    concurrent-ruby (1.1.10)
     dependabot-bundler (0.215.0)
       dependabot-common (= 0.215.0)
     dependabot-cargo (0.215.0)
@@ -94,7 +70,37 @@ GEM
       dependabot-common (= 0.215.0)
     dependabot-terraform (0.215.0)
       dependabot-common (= 0.215.0)
-    docker_registry2 (1.12.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.701.0)
+    aws-sdk-codecommit (1.53.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.170.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-ecr (1.58.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+    citrus (3.0.2)
+    commonmarker (0.23.7)
+    concurrent-ruby (1.2.0)
+    docker_registry2 (1.13.0)
       rest-client (>= 1.8.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -111,8 +117,8 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
-    httparty (0.20.0)
-      mime-types (~> 3.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -120,21 +126,22 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    minitest (5.16.3)
+    mini_mime (1.1.2)
+    minitest (5.17.0)
     multi_xml (0.6.0)
     netrc (0.11.0)
-    nokogiri (1.13.10-arm64-darwin)
+    nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     octokit (6.0.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     parseconfig (1.0.8)
-    parser (3.1.3.0)
+    parser (3.2.0.0)
       ast (~> 2.4.1)
     public_suffix (5.0.1)
-    racc (1.6.1)
+    racc (1.6.2)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -148,19 +155,19 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     toml-rb (2.2.0)
       citrus (~> 3.0, > 3.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (2.3.0)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
-  dependabot-omnibus (~> 0.215.0)
+  dependabot-omnibus!
 
 BUNDLED WITH
    2.3.26


### PR DESCRIPTION
Given that tagged releases of `dependabot-omnibus` are currently slow, this PR is switching to getting the gem directly from git so that we can get more recent changes in here.

This should help in testing #366 