### PR TITLE
Add execute permissions to bin/entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
 # This entrypoint exists to solve specific setup problems.
 # It is only used with the extension and directly on Docker.
 # Hosted version does not allow this.
+RUN chmod +x bin/entrypoint.sh
 ENTRYPOINT ["bin/entrypoint.sh"]
 
 CMD ["bundle", "exec", "ruby", "bin/update-script.rb"]


### PR DESCRIPTION
Currently executing the Dockerfile results in error "docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "bin/entrypoint.sh": permission denied: unknown." 

This change is to add execute permissions to bin/entrypoint.sh to run properly.