### PR TITLE
Source from submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,12 @@ updates:
     interval: "weekly"
     time: "04:00"
   open-pull-requests-limit: 10
+- package-ecosystem: "gitsubmodule" # See documentation for possible values
+  directory: "/script" # Location of package manifests
+  schedule:
+    interval: "weekly"
+    time: "04:00"
+  open-pull-requests-limit: 10
 - package-ecosystem: "npm" # See documentation for possible values
   directory: "/extension" # Location of package manifests
   schedule:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0 # Required for GitVersion
+        submodules: true
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "script/dependabot-core"]
+	path = script/dependabot-core
+	url = https://github.com/dependabot/dependabot-core.git

--- a/script/Dockerfile
+++ b/script/Dockerfile
@@ -12,6 +12,9 @@ RUN mkdir -p ${CODE_DIR}
 COPY --chown=dependabot:dependabot Gemfile Gemfile.lock ${CODE_DIR}/
 WORKDIR ${CODE_DIR}
 
+# Copy core logic
+COPY dependabot-core dependabot-core/
+
 # Install dependencies
 RUN bundle config set --local path "vendor" \
   && bundle install --jobs 4 --retry 3

--- a/script/Gemfile
+++ b/script/Gemfile
@@ -2,10 +2,20 @@
 
 source "https://rubygems.org"
 
-# The tagged versions are currently slow (sometimes it takes months)
-# We temporarily switch to getting the gem from git.
-# When the changes to this repository are no longer many/major,
-# we can switch back to using the tagged versions.
-
-# gem "dependabot-omnibus", "~> 0.215.0"
-gem 'dependabot-omnibus', github: 'dependabot/dependabot-core', ref: '05d11aa'
+gem "dependabot-bundler", path: "dependabot-core/bundler"
+gem "dependabot-cargo", path: "dependabot-core/cargo"
+gem "dependabot-common", path: "dependabot-core/common"
+gem "dependabot-composer", path: "dependabot-core/composer"
+gem "dependabot-docker", path: "dependabot-core/docker"
+gem "dependabot-elm", path: "dependabot-core/elm"
+gem "dependabot-github_actions", path: "dependabot-core/github_actions"
+gem "dependabot-git_submodules", path: "dependabot-core/git_submodules"
+gem "dependabot-go_modules", path: "dependabot-core/go_modules"
+gem "dependabot-gradle", path: "dependabot-core/gradle"
+gem "dependabot-hex", path: "dependabot-core/hex"
+gem "dependabot-maven", path: "dependabot-core/maven"
+gem "dependabot-npm_and_yarn", path: "dependabot-core/npm_and_yarn"
+gem "dependabot-nuget", path: "dependabot-core/nuget"
+gem "dependabot-pub", path: "dependabot-core/pub"
+gem "dependabot-python", path: "dependabot-core/python"
+gem "dependabot-terraform", path: "dependabot-core/terraform"

--- a/script/Gemfile.lock
+++ b/script/Gemfile.lock
@@ -1,12 +1,18 @@
-GIT
-  remote: https://github.com/dependabot/dependabot-core.git
-  revision: 05d11aa4cf521b92c377dc34682483ab20f02de4
-  ref: 05d11aa
+PATH
+  remote: dependabot-core/bundler
   specs:
     dependabot-bundler (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/cargo
+  specs:
     dependabot-cargo (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/common
+  specs:
     dependabot-common (0.215.0)
       activesupport (>= 6.0.0)
       aws-sdk-codecommit (~> 1.28)
@@ -22,52 +28,90 @@ GIT
       octokit (>= 4.6, < 7.0)
       parser (>= 2.5, < 4.0)
       toml-rb (>= 1.1.2, < 3.0)
+
+PATH
+  remote: dependabot-core/composer
+  specs:
     dependabot-composer (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/docker
+  specs:
     dependabot-docker (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/elm
+  specs:
     dependabot-elm (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/git_submodules
+  specs:
     dependabot-git_submodules (0.215.0)
       dependabot-common (= 0.215.0)
       parseconfig (~> 1.0, < 1.1.0)
+
+PATH
+  remote: dependabot-core/github_actions
+  specs:
     dependabot-github_actions (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/go_modules
+  specs:
     dependabot-go_modules (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/gradle
+  specs:
     dependabot-gradle (0.215.0)
       dependabot-common (= 0.215.0)
       dependabot-maven (= 0.215.0)
+
+PATH
+  remote: dependabot-core/hex
+  specs:
     dependabot-hex (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/maven
+  specs:
     dependabot-maven (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/npm_and_yarn
+  specs:
     dependabot-npm_and_yarn (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/nuget
+  specs:
     dependabot-nuget (0.215.0)
       dependabot-common (= 0.215.0)
-    dependabot-omnibus (0.215.0)
-      dependabot-bundler (= 0.215.0)
-      dependabot-cargo (= 0.215.0)
-      dependabot-common (= 0.215.0)
-      dependabot-composer (= 0.215.0)
-      dependabot-docker (= 0.215.0)
-      dependabot-elm (= 0.215.0)
-      dependabot-git_submodules (= 0.215.0)
-      dependabot-github_actions (= 0.215.0)
-      dependabot-go_modules (= 0.215.0)
-      dependabot-gradle (= 0.215.0)
-      dependabot-hex (= 0.215.0)
-      dependabot-maven (= 0.215.0)
-      dependabot-npm_and_yarn (= 0.215.0)
-      dependabot-nuget (= 0.215.0)
-      dependabot-pub (= 0.215.0)
-      dependabot-python (= 0.215.0)
-      dependabot-terraform (= 0.215.0)
+
+PATH
+  remote: dependabot-core/pub
+  specs:
     dependabot-pub (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/python
+  specs:
     dependabot-python (0.215.0)
       dependabot-common (= 0.215.0)
+
+PATH
+  remote: dependabot-core/terraform
+  specs:
     dependabot-terraform (0.215.0)
       dependabot-common (= 0.215.0)
 
@@ -83,7 +127,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.701.0)
+    aws-partitions (1.705.0)
     aws-sdk-codecommit (1.53.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
@@ -98,7 +142,7 @@ GEM
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
     citrus (3.0.2)
-    commonmarker (0.23.7)
+    commonmarker (0.23.8)
     concurrent-ruby (1.2.0)
     docker_registry2 (1.13.0)
       rest-client (>= 1.8.0)
@@ -130,9 +174,9 @@ GEM
     minitest (5.17.0)
     multi_xml (0.6.0)
     netrc (0.11.0)
-    nokogiri (1.14.0-arm64-darwin)
+    nokogiri (1.14.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-linux)
+    nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     octokit (6.0.1)
       faraday (>= 1, < 3)
@@ -167,7 +211,23 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  dependabot-omnibus!
+  dependabot-bundler!
+  dependabot-cargo!
+  dependabot-common!
+  dependabot-composer!
+  dependabot-docker!
+  dependabot-elm!
+  dependabot-git_submodules!
+  dependabot-github_actions!
+  dependabot-go_modules!
+  dependabot-gradle!
+  dependabot-hex!
+  dependabot-maven!
+  dependabot-npm_and_yarn!
+  dependabot-nuget!
+  dependabot-pub!
+  dependabot-python!
+  dependabot-terraform!
 
 BUNDLED WITH
    2.3.26


### PR DESCRIPTION
As a followup to #490, this PR adds a git-submodule to https://github.com/dependabot/dependabot-core hence allowing for weekly updates to actually work. Sourcing gems vis git seems to not work as envisioned.