### PR TITLE
Remove use of blank method in filtering

### DIFF
--- a/updater/bin/update-script.rb
+++ b/updater/bin/update-script.rb
@@ -305,14 +305,14 @@ def security_advisories_for(dep)
     safe_versions = (adv["patched-versions"] || []) +
                     (adv["unaffected-versions"] || [])
 
-    # Filter out nil (blank objects) and empty strings which is necessary for situations
+    # Filter out nil (using .compact), white spaces and empty strings which is necessary for situations
     # where the API response contains null that is converted to nil, or it is an empty
     # string. For example, npm package named faker does not have patched version as of 2023-01-16
     # See: https://github.com/advisories/GHSA-5w9c-rv96-fr7g for npm package
     # This ideally fixes
     # https://github.com/tinglesoftware/dependabot-azure-devops/issues/453#issuecomment-1383587644
-    vulnerable_versions = vulnerable_versions.reject(&:blank?).reject(&:empty?)
-    safe_versions = safe_versions.reject(&:blank?).reject(&:empty?)
+    vulnerable_versions = vulnerable_versions.compact.reject { |v| v.strip.empty? }
+    safe_versions = safe_versions.compact.reject { |v| v.strip.empty? }
     next if vulnerable_versions.empty? && safe_versions.empty?
 
     Dependabot::SecurityAdvisory.new(


### PR DESCRIPTION
Change filtering/mapping to not use the blank method. This likely fails now due to the removal of ActiveSupport in #523 
Filtering is done using `compact` (nulls), `strip` (whitespaces) and `empty.

Fixes #529