### PR TITLE
Push to GitHub Container Registry alongside Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ jobs:
 
     env:
       IMAGE_NAME: 'dependabot-azure-devops'
+      IMAGE_NAME_GHCR: 'dependabot-updater'
       DOCKER_BUILDKIT: 1 # Enable Docker BuildKit
       # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/updater/Gemfile
@@ -72,6 +73,10 @@ jobs:
         -t "tingle/$IMAGE_NAME:$GITVERSION_FULLSEMVER" \
         -t "tingle/$IMAGE_NAME:$GITVERSION_MAJOR.$GITVERSION_MINOR" \
         -t "tingle/$IMAGE_NAME:$GITVERSION_MAJOR" \
+        -t "tingle/$IMAGE_NAME_GHCR:latest" \
+        -t "tingle/$IMAGE_NAME_GHCR:$GITVERSION_FULLSEMVER" \
+        -t "tingle/$IMAGE_NAME_GHCR:$GITVERSION_MAJOR.$GITVERSION_MINOR" \
+        -t "tingle/$IMAGE_NAME_GHCR:$GITVERSION_MAJOR" \
         --cache-from tingle/$IMAGE_NAME:latest \
         --build-arg BUILDKIT_INLINE_CACHE=1 \
         .
@@ -80,16 +85,34 @@ jobs:
       if: ${{ (github.ref == 'refs/heads/main') || (!startsWith(github.ref, 'refs/pull')) || startsWith(github.ref, 'refs/tags') }}
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
+    - name: Log into registry (GHCR)
+      if: ${{ (github.ref == 'refs/heads/main') || (!startsWith(github.ref, 'refs/pull')) || startsWith(github.ref, 'refs/tags') }}
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
     - name: Push image to Docker Hub (latest)
       if: github.ref == 'refs/heads/main'
       run: docker push "tingle/$IMAGE_NAME:latest"
 
+    - name: Push image to GHCR (latest)
+      if: github.ref == 'refs/heads/main'
+      run: docker push "ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME_GHCR:latest"
+
     - name: Push image to Docker Hub (FullSemVer)
       if: "!startsWith(github.ref, 'refs/pull')"
       run: docker push "tingle/$IMAGE_NAME:$GITVERSION_FULLSEMVER"
+
+    - name: Push image to GHCR (FullSemVer)
+      if: "!startsWith(github.ref, 'refs/pull')"
+      run: docker push "ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME_GHCR:$GITVERSION_FULLSEMVER"
 
     - name: Push image to Docker Hub (major, minor)
       if: startsWith(github.ref, 'refs/tags')
       run: |
         docker push "tingle/$IMAGE_NAME:$GITVERSION_MAJOR.$GITVERSION_MINOR"
         docker push "tingle/$IMAGE_NAME:$GITVERSION_MAJOR"
