### PR TITLE
Fix version alignment

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -68,8 +68,8 @@ The deployment exposes the following parameters that can be tuned to suit the se
 |notificationsPassword|The password used to authenticate incoming requests from Azure DevOps|No|&lt;auto-generated&gt;|
 |dockerImageRegistry|The docker registry to use when pulling the docker containers if needed. By default this will GitHub Container Registry. This can be useful if the container needs to come from an internal docker registry mirror or alternative source for testing. If the registry requires authentication ensure to assign `acrPull` permissions to the managed identity.<br />Example: `contoso.azurecr.io`|No|`ghcr.io`|
 |serverImageRepository|The docker container repository to use when pulling the server docker container. This can be useful if the default container requires customizations such as custom certs.|No|`tinglesoftware/dependabot-server`|
-|serverImageTag|The image tag to use when pulling the docker container. A tag also defines the version. You should avoid using `latest`. Example: `0.1.0`|No|&lt;version-downloaded&gt;|
-|updaterImageTag|The image tag to use when pulling the updater docker container. A tag also defines the version. You should avoid using `latest`. Example: `0.1.0`|No|&lt;version-downloaded&gt;|
+|serverImageTag|The image tag to use when pulling the docker container. A tag also defines the version. You should avoid using `latest`. Example: `1.1.0`|No|&lt;version-downloaded&gt;|
+|updaterImageTag|The image tag to use when pulling the updater docker container. A tag also defines the version. You should avoid using `latest`. Example: `1.1.0`|No|&lt;version-downloaded&gt;|
 |minReplicas|The minimum number of replicas to required for the deployment. Given that scheduling runs in process, this value cannot be less than `1`. This may change in the future.|No|1|
 |maxReplicas|The maximum number of replicas when automatic scaling engages. In most cases, you do not need more than 1.|No|1|
 

--- a/extension/task/utils/getDockerImageTag.ts
+++ b/extension/task/utils/getDockerImageTag.ts
@@ -25,13 +25,11 @@ export default function getDockerImageTag(): string {
       throw new Error("Invalid dependabot config object");
     }
 
-    // we only pull the minor version, the major is fixed for two reasons:
-    // 1. The docker version and the task version are not aligned
-    // 2. Major docker changes mostly require major changes in the task
+    const versionMajor = obj["version"]["Major"];
     const versionMinor = obj["version"]["Minor"];
-    if (!!!versionMinor) throw new Error("Minor version could not be parsed from the file");
+    if (!!!versionMajor || !!!versionMinor) throw new Error("Major and/or Minor version could not be parsed from the file");
 
-    dockerImageTag = `0.${versionMinor}`;
+    dockerImageTag = `${versionMajor}.${versionMinor}`;
   }
 
   return dockerImageTag;

--- a/server/Tingle.Dependabot.Tests/Workflow/UpdateRunnerTests.cs
+++ b/server/Tingle.Dependabot.Tests/Workflow/UpdateRunnerTests.cs
@@ -222,12 +222,12 @@ public class UpdateRunnerTests
     }
 
     [Theory]
-    [InlineData("contoso.azurecr.io/tinglesoftware/dependabot-updater-nuget:0.11", true, "contoso.azurecr.io")]
-    [InlineData("fabrikam.azurecr.io/tinglesoftware/dependabot-updater-nuget:0.11", true, "fabrikam.azurecr.io")]
-    [InlineData("dependabot.azurecr.io/tinglesoftware/dependabot-updater-nuget:0.11", true, "dependabot.azurecr.io")]
-    [InlineData("ghcr.io/tinglesoftware/dependabot-updater-nuget:0.11", false, null)]
-    [InlineData("tingle/dependabot-updater-nuget:0.11", false, null)]
-    [InlineData("tingle/dependabot-azure-devops:0.11", false, null)]
+    [InlineData("contoso.azurecr.io/tinglesoftware/dependabot-updater-nuget:1.20", true, "contoso.azurecr.io")]
+    [InlineData("fabrikam.azurecr.io/tinglesoftware/dependabot-updater-nuget:1.20", true, "fabrikam.azurecr.io")]
+    [InlineData("dependabot.azurecr.io/tinglesoftware/dependabot-updater-nuget:1.20", true, "dependabot.azurecr.io")]
+    [InlineData("ghcr.io/tinglesoftware/dependabot-updater-nuget:1.20", false, null)]
+    [InlineData("tingle/dependabot-updater-nuget:1.20", false, null)]
+    [InlineData("tingle/dependabot-azure-devops:1.20", false, null)]
     public void TryGetAzureContainerRegistry_Works(string input, bool matches, string? expected)
     {
         var found = UpdateRunner.TryGetAzureContainerRegistry(input, out var actual);

--- a/server/Tingle.Dependabot/Workflow/WorkflowOptions.cs
+++ b/server/Tingle.Dependabot/Workflow/WorkflowOptions.cs
@@ -42,7 +42,7 @@ public class WorkflowOptions
     /// <br/>
     /// However, in production there maybe an issue that requires a rollback hence the value is placed in options.
     /// </summary>
-    /// <example>ghcr.io/tinglesoftware/dependabot-updater-{{ecosystem}}:0.14</example>
+    /// <example>ghcr.io/tinglesoftware/dependabot-updater-{{ecosystem}}:1.20</example>
     public string? UpdaterContainerImageTemplate { get; set; }
 
     /// <summary>URL for the project.</summary>

--- a/server/Tingle.Dependabot/appsettings.json
+++ b/server/Tingle.Dependabot/appsettings.json
@@ -64,7 +64,7 @@
     "LogAnalyticsWorkspaceId": "00000000-0000-1111-0001-000000000000",
     "LogAnalyticsWorkspaceKey": "AAAAAAAAAAA=",
     "ManagedIdentityId": "/subscriptions/00000000-0000-1111-0001-000000000000/resourceGroups/DEPENDABOT/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dependabot",
-    "UpdaterContainerImageTemplate": "ghcr.io/tinglesoftware/dependabot-updater-{{ecosystem}}:0.14.2-ci.37",
+    "UpdaterContainerImageTemplate": "ghcr.io/tinglesoftware/dependabot-updater-{{ecosystem}}:1.20.0-ci.37",
     "ProjectUrl": "https://dev.azure.com/fabrikam/DefaultCollection",
     "ProjectToken": "<my-pat-here>",
     "GithubToken": "<github-pat-here>",


### PR DESCRIPTION
After accidentally releasing version 1.20.0 instead of version 0.20.0, we have to align the versions now. This PR now aligns the versions in the extension's task logic and in comments.