### PR TITLE
Setup updater server endpoints

### DIFF
--- a/server/Tingle.Dependabot/Migrations/20230824083425_InitialCreate.Designer.cs
+++ b/server/Tingle.Dependabot/Migrations/20230824083425_InitialCreate.Designer.cs
@@ -20,7 +20,7 @@ namespace Tingle.Dependabot.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.10")
+                .HasAnnotation("ProductVersion", "7.0.11")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -127,6 +127,9 @@ namespace Tingle.Dependabot.Migrations
 
                     b.Property<DateTimeOffset?>("End")
                         .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Error")
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<byte[]>("Etag")
                         .IsConcurrencyToken()

--- a/server/Tingle.Dependabot/Migrations/20230824083425_InitialCreate.cs
+++ b/server/Tingle.Dependabot/Migrations/20230824083425_InitialCreate.cs
@@ -67,6 +67,7 @@ public partial class InitialCreate : Migration
                 End = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
                 Duration = table.Column<long>(type: "bigint", nullable: true),
                 Log = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                Error = table.Column<string>(type: "nvarchar(max)", nullable: true),
                 Etag = table.Column<byte[]>(type: "rowversion", rowVersion: true, nullable: true)
             },
             constraints: table =>

--- a/server/Tingle.Dependabot/Migrations/MainDbContextModelSnapshot.cs
+++ b/server/Tingle.Dependabot/Migrations/MainDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace Tingle.Dependabot.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.10")
+                .HasAnnotation("ProductVersion", "7.0.11")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
@@ -124,6 +124,9 @@ namespace Tingle.Dependabot.Migrations
 
                     b.Property<DateTimeOffset?>("End")
                         .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("Error")
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<byte[]>("Etag")
                         .IsConcurrencyToken()

--- a/server/Tingle.Dependabot/Models/MainDbContext.cs
+++ b/server/Tingle.Dependabot/Models/MainDbContext.cs
@@ -32,6 +32,7 @@ public class MainDbContext : DbContext, IDataProtectionKeyContext
         modelBuilder.Entity<UpdateJob>(b =>
         {
             b.Property(j => j.PackageEcosystem).IsRequired();
+            HasJsonConversion(b.Property(j => j.Error));
 
             b.HasIndex(j => j.Created).IsDescending(); // faster filtering
             b.HasIndex(j => j.RepositoryId);

--- a/server/Tingle.Dependabot/Models/UpdateJob.cs
+++ b/server/Tingle.Dependabot/Models/UpdateJob.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Tingle.Dependabot.Models;
@@ -71,6 +72,15 @@ public class UpdateJob
     /// <summary>Detailed log output.</summary>
     public string? Log { get; set; }
 
+    /// <summary>Error recorded by the job, if any.</summary>
+    public UpdateJobError? Error { get; set; }
+
     [Timestamp]
     public byte[]? Etag { get; set; }
+}
+
+public class UpdateJobError
+{
+    public string? Type { get; set; }
+    public JsonNode? Detail { get; set; }
 }

--- a/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
+++ b/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
@@ -86,6 +86,12 @@ public sealed record UpdateJobAttributesSource
     public string? ApiEndpoint { get; set; }
 }
 
+public sealed class MarkAsProcessedModel
+{
+    [JsonPropertyName("base-commit-sha")]
+    public string? BaseCommitSha { get; set; }
+}
+
 public sealed class UpdateDependencyListModel
 {
     [Required]

--- a/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
+++ b/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace Tingle.Dependabot.Models;
 
@@ -63,7 +65,7 @@ public sealed record UpdateJobAttributes()
     public bool? Debug { get; set; }
 }
 
-public sealed record UpdateJobAttributesSource()
+public sealed record UpdateJobAttributesSource
 {
     [JsonPropertyName("provider")]
     public required string Provider { get; set; }
@@ -82,4 +84,16 @@ public sealed record UpdateJobAttributesSource()
 
     [JsonPropertyName("api-endpoint")]
     public string? ApiEndpoint { get; set; }
+}
+
+public sealed class UpdateDependencyListModel
+{
+    [Required]
+    [JsonPropertyName("dependencies")]
+    public List<JsonNode>? Dependencies { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    [JsonPropertyName("dependency_files")]
+    public List<string>? DependencyFiles { get; set; }
 }

--- a/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
+++ b/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
@@ -86,6 +86,15 @@ public sealed record UpdateJobAttributesSource
     public string? ApiEndpoint { get; set; }
 }
 
+public sealed class RecordUpdateJobErrorModel
+{
+    [JsonPropertyName("error-type")]
+    public string? ErrorType { get; set; }
+
+    [JsonPropertyName("error-detail")]
+    public JsonNode? ErrorDetail { get; set; }
+}
+
 public sealed class MarkAsProcessedModel
 {
     [JsonPropertyName("base-commit-sha")]

--- a/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
+++ b/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
@@ -86,6 +86,20 @@ public sealed record UpdateJobAttributesSource
     public string? ApiEndpoint { get; set; }
 }
 
