### PR TITLE
Use `convertPlaceholder()` when parsing directory

### DIFF
--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -159,7 +159,7 @@ function parseUpdates(config: any): IDependabotUpdate[] {
   rawUpdates.forEach((update) => {
     var dependabotUpdate: IDependabotUpdate = {
       packageEcosystem: update["package-ecosystem"],
-      directory: update["directory"],
+      directory: convertPlaceholder(update["directory"]),
 
       openPullRequestsLimit: update["open-pull-requests-limit"],
 


### PR DESCRIPTION
Partially solves #552 

This will replace variable placeholders within the `directory` property under `updates`. 

More properties will most likely want to be parsed this way but I'm unsure what the cost will be in terms of speed if that's done.
For now, I believe this is a reasonable change as a directory is likely to be something that's configurable (at least it is in my case).