### PR TITLE
Replace git-submodule with gems via git

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,6 @@ updates:
     interval: "weekly"
     time: "04:00"
   open-pull-requests-limit: 10
-- package-ecosystem: "gitsubmodule" # See documentation for possible values
-  directory: "/" # Location of package manifests
-  schedule:
-    interval: "weekly"
-    time: "04:00"
-  open-pull-requests-limit: 10
 - package-ecosystem: "bundler" # See documentation for possible values
   directory: "/updater" # Location of package manifests
   schedule:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0 # Required for GitVersion
-        submodules: true
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "dependabot-core"]
-	shallow = true
-	path = dependabot-core
-	url = https://github.com/dependabot/dependabot-core.git

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,6 @@ require: rubocop-performance
 AllCops:
   DisplayCopNames: true
   Exclude:
-    - "dependabot-core/**/*"
     - "../*/bin/**/*" # TODO: remove this once files in bin have been distributed
     - "updater/tmp/**/*"
     - "updater/spec/fixtures/**/*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ENV DEPENDABOT_HOME /home/dependabot
 WORKDIR ${DEPENDABOT_HOME}
 
 COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock dependabot-updater/
-COPY --chown=dependabot:dependabot dependabot-core dependabot-core/
 
 WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
@@ -30,8 +29,6 @@ RUN bundle config set --local path 'vendor' && \
 # Add project
 COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
-
-WORKDIR $DEPENDABOT_HOME/dependabot-updater
 
 # This entrypoint exists to solve specific setup problems.
 # It is only used with the extension and directly on Docker.

--- a/updater/Gemfile
+++ b/updater/Gemfile
@@ -2,40 +2,31 @@
 
 source "https://rubygems.org"
 
-gem "dependabot-bundler", path: "../dependabot-core/bundler"
-gem "dependabot-cargo", path: "../dependabot-core/cargo"
-gem "dependabot-common", path: "../dependabot-core/common"
-gem "dependabot-composer", path: "../dependabot-core/composer"
-gem "dependabot-docker", path: "../dependabot-core/docker"
-gem "dependabot-elm", path: "../dependabot-core/elm"
-gem "dependabot-github_actions", path: "../dependabot-core/github_actions"
-gem "dependabot-git_submodules", path: "../dependabot-core/git_submodules"
-gem "dependabot-go_modules", path: "../dependabot-core/go_modules"
-gem "dependabot-gradle", path: "../dependabot-core/gradle"
-gem "dependabot-hex", path: "../dependabot-core/hex"
-gem "dependabot-maven", path: "../dependabot-core/maven"
-gem "dependabot-npm_and_yarn", path: "../dependabot-core/npm_and_yarn"
-gem "dependabot-nuget", path: "../dependabot-core/nuget"
-gem "dependabot-pub", path: "../dependabot-core/pub"
-gem "dependabot-python", path: "../dependabot-core/python"
-gem "dependabot-terraform", path: "../dependabot-core/terraform"
+git "https://github.com/dependabot/dependabot-core.git", :ref => "0672e3b" do
+  gem "dependabot-bundler"
+  gem "dependabot-cargo"
+  gem "dependabot-common"
+  gem "dependabot-composer"
+  gem "dependabot-docker"
+  gem "dependabot-elm"
+  gem "dependabot-github_actions"
+  gem "dependabot-git_submodules"
+  gem "dependabot-go_modules"
+  gem "dependabot-gradle"
+
+  gem "dependabot-hex"
+  gem "dependabot-maven"
+  gem "dependabot-npm_and_yarn"
+  gem "dependabot-nuget"
+  gem "dependabot-pub"
+  gem "dependabot-python"
+  gem "dependabot-terraform"
+end
 
 group :test do
-  common_gemspec = File.expand_path("../dependabot-core/common/dependabot-common.gemspec", __dir__)
-
-  deps_shared_with_core = %w(
-    rspec
-    rubocop
-    rubocop-performance
-    vcr
-    webmock
-  )
-
-  Dir.chdir(File.dirname(common_gemspec)) do
-    Gem::Specification.load(common_gemspec).development_dependencies.each do |dep|
-      next unless deps_shared_with_core.include?(dep.name)
-
-      gem dep.name, *dep.requirement.as_list
-    end
-  end
+  gem "rspec"
+  gem "rubocop"
+  gem "rubocop-performance"
+  gem "vcr"
+  gem "webmock"
 end