+public sealed class ClosePullRequestModel
+{
+    //[Required]
+    //[MinLength(1)]
+    //[JsonPropertyName("dependency-names")]
+    //public List<string>? DependencyNames { get; set; } // This can also be a string that's why it has not been enabled
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; } // convert from string to enum once we know all possible values
+
+    [JsonExtensionData]
+    public Dictionary<string, object>? Extensions { get; set; }
+}
+
 public sealed class RecordUpdateJobErrorModel
 {
     [JsonPropertyName("error-type")]
@@ -93,12 +107,18 @@ public sealed class RecordUpdateJobErrorModel
 
     [JsonPropertyName("error-detail")]
     public JsonNode? ErrorDetail { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, object>? Extensions { get; set; }
 }
 
 public sealed class MarkAsProcessedModel
 {
     [JsonPropertyName("base-commit-sha")]
     public string? BaseCommitSha { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, object>? Extensions { get; set; }
 }
 
 public sealed class UpdateDependencyListModel
@@ -111,4 +131,7 @@ public sealed class UpdateDependencyListModel
     [MinLength(1)]
     [JsonPropertyName("dependency_files")]
     public List<string>? DependencyFiles { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, object>? Extensions { get; set; }
 }

--- a/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
+++ b/server/Tingle.Dependabot/Models/UpdateJobResponse.cs
@@ -86,6 +86,96 @@ public sealed record UpdateJobAttributesSource
     public string? ApiEndpoint { get; set; }
 }
 
+public sealed class CreatePullRequestModel
+{
+    [Required]
+    [MinLength(1)]
+    [JsonPropertyName("dependencies")]
+    public List<ChangedDependency>? Dependencies { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    [JsonPropertyName("updated-dependency-files")]
+    public List<UpdatedDependencyFile>? DependencyFiles { get; set; }
+
+    [JsonPropertyName("base-commit-sha")]
+    public string? BaseCommitSha { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, object>? Extensions { get; set; }
+}
+
+public sealed class ChangedDependency
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("previous-version")]
+    public string? PreviousVersion { get; set; }
+
+    [Required]
+    [JsonPropertyName("requirements")]
+    public JsonArray? Requirements { get; set; }
+
+    [JsonPropertyName("previous-requirements")]
+    public string? PreviousRequirements { get; set; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("removed")]
+    public bool? Removed { get; set; }
+}
+
+public sealed class UpdatePullRequestModel
+{
+    [Required]
+    [MinLength(1)]
+    [JsonPropertyName("dependency-names")]
+    public List<string>? DependencyNames { get; set; }
+
+    [Required]
+    [MinLength(1)]
+    [JsonPropertyName("updated-dependency-files")]
+    public List<UpdatedDependencyFile>? DependencyFiles { get; set; }
+
+    [JsonPropertyName("base-commit-sha")]
+    public string? BaseCommitSha { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, object>? Extensions { get; set; }
+}
+
+public sealed class UpdatedDependencyFile
+{
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+
+    [JsonPropertyName("content_encoding")]
+    public string? ContentEncoding { get; set; }
+
+    [JsonPropertyName("deleted")]
+    public bool? Deleted { get; set; }
+
+    [JsonPropertyName("directory")]
+    public string? Directory { get; set; }
+
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("operation")]
+    public string? Operation { get; set; } // convert from string to enum once we know all possible values
+
+    [JsonPropertyName("support_file")]
+    public bool? SupportFile { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; } // convert from string to enum once we know all possible values
+}
+
 public sealed class ClosePullRequestModel
 {
     //[Required]
@@ -125,7 +215,7 @@ public sealed class UpdateDependencyListModel
 {
     [Required]
     [JsonPropertyName("dependencies")]
-    public List<JsonNode>? Dependencies { get; set; }
+    public JsonArray? Dependencies { get; set; }
 
     [Required]
     [MinLength(1)]

--- a/server/Tingle.Dependabot/Program.cs
+++ b/server/Tingle.Dependabot/Program.cs
@@ -261,46 +261,28 @@ internal static class ApplicationExtensions
     {
         var logger = builder.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("UpdateJobsApi");
 
+        // endpoints accessed by the updater during execution
+
         var group = builder.MapGroup("update_jobs");
         group.RequireAuthorization(AuthConstants.PolicyNameUpdater);
 
-        // TODO: create endpoints accessed by the updater during execution similar to the one hosted by GitHub
-
-        //group.MapGet("/{id}", async (MainDbContext dbContext, [FromRoute, Required] string id) =>
-        //{
-        //    var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
-
-        //    var attr = new UpdateJobAttributes(job)
-        //    {
-        //        AllowedUpdates = Array.Empty<object>(),
-        //        CredentialsMetadata = Array.Empty<object>(),
-        //        Dependencies = Array.Empty<object>(),
-        //        Directory = job.Directory!,
-        //        ExistingPullRequests = Array.Empty<object>(),
-        //        IgnoreConditions = Array.Empty<object>(),
-        //        PackageManager = job.PackageEcosystem,
-        //        RepoName = job.RepositorySlug!,
-        //        SecurityAdvisories = Array.Empty<object>(),
-        //        Source = new UpdateJobAttributesSource
-        //        {
-        //            Directory = job.Directory!,
-        //            Provider = "azure",
-        //            Repo = job.RepositorySlug!,
-        //            Branch = job.Branch,
-        //            Hostname = ,
-        //            ApiEndpoint =,
-        //        },
-        //    };
-        //    return Results.Ok(new UpdateJobResponse(new(attr)));
-        //});
-
-        //group.MapPost("/{id}/create_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] CreatePullRequestModel model) => { });
-        //group.MapPost("/{id}/update_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] UpdatePullRequestModel model) => { });
-
+        // TODO: implement logic for *pull_request endpoints
+        group.MapPost("/{id}/create_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<CreatePullRequestModel> model) =>
+        {
+            var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
+            logger.LogInformation("Received request to create a pull request from job {JobId} but we did nothing.\r\n{ModelJson}", id, JsonSerializer.Serialize(model));
+            return Results.Ok();
+        });
+        group.MapPost("/{id}/update_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<UpdatePullRequestModel> model) =>
+        {
+            var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
+            logger.LogInformation("Received request to update a pull request from job {JobId} but we did nothing.\r\n{ModelJson}", id, JsonSerializer.Serialize(model));
+            return Results.Ok();
+        });
         group.MapPost("/{id}/close_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<ClosePullRequestModel> model) =>
         {
             var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
-            logger.LogInformation("Received request to close pull request from job {JobId} but we did nothing.\r\n{ModelJson}", id, JsonSerializer.Serialize(model));
+            logger.LogInformation("Received request to close a pull request from job {JobId} but we did nothing.\r\n{ModelJson}", id, JsonSerializer.Serialize(model));
             return Results.Ok();
         });
 
@@ -318,7 +300,6 @@ internal static class ApplicationExtensions
 
             return Results.Ok();
         });
-
         group.MapPatch("/{id}/mark_as_processed", async (IEventPublisher publisher, MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<MarkAsProcessedModel> model) =>
         {
             var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
@@ -329,7 +310,6 @@ internal static class ApplicationExtensions
 
             return Results.Ok();
         });
-
         group.MapPost("/{id}/update_dependency_list", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<UpdateDependencyListModel> model) =>
         {
             var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
@@ -352,7 +332,6 @@ internal static class ApplicationExtensions
             logger.LogInformation("Received request to record ecosystem version from job {JobId} but we did nothing.\r\n{ModelJson}", id, model.ToJsonString());
             return Results.Ok();
         });
-
         group.MapPost("/{id}/increment_metric", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] JsonNode model) =>
         {
             var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);

