### PR TITLE
Migrate from ContainerGroups/ContainerInstances to ContainerAppJobs

### DIFF
--- a/server/Tingle.Dependabot.Tests/Workflow/UpdateRunnerTests.cs
+++ b/server/Tingle.Dependabot.Tests/Workflow/UpdateRunnerTests.cs
@@ -220,18 +220,4 @@ public class UpdateRunnerTests
         var result = UpdateRunner.ConvertPlaceholder(input, secrets);
         Assert.Equal(":cake", result);
     }
-
-    [Theory]
-    [InlineData("contoso.azurecr.io/tinglesoftware/dependabot-updater-nuget:1.20", true, "contoso.azurecr.io")]
-    [InlineData("fabrikam.azurecr.io/tinglesoftware/dependabot-updater-nuget:1.20", true, "fabrikam.azurecr.io")]
-    [InlineData("dependabot.azurecr.io/tinglesoftware/dependabot-updater-nuget:1.20", true, "dependabot.azurecr.io")]
-    [InlineData("ghcr.io/tinglesoftware/dependabot-updater-nuget:1.20", false, null)]
-    [InlineData("tingle/dependabot-updater-nuget:1.20", false, null)]
-    [InlineData("tingle/dependabot-azure-devops:1.20", false, null)]
-    public void TryGetAzureContainerRegistry_Works(string input, bool matches, string? expected)
-    {
-        var found = UpdateRunner.TryGetAzureContainerRegistry(input, out var actual);
-        Assert.Equal(matches, found);
-        Assert.Equal(expected, actual);
-    }
 }

--- a/server/Tingle.Dependabot/Models/UpdateJobResources.cs
+++ b/server/Tingle.Dependabot/Models/UpdateJobResources.cs
@@ -1,4 +1,4 @@
-﻿using Azure.ResourceManager.ContainerInstance.Models;
+﻿using Azure.ResourceManager.AppContainers.Models;
 using System.ComponentModel.DataAnnotations;
 
 namespace Tingle.Dependabot.Models;
@@ -31,20 +31,18 @@ public class UpdateJobResources
 
     public static UpdateJobResources FromEcosystem(string ecosystem)
     {
-        // the minimum we can be billed for on Container Instances is 1vCPU and 1GB, we might as well use it
-        // TODO: change to selection per ecosystem when migrate to ContainerApp Jobs
         return ecosystem switch
         {
             //"nuget" => new(cpu: 0.25, memory: 0.2),
             //"gitsubmodule" => new(cpu: 0.1, memory: 0.2),
             //"terraform" => new(cpu: 0.25, memory: 1),
             //"npm" => new(cpu: 0.25, memory: 1),
-            _ => new UpdateJobResources(cpu: 1, memory: 1), // the minimum
+            _ => new UpdateJobResources(cpu: 0.25, memory: 0.5), // the minimum
         };
     }
 
-    public static implicit operator ContainerResourceRequestsContent(UpdateJobResources resources)
+    public static implicit operator AppContainerResources(UpdateJobResources resources)
     {
-        return new(memoryInGB: resources.Memory, cpu: resources.Cpu);
+        return new() { Cpu = resources.Cpu, Memory = $"{resources.Memory}Gi", };
     }
 }

--- a/server/Tingle.Dependabot/Tingle.Dependabot.csproj
+++ b/server/Tingle.Dependabot/Tingle.Dependabot.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Azure.Identity" Version="1.10.1" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.2.0" />
     <PackageReference Include="Azure.ResourceManager.AppContainers" Version="1.1.0" />
-    <PackageReference Include="Azure.ResourceManager.ContainerInstance" Version="1.1.0" />
     <PackageReference Include="FlakeId" Version="1.1.1" />
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
@@ -35,6 +34,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Microsoft.VisualStudio.Services.ServiceHooks.WebApi" Version="19.225.0-preview" />
     <PackageReference Include="MiniValidation" Version="0.8.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Tingle.EventBus.Transports.Azure.ServiceBus" Version="0.19.2" />
     <PackageReference Include="Tingle.EventBus.Transports.InMemory" Version="0.19.2" />
     <PackageReference Include="Tingle.Extensions.DataAnnotations" Version="4.2.1" />

--- a/server/Tingle.Dependabot/Workflow/WorkflowConfigureOptions.cs
+++ b/server/Tingle.Dependabot/Workflow/WorkflowConfigureOptions.cs
@@ -43,14 +43,14 @@ internal class WorkflowConfigureOptions : IPostConfigureOptions<WorkflowOptions>
             return ValidateOptionsResult.Fail($"'{nameof(options.ResourceGroupId)}' cannot be null or whitespace");
         }
 