+
+    - name: Push image to GHCR (major, minor)
+      if: startsWith(github.ref, 'refs/tags')
+      run: |
+        docker push "ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME_GHCR:$GITVERSION_MAJOR.$GITVERSION_MINOR"
+        docker push "ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME_GHCR:$GITVERSION_MAJOR"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This repository contains tools for updating dependencies in Azure DevOps reposit
 
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/tinglesoftware/dependabot-azure-devops/docker.yml?branch=main&style=flat-square)
 [![Release](https://img.shields.io/github/release/tinglesoftware/dependabot-azure-devops.svg?style=flat-square)](https://github.com/tinglesoftware/dependabot-azure-devops/releases/latest)
-[![Docker Image](https://img.shields.io/docker/image-size/tingle/dependabot-azure-devops/latest?style=flat-square)](https://hub.docker.com/r/tingle/dependabot-azure-devops)
-[![Docker Pulls](https://img.shields.io/docker/pulls/tingle/dependabot-azure-devops?style=flat-square)](https://hub.docker.com/r/tingle/dependabot-azure-devops)
 [![license](https://img.shields.io/github/license/tinglesoftware/dependabot-azure-devops.svg?style=flat-square)](LICENSE)
 
 In this repository you'll find:

--- a/cronjob-template.yaml
+++ b/cronjob-template.yaml
@@ -36,7 +36,7 @@ spec:
           activeDeadlineSeconds: 3600
           containers:
           - name: dependabot
-            image: 'tingle/dependabot-azure-devops:0.10' # Use a specific tag otherwise the image may be cached already
+            image: 'ghcr.io/tinglesoftware/dependabot-updater:0.10' # Use a specific tag otherwise the image may be cached already
             resources: {} # decide based on your usage
             env:
             - name: GITHUB_ACCESS_TOKEN

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -3,7 +3,7 @@
 First, you need to pull the image locally to your machine:
 
 ```bash
-docker pull tingle/dependabot-azure-devops:0.10
+docker pull ghcr.io/tinglesoftware/dependabot-updater:0.10
 ```
 
 Next create and run a container from the image:
@@ -32,7 +32,7 @@ docker run --rm -t \
            -e AZURE_SET_AUTO_COMPLETE=<true/false> \
            -e AZURE_AUTO_APPROVE_PR=<true/false> \
            -e AZURE_AUTO_APPROVE_USER_TOKEN=<approving-user-token-here> \
-           tingle/dependabot-azure-devops:0.10
+           ghcr.io/tinglesoftware/dependabot-updater:0.10
 ```
 
 An example, for Azure DevOps Services:
@@ -54,11 +54,11 @@ docker run --rm -t \
            -e AZURE_ACCESS_TOKEN=abcd..efgh \
            -e AZURE_ORGANIZATION=tinglesoftware \
            -e AZURE_PROJECT=oss \
-           -e AZURE_REPOSITORY=dependabot-azure-devops \
+           -e AZURE_REPOSITORY=repro-411 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
            -e AZURE_AUTO_APPROVE_USER_TOKEN=ijkl..mnop \
-           tingle/dependabot-azure-devops:0.10
+           ghcr.io/tinglesoftware/dependabot-updater:0.10
 ```
 
 An example, for Azure DevOps Server:
@@ -83,11 +83,11 @@ docker run --rm -t \
            -e AZURE_ACCESS_TOKEN=abcd..efgh \
            -e AZURE_ORGANIZATION=tinglesoftware \
            -e AZURE_PROJECT=oss \
-           -e AZURE_REPOSITORY=dependabot-azure-devops \
+           -e AZURE_REPOSITORY=repro-411 \
            -e AZURE_SET_AUTO_COMPLETE=true \
            -e AZURE_AUTO_APPROVE_PR=true \
            -e AZURE_AUTO_APPROVE_USER_TOKEN=ijkl..mnop \
-           tingle/dependabot-azure-devops:0.10
+           ghcr.io/tinglesoftware/dependabot-updater:0.10
 ```
 
 ## Environment Variables

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -218,8 +218,8 @@ async function run() {
         dockerRunner.arg(['--mount', `type=bind,source=/ssh-agent,target=/ssh-agent`]);
       }
 
-      // Form the docker image based on the repository and the tag, e.g. tingle/dependabot-azure-devops
-      // For custom/enterprise registries, prefix with the registry, e.g. contoso.azurecr.io/tingle/dependabot-azure-devops
+      // Form the docker image based on the repository and the tag, e.g. tinglesoftware/dependabot-updater
+      // For custom/enterprise registries, prefix with the registry, e.g. contoso.azurecr.io/tinglesoftware/dependabot-updater
       let dockerImage: string = `${variables.dockerImageRepository}:${variables.dockerImageTag}`;
       if (variables.dockerImageRegistry) {
         dockerImage = `${variables.dockerImageRegistry}/${dockerImage}`.replace("//", "/");

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -205,6 +205,7 @@
       "label": "Container registry override",
       "groupName": "advanced",
       "helpMarkDown": "The docker registry to use when pulling the docker container used by the task if needed. By default this will use docker hub. This can be useful if the container needs to come from an internal docker registry mirror or alternative source for testing. If the mirror requires authentication add a `docker login` task before this task. Example: `contoso.azurecr.io`",
+      "defaultValue": "ghcr.io",
       "required": false
     },
     {
@@ -212,7 +213,7 @@
       "label": "Docker Container repository",
       "type": "string",
       "helpMarkDown": "The docker container repository to use when pulling the docker container used by the task if needed. This can be useful if the default container requires customizations such as custom certs.",
-      "defaultValue": "tingle/dependabot-azure-devops",
+      "defaultValue": "tinglesoftware/dependabot-updater",
       "required": true,
       "groupName": "advanced"
     },


### PR DESCRIPTION
This PR adds support for pushing to GitHub Container Registry alongside Docker Hub due to limits in non-authenticated requests. The extension now defaults to using GitHub Container Registry.