--- a/server/Tingle.Dependabot/Program.cs
+++ b/server/Tingle.Dependabot/Program.cs
@@ -296,7 +296,13 @@ internal static class ApplicationExtensions
 
         //group.MapPost("/{id}/create_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] CreatePullRequestModel model) => { });
         //group.MapPost("/{id}/update_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] UpdatePullRequestModel model) => { });
-        //group.MapPost("/{id}/close_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] ClosePullRequestModel model) => { });
+
+        group.MapPost("/{id}/close_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<ClosePullRequestModel> model) =>
+        {
+            var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
+            logger.LogInformation("Received request to close pull request from job {JobId} but we did nothing.\r\n{ModelJson}", id, JsonSerializer.Serialize(model));
+            return Results.Ok();
+        });
 
         group.MapPost("/{id}/record_update_job_error", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<RecordUpdateJobErrorModel> model) =>
         {
@@ -343,14 +349,14 @@ internal static class ApplicationExtensions
         group.MapPost("/{id}/record_ecosystem_versions", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] JsonNode model) =>
         {
             var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
-            logger.LogInformation("Received request to record ecosystem version for {JobId} but we did nothing.\r\n{ModelJson}", id, model.ToJsonString());
+            logger.LogInformation("Received request to record ecosystem version from job {JobId} but we did nothing.\r\n{ModelJson}", id, model.ToJsonString());
             return Results.Ok();
         });
 
         group.MapPost("/{id}/increment_metric", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] JsonNode model) =>
         {
             var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
-            logger.LogInformation("Received metrics for {JobId} but we did nothing with them.\r\n{ModelJson}", id, model.ToJsonString());
+            logger.LogInformation("Received metrics from job {JobId} but we did nothing with them.\r\n{ModelJson}", id, model.ToJsonString());
             return Results.Ok();
         });
 