+        if (string.IsNullOrWhiteSpace(options.AppEnvironmentId))
+        {
+            return ValidateOptionsResult.Fail($"'{nameof(options.AppEnvironmentId)}' cannot be null or whitespace");
+        }
+
         if (string.IsNullOrWhiteSpace(options.LogAnalyticsWorkspaceId))
         {
             return ValidateOptionsResult.Fail($"'{nameof(options.LogAnalyticsWorkspaceId)}' cannot be null or whitespace");
-        }
-
-        if (string.IsNullOrWhiteSpace(options.LogAnalyticsWorkspaceKey))
-        {
-            return ValidateOptionsResult.Fail($"'{nameof(options.LogAnalyticsWorkspaceKey)}' cannot be null or whitespace");
         }
 
         if (string.IsNullOrWhiteSpace(options.UpdaterContainerImageTemplate))
@@ -66,21 +66,6 @@ internal class WorkflowConfigureOptions : IPostConfigureOptions<WorkflowOptions>
         if (string.IsNullOrWhiteSpace(options.Location))
         {
             return ValidateOptionsResult.Fail($"'{nameof(options.Location)}' cannot be null or whitespace");
-        }
-
-        if (string.IsNullOrWhiteSpace(options.StorageAccountName))
-        {
-            return ValidateOptionsResult.Fail($"'{nameof(options.StorageAccountName)}' cannot be null or whitespace");
-        }
-
-        if (string.IsNullOrWhiteSpace(options.StorageAccountKey))
-        {
-            return ValidateOptionsResult.Fail($"'{nameof(options.StorageAccountKey)}' cannot be null or whitespace");
-        }
-
-        if (string.IsNullOrWhiteSpace(options.FileShareName))
-        {
-            return ValidateOptionsResult.Fail($"'{nameof(options.FileShareName)}' cannot be null or whitespace");
         }
 
         return ValidateOptionsResult.Success;

--- a/server/Tingle.Dependabot/Workflow/WorkflowOptions.cs
+++ b/server/Tingle.Dependabot/Workflow/WorkflowOptions.cs
@@ -23,13 +23,13 @@ public class WorkflowOptions
     /// <example>/subscriptions/00000000-0000-1111-0001-000000000000/resourceGroups/DEPENDABOT</example>
     public string? ResourceGroupId { get; set; }
 
+    /// <summary>Name of the file share for the working directory</summary>
+    /// <example>/subscriptions/00000000-0000-1111-0001-000000000000/resourceGroups/DEPENDABOT/Microsoft.App/managedEnvironments/dependabot</example>
+    public string? AppEnvironmentId { get; set; }
+
     /// <summary>CustomerId of the LogAnalytics workspace.</summary>
     /// <example>00000000-0000-1111-0001-000000000000</example>
     public string? LogAnalyticsWorkspaceId { get; set; }
-
-    /// <summary>AuthenticationKey of the LogAnalytics workspace.</summary>
-    /// <example>AAAAAAAAAAA=</example>
-    public string? LogAnalyticsWorkspaceKey { get; set; }
 
     /// <summary>
     /// Template representing the docker container image  to use.
@@ -98,17 +98,6 @@ public class WorkflowOptions
 
     /// <summary>Location/region where to create new update jobs.</summary>
     public string? Location { get; set; } // using Azure.Core.Location does not work when binding from IConfiguration
-
-    /// <summary>Name of the storage account.</summary>
-    /// <example>dependabot-1234567890</example>
-    public string? StorageAccountName { get; set; } // only used with ContainerInstances
-
-    /// <summary>Access key for the storage account.</summary>
-    public string? StorageAccountKey { get; set; } // only used with ContainerInstances
-
-    /// <summary>Name of the file share for the working directory</summary>
-    /// <example>working-dir</example>
-    public string? FileShareName { get; set; } // only used with ContainerInstances
 
     /// <summary>
     /// Possible/allowed paths for the configuration files in a repository.

--- a/server/Tingle.Dependabot/appsettings.json
+++ b/server/Tingle.Dependabot/appsettings.json
@@ -61,16 +61,13 @@
     "WebhookEndpoint": "http://localhost:3000/",
     "SubscriptionPassword": "<my-password-here>",
     "ResourceGroupId": "/subscriptions/00000000-0000-1111-0001-000000000000/resourceGroups/DEPENDABOT",
+    "AppEnvironmentId": "/subscriptions/00000000-0000-1111-0001-000000000000/resourceGroups/DEPENDABOT/providers/Microsoft.App/managedEnvironments/dependabot",
     "LogAnalyticsWorkspaceId": "00000000-0000-1111-0001-000000000000",
-    "LogAnalyticsWorkspaceKey": "AAAAAAAAAAA=",
     "UpdaterContainerImageTemplate": "ghcr.io/tinglesoftware/dependabot-updater-{{ecosystem}}:1.20.0-ci.37",
     "ProjectUrl": "https://dev.azure.com/fabrikam/DefaultCollection",
     "ProjectToken": "<my-pat-here>",
     "WorkingDirectory": "work",
     "GithubToken": "<github-pat-here>",
