### PR TITLE
Add support for ignore conditions using .github/dependabot.yml file.

### DIFF
--- a/extension/task/IDependabotConfig.ts
+++ b/extension/task/IDependabotConfig.ts
@@ -34,6 +34,10 @@ export interface IDependabotUpdate {
    */
   allow?: string;
   /**
+   * Ignore certain dependencies or versions.
+   */
+  ignore?: string;
+  /**
    * Custom labels/tags.
    */
   labels?: string;

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -98,6 +98,10 @@ async function run() {
         dockerRunner.arg(["-e", `DEPENDABOT_ALLOW_CONDITIONS=${allow}`]);
       }
 
+      if(update.ignore) {
+        dockerRunner.arg(["-e", `DEPENDABOT_IGNORE_CONDITIONS=${update.ignore}`]);
+      }
+
       // Set the requirements that should not be unlocked
       if (variables.excludeRequirementsToUnlock) {
         dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${variables.excludeRequirementsToUnlock}`]);

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -174,6 +174,7 @@ function parseUpdates(config: any): IDependabotUpdate[] {
 
       // Convert to JSON or as required by the script
       allow: update["allow"] ? JSON.stringify(update["allow"]) : undefined,
+      ignore: update["ignore"] ? JSON.stringify(update["ignore"]) : undefined,
       labels: update["labels"] ? JSON.stringify(update["labels"]) : undefined,
       reviewers: update["reviewers"]
         ? JSON.stringify(update["reviewers"])


### PR DESCRIPTION
Currently the ignore value ([docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore)) is not being read from the .github/dependabot.yml file.

I updated the extension so that this value will now be used to set the DEPENDABOT_IGNORE_CONDITIONS environment variable.