@@ -361,5 +367,8 @@ internal static class ApplicationExtensions
     {
         [Required]
         public T? Data { get; set; }
+
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public Dictionary<string, object>? Extensions { get; set; }
     }
 }

--- a/server/Tingle.Dependabot/Program.cs
+++ b/server/Tingle.Dependabot/Program.cs
@@ -297,7 +297,21 @@ internal static class ApplicationExtensions
         //group.MapPost("/{id}/create_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] CreatePullRequestModel model) => { });
         //group.MapPost("/{id}/update_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] UpdatePullRequestModel model) => { });
         //group.MapPost("/{id}/close_pull_request", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] ClosePullRequestModel model) => { });
-        //group.MapPost("/{id}/record_update_job_error", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] RecordUpdateJobErrorModel model) => { });
+
+        group.MapPost("/{id}/record_update_job_error", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<RecordUpdateJobErrorModel> model) =>
+        {
+            var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
+
+            job.Error = new UpdateJobError
+            {
+                Type = model.Data!.ErrorType,
+                Detail = model.Data.ErrorDetail,
+            };
+
+            await dbContext.SaveChangesAsync();
+
+            return Results.Ok();
+        });
 
         group.MapPatch("/{id}/mark_as_processed", async (IEventPublisher publisher, MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] PayloadWithData<MarkAsProcessedModel> model) =>
         {

--- a/server/Tingle.Dependabot/Program.cs
+++ b/server/Tingle.Dependabot/Program.cs
@@ -300,7 +300,13 @@ internal static class ApplicationExtensions
         //group.MapPost("/{id}/record_update_job_error", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] RecordUpdateJobErrorModel model) => { });
         //group.MapPatch("/{id}/mark_as_processed", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] MarkAsProcessedModel model) => { });
         //group.MapPost("/{id}/update_dependency_list", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] UpdateDependencyListModel model) => { });
-        //group.MapPost("/{id}/record_package_manager_version", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] RecordPackageManagerVersionModel model) => { });
+
+        group.MapPost("/{id}/record_ecosystem_versions", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] JsonNode model) =>
+        {
+            var job = await dbContext.UpdateJobs.SingleAsync(p => p.Id == id);
+            logger.LogInformation("Received request to record ecosystem version for {JobId} but we did nothing.\r\n{ModelJson}", id, model.ToJsonString());
+            return Results.Ok();
+        });
 
         group.MapPost("/{id}/increment_metric", async (MainDbContext dbContext, [FromRoute, Required] string id, [FromBody] JsonNode model) =>
         {

--- a/server/Tingle.Dependabot/Workflow/UpdateRunner.cs
+++ b/server/Tingle.Dependabot/Workflow/UpdateRunner.cs
@@ -203,6 +203,30 @@ internal partial class UpdateRunner
 
         var jobDirectory = Path.Join(options.WorkingDirectory, job.Id);
 
+        // TODO: write the job definition file (find out if it is YAML/JSON)
+
+        //    var attr = new UpdateJobAttributes(job)
+        //    {
+        //        AllowedUpdates = Array.Empty<object>(),
+        //        CredentialsMetadata = Array.Empty<object>(),
+        //        Dependencies = Array.Empty<object>(),
+        //        Directory = job.Directory!,
+        //        ExistingPullRequests = Array.Empty<object>(),
+        //        IgnoreConditions = Array.Empty<object>(),
+        //        PackageManager = job.PackageEcosystem,
+        //        RepoName = job.RepositorySlug!,
+        //        SecurityAdvisories = Array.Empty<object>(),
+        //        Source = new UpdateJobAttributesSource
+        //        {
+        //            Directory = job.Directory!,
+        //            Provider = "azure",
+        //            Repo = job.RepositorySlug!,
+        //            Branch = job.Branch,
+        //            Hostname = ,
+        //            ApiEndpoint =,
+        //        },
+        //    };
+
         // Add compulsory values
         var values = new Dictionary<string, string>
         {


### PR DESCRIPTION
Setup server endpoints to be reached/used by the updater although the pull request logic is yet to be written hence the CodeQL warnings/alerts.

Endpoints
* `update_jobs/{id}/increment_metric`
* `update_jobs/{id}/record_ecosystem_versions`
* `update_jobs/{id}/update_dependency_list`
* `update_jobs/{id}/mark_as_processed`
* `update_jobs/{id}/record_update_job_error`
* `update_jobs/{id}/close_pull_request`
* `update_jobs/{id}/create_pull_request`