-    "Location": "westeurope",
-    "StorageAccountName": "dependabot-1234567890",
-    "StorageAccountKey": "<key-here>",
-    "FileShareName": "working-dir"
+    "Location": "westeurope"
   }
 }

--- a/server/main.bicep
+++ b/server/main.bicep
@@ -266,7 +266,6 @@ resource app 'Microsoft.App/containerApps@2023-05-01' = {
         }
         { name: 'notifications-password', value: notificationsPassword }
         { name: 'project-token', value: projectToken }
-        { name: 'log-analytics-workspace-key', value: logAnalyticsWorkspace.listKeys().primarySharedKey }
         { name: 'storage-account-key', value: storageAccount.listKeys().keys[0].value }
         { name: 'connection-strings-asb-scaler', value: serviceBusNamespace::authorizationRule.listKeys().primaryConnectionString }
       ]
@@ -299,11 +298,11 @@ resource app 'Microsoft.App/containerApps@2023-05-01' = {
             }
             { name: 'Workflow__SubscriptionPassword', secretRef: 'notifications-password' }
             { name: 'Workflow__ResourceGroupId', value: resourceGroup().id }
+            { name: 'Workflow__AppEnvironmentId', value: appEnvironment.id }
             {
               name: 'Workflow__LogAnalyticsWorkspaceId'
               value: logAnalyticsWorkspace.properties.customerId
             }
-            { name: 'Workflow__LogAnalyticsWorkspaceKey', secretRef: 'log-analytics-workspace-key' }
             { name: 'Workflow__UpdaterContainerImageTemplate', value: 'ghcr.io/tinglesoftware/dependabot-updater-{{ecosystem}}:${imageTag}' }
             { name: 'Workflow__FailOnException', value: failOnException ? 'true' : 'false' }
             { name: 'Workflow__AutoComplete', value: autoComplete ? 'true' : 'false' }
@@ -312,9 +311,6 @@ resource app 'Microsoft.App/containerApps@2023-05-01' = {
             { name: 'Workflow__AutoApprove', value: autoApprove ? 'true' : 'false' }
             { name: 'Workflow__GithubToken', value: githubToken }
             { name: 'Workflow__Location', value: location }
-            { name: 'Workflow__StorageAccountName', value: storageAccount.name }
-            { name: 'Workflow__StorageAccountKey', secretRef: 'storage-account-key' }
-            { name: 'Workflow__FileShareName', value: fileShareName }
 
             {
               name: 'Authentication__Schemes__Management__Authority'

--- a/server/main.json
+++ b/server/main.json
@@ -376,10 +376,6 @@
               "value": "[parameters('projectToken')]"
             },
             {
-              "name": "log-analytics-workspace-key",
-              "value": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), '2022-10-01').primarySharedKey]"
-            },
-            {
               "name": "storage-account-key",
               "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', format('{0}{1}', parameters('name'), variables('collisionSuffix'))), '2022-09-01').keys[0].value]"
             },
@@ -466,12 +462,12 @@
                   "value": "[resourceGroup().id]"
                 },
                 {
-                  "name": "Workflow__LogAnalyticsWorkspaceId",
-                  "value": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), '2022-10-01').customerId]"
+                  "name": "Workflow__AppEnvironmentId",
+                  "value": "[resourceId('Microsoft.App/managedEnvironments', parameters('name'))]"
                 },
                 {
-                  "name": "Workflow__LogAnalyticsWorkspaceKey",
-                  "secretRef": "log-analytics-workspace-key"
+                  "name": "Workflow__LogAnalyticsWorkspaceId",
+                  "value": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('name')), '2022-10-01').customerId]"
                 },
                 {
                   "name": "Workflow__UpdaterContainerImageTemplate",
@@ -504,18 +500,6 @@
                 {
                   "name": "Workflow__Location",
                   "value": "[parameters('location')]"
-                },
-                {
-                  "name": "Workflow__StorageAccountName",
-                  "value": "[format('{0}{1}', parameters('name'), variables('collisionSuffix'))]"
-                },
-                {
-                  "name": "Workflow__StorageAccountKey",
-                  "secretRef": "storage-account-key"
-                },
-                {
-                  "name": "Workflow__FileShareName",
-                  "value": "[variables('fileShareName')]"
                 },
                 {
                   "name": "Authentication__Schemes__Management__Authority",


### PR DESCRIPTION
ContainerApp Jobs are easier to manage and startup faster as compared to ContainerGroups/ContainerInstances. This PR changes the deployment of jobs to the former.

This change will also allow the use of the new update with network restrictions in the future which would have been lots of plumbing work with ContainerInstances.

Running of schedules updates is still triggered using the main application for tracking purposes and also because of timezone and cron validation issues in ContainerApp Jobs. There may be no need to migrate that anyway.