### PR TITLE
Fix role assignments

### DIFF
--- a/server/Tingle.Dependabot/appsettings.json
+++ b/server/Tingle.Dependabot/appsettings.json
@@ -37,7 +37,7 @@
   },
 
   "EventBus": {
-    "SelectedTransport": "InMemory", // InMemory|ServiceBus
+    "SelectedTransport": "InMemory", // InMemory|ServiceBus|QueueStorage
 
     "DefaultTransportWaitStarted": false, // defaults to true which causes startup tasks to hang
     "Naming": {

--- a/server/main.bicep
+++ b/server/main.bicep
@@ -355,7 +355,7 @@ resource app 'Microsoft.App/containerApps@2022-06-01-preview' = {
 
 /* Role Assignments */
 resource contributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {// needed for creating jobs
-  name: guid(resourceGroup().id, 'managedIdentity', 'ContributorRoleAssignment')
+  name: guid(managedIdentity.id, 'ContributorRoleAssignment')
   scope: resourceGroup()
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
@@ -364,7 +364,7 @@ resource contributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022
   }
 }
 resource serviceBusDataOwnerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, 'managedIdentity', 'AzureServiceBusDataOwner')
+  name: guid(managedIdentity.id, 'AzureServiceBusDataOwner')
   scope: resourceGroup()
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '090c5cfd-751d-490a-894a-3ce6f1109419')
@@ -373,7 +373,7 @@ resource serviceBusDataOwnerRoleAssignment 'Microsoft.Authorization/roleAssignme
   }
 }
 resource logAnalyticsReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(resourceGroup().id, 'managedIdentity', 'LogAnalyticsReader')
+  name: guid(managedIdentity.id, 'LogAnalyticsReader')
   scope: resourceGroup()
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')

--- a/server/main.bicep
+++ b/server/main.bicep
@@ -110,7 +110,18 @@ resource managedIdentityJobs 'Microsoft.ManagedIdentity/userAssignedIdentities@2
   location: location
 }
 
-/* Storage Account and Service Bus namespace */
+/* Service Bus namespace and Storage Account*/
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-11-01' = if (eventBusTransport == 'ServiceBus') {
+  name: '${name}-${collisionSuffix}'
+  location: location
+  properties: {
+    disableLocalAuth: false
+    zoneRedundant: false
+  }
+  sku: {
+    name: 'Basic'
+  }
+}
 resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = if (eventBusTransport == 'QueueStorage') {
   name: '${name}-${collisionSuffix}'
   location: location
@@ -126,17 +137,6 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = if (eve
       bypass: 'AzureServices'
       defaultAction: 'Allow'
     }
-  }
-}
-resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-11-01' = if (eventBusTransport == 'ServiceBus') {
-  name: '${name}-${collisionSuffix}'
-  location: location
-  properties: {
-    disableLocalAuth: false
-    zoneRedundant: false
-  }
-  sku: {
-    name: 'Basic'
   }
 }
 
@@ -363,7 +363,7 @@ resource contributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022
     principalType: 'ServicePrincipal'
   }
 }
-resource serviceBusDataOwnerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource serviceBusDataOwnerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (eventBusTransport == 'ServiceBus') {
   name: guid(managedIdentity.id, 'AzureServiceBusDataOwner')
   scope: resourceGroup()
   properties: {

--- a/server/main.bicep
+++ b/server/main.bicep
@@ -372,6 +372,15 @@ resource serviceBusDataOwnerRoleAssignment 'Microsoft.Authorization/roleAssignme
     principalType: 'ServicePrincipal'
   }
 }
+resource storageQueueDataContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (eventBusTransport == 'QueueStorage') {
+  name: guid(managedIdentity.id, 'StorageQueueDataContributor')
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
 resource logAnalyticsReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(managedIdentity.id, 'LogAnalyticsReader')
   scope: resourceGroup()

--- a/server/main.json
+++ b/server/main.json
@@ -210,6 +210,20 @@
       "location": "[parameters('location')]"
     },
     {
+      "condition": "[equals(parameters('eventBusTransport'), 'ServiceBus')]",
+      "type": "Microsoft.ServiceBus/namespaces",
+      "apiVersion": "2021-11-01",
+      "name": "[format('{0}-{1}', parameters('name'), variables('collisionSuffix'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "disableLocalAuth": false,
+        "zoneRedundant": false
+      },
+      "sku": {
+        "name": "Basic"
+      }
+    },
+    {
       "condition": "[equals(parameters('eventBusTransport'), 'QueueStorage')]",
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2022-09-01",
@@ -227,20 +241,6 @@
           "bypass": "AzureServices",
           "defaultAction": "Allow"
         }
-      }
-    },
-    {
-      "condition": "[equals(parameters('eventBusTransport'), 'ServiceBus')]",
-      "type": "Microsoft.ServiceBus/namespaces",
-      "apiVersion": "2021-11-01",
-      "name": "[format('{0}-{1}', parameters('name'), variables('collisionSuffix'))]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "disableLocalAuth": false,
-        "zoneRedundant": false
-      },
-      "sku": {
-        "name": "Basic"
       }
     },
     {
@@ -539,7 +539,7 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
-      "name": "[guid(resourceGroup().id, 'managedIdentity', 'ContributorRoleAssignment')]",
+      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), 'ContributorRoleAssignment')]",
       "properties": {
         "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
         "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), '2018-11-30').principalId]",
@@ -550,9 +550,10 @@
       ]
     },
     {
+      "condition": "[equals(parameters('eventBusTransport'), 'ServiceBus')]",
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
-      "name": "[guid(resourceGroup().id, 'managedIdentity', 'AzureServiceBusDataOwner')]",
+      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), 'AzureServiceBusDataOwner')]",
       "properties": {
         "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '090c5cfd-751d-490a-894a-3ce6f1109419')]",
         "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), '2018-11-30').principalId]",
@@ -563,9 +564,23 @@
       ]
     },
     {
+      "condition": "[equals(parameters('eventBusTransport'), 'QueueStorage')]",
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
-      "name": "[guid(resourceGroup().id, 'managedIdentity', 'LogAnalyticsReader')]",
+      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), 'StorageQueueDataContributor')]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), '2018-11-30').principalId]",
+        "principalType": "ServicePrincipal"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), 'LogAnalyticsReader')]",
       "properties": {
         "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
         "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), '2018-11-30').principalId]",


### PR DESCRIPTION
- Use simpler names for the role assignments
- Only create role assignment for Service Bus if the transport is `ServiceBus`.
- Create `Storage Queue Data Contributor` role assignment when transport is `QueueStorage`.