### PR TITLE
fix: retrieve active pull requests against chosen target branch

### DIFF
--- a/updater/bin/update-script.rb
+++ b/updater/bin/update-script.rb
@@ -554,8 +554,7 @@ azure_client = Dependabot::Clients::Azure.for_source(
   credentials: $options[:credentials]
 )
 user_id = azure_client.get_user_id
-default_branch_name = azure_client.fetch_default_branch($source.repo)
-active_pull_requests = azure_client.pull_requests_active(user_id, default_branch_name)
+active_pull_requests = azure_client.pull_requests_active(user_id, $options[:branch])
 
 pull_requests_count = 0
 
@@ -922,7 +921,7 @@ end
 # look for pull requests that are no longer needed to be abandoned
 if $options[:close_unwanted]
   puts "Looking for pull requests that are no longer needed."
-  active_pull_requests = azure_client.pull_requests_active(user_id, default_branch_name)
+  active_pull_requests = azure_client.pull_requests_active(user_id, $options[:branch])
   active_pull_requests.each do |pr|
     pr_id = pr["pullRequestId"]
     title = pr["title"]

--- a/updater/bin/update-script.rb
+++ b/updater/bin/update-script.rb
@@ -554,6 +554,7 @@ azure_client = Dependabot::Clients::Azure.for_source(
   credentials: $options[:credentials]
 )
 user_id = azure_client.get_user_id
+$options[:branch] = azure_client.fetch_default_branch($source.repo) unless $options[:branch]
 active_pull_requests = azure_client.pull_requests_active(user_id, $options[:branch])
 
 pull_requests_count = 0


### PR DESCRIPTION
With the current behaviour PRs are not updated or closed when the target branch deviates from the default branch.