--- a/updater/Gemfile
+++ b/updater/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-git "https://github.com/dependabot/dependabot-core.git", :ref => "0672e3b" do
+git "https://github.com/dependabot/dependabot-core.git", ref: "0672e3b" do
   gem "dependabot-bundler"
   gem "dependabot-cargo"
   gem "dependabot-common"

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -1,18 +1,12 @@
-PATH
-  remote: ../dependabot-core/bundler
+GIT
+  remote: https://github.com/dependabot/dependabot-core.git
+  revision: 0672e3b867bb1959d3b57dd8f543f932cc1febf0
+  ref: 0672e3b
   specs:
     dependabot-bundler (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/cargo
-  specs:
     dependabot-cargo (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/common
-  specs:
     dependabot-common (0.215.0)
       aws-sdk-codecommit (~> 1.28)
       aws-sdk-ecr (~> 1.5)
@@ -27,90 +21,34 @@ PATH
       octokit (>= 4.6, < 7.0)
       parser (>= 2.5, < 4.0)
       toml-rb (>= 1.1.2, < 3.0)
-
-PATH
-  remote: ../dependabot-core/composer
-  specs:
     dependabot-composer (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/docker
-  specs:
     dependabot-docker (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/elm
-  specs:
     dependabot-elm (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/git_submodules
-  specs:
     dependabot-git_submodules (0.215.0)
       dependabot-common (= 0.215.0)
       parseconfig (~> 1.0, < 1.1.0)
-
-PATH
-  remote: ../dependabot-core/github_actions
-  specs:
     dependabot-github_actions (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/go_modules
-  specs:
     dependabot-go_modules (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/gradle
-  specs:
     dependabot-gradle (0.215.0)
       dependabot-common (= 0.215.0)
       dependabot-maven (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/hex
-  specs:
     dependabot-hex (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/maven
-  specs:
     dependabot-maven (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/npm_and_yarn
-  specs:
     dependabot-npm_and_yarn (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/nuget
-  specs:
     dependabot-nuget (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/pub
-  specs:
     dependabot-pub (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/python
-  specs:
     dependabot-python (0.215.0)
       dependabot-common (= 0.215.0)
-
-PATH
-  remote: ../dependabot-core/terraform
-  specs:
     dependabot-terraform (0.215.0)
       dependabot-common (= 0.215.0)
 
@@ -121,7 +59,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.705.0)
+    aws-partitions (1.715.0)
     aws-sdk-codecommit (1.53.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
@@ -144,7 +82,7 @@ GEM
       rest-client (>= 1.8.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    excon (0.98.0)
+    excon (0.99.0)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -165,25 +103,25 @@ GEM
     json (2.6.3)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     multi_xml (0.6.0)
     netrc (0.11.0)
-    nokogiri (1.14.1-arm64-darwin)
+    nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.1-x86_64-linux)
+    nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     octokit (6.0.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     parallel (1.22.1)
     parseconfig (1.0.8)
-    parser (3.2.0.0)
+    parser (3.2.1.0)
       ast (~> 2.4.1)
     public_suffix (5.0.1)
     racc (1.6.2)
     rainbow (3.1.1)
-    regexp_parser (2.6.2)
+    regexp_parser (2.7.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -203,18 +141,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.44.1)
+    rubocop (1.46.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.24.1, < 2.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.24.1)
-      parser (>= 3.1.1.0)
+    rubocop-ast (1.26.0)
+      parser (>= 3.2.1.0)
     rubocop-performance (1.16.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -259,11 +197,11 @@ DEPENDENCIES
   dependabot-pub!
   dependabot-python!
   dependabot-terraform!
-  rspec (~> 3.12)
-  rubocop (~> 1.44.0)
-  rubocop-performance (~> 1.16.0)
-  vcr (~> 6.1)
-  webmock (~> 3.18)
+  rspec
+  rubocop
+  rubocop-performance
+  vcr
+  webmock
 
 BUNDLED WITH
    2.3.26


### PR DESCRIPTION
Remove the dependabot-core git submodule, instead use gems via git. This removes the startup warnings and fixed build failures after updates.