### PR TITLE
Replace VSTS/TFS/AzureDevOps libraries

### DIFF
--- a/server/Tingle.Dependabot/Extensions/IServiceCollectionExtensions.cs
+++ b/server/Tingle.Dependabot/Extensions/IServiceCollectionExtensions.cs
@@ -86,7 +86,7 @@ public static class IServiceCollectionExtensions
         services.AddScoped<UpdateRunner>();
         services.AddSingleton<UpdateScheduler>();
 
-        services.AddScoped<AzureDevOpsProvider>();
+        services.AddHttpClient<AzureDevOpsProvider>();
         services.AddScoped<Synchronizer>();
 
         return services;

--- a/server/Tingle.Dependabot/Models/Azure/AzdoProject.cs
+++ b/server/Tingle.Dependabot/Models/Azure/AzdoProject.cs
@@ -16,30 +16,3 @@ public class AzdoProject
     [JsonPropertyName("lastUpdateTime")]
     public required DateTimeOffset LastUpdatedTime { get; set; }
 }
-
-public class AzdoGitRepository
-{
-    [JsonPropertyName("id")]
-    public required string Id { get; set; }
-
-    [JsonPropertyName("name")]
-    public required string Name { get; set; }
-
-    [JsonPropertyName("project")]
-    public required AzdoProject Project { get; set; }
-
-    [JsonPropertyName("isDisabled")]
-    public required bool IsDisabled { get; set; }
-
-    [JsonPropertyName("isFork")]
-    public required bool IsFork { get; set; }
-}
-
-internal class AzdoListResponse<T> where T : class
-{
-    [JsonPropertyName("value")]
-    public required List<T> Value { get; set; }
-
-    [JsonPropertyName("count")]
-    public required int Count { get; set; }
-}

--- a/server/Tingle.Dependabot/Models/Azure/AzdoProject.cs
+++ b/server/Tingle.Dependabot/Models/Azure/AzdoProject.cs
@@ -16,3 +16,21 @@ public class AzdoProject
     [JsonPropertyName("lastUpdateTime")]
     public required DateTimeOffset LastUpdatedTime { get; set; }
 }
+
+public class AzdoGitRepository
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("project")]
+    public required AzdoProject Project { get; set; }
+
+    [JsonPropertyName("isDisabled")]
+    public required bool IsDisabled { get; set; }
+
+    [JsonPropertyName("isFork")]
+    public required bool IsFork { get; set; }
+}

--- a/server/Tingle.Dependabot/Models/Azure/AzdoProject.cs
+++ b/server/Tingle.Dependabot/Models/Azure/AzdoProject.cs
@@ -34,3 +34,12 @@ public class AzdoGitRepository
     [JsonPropertyName("isFork")]
     public required bool IsFork { get; set; }
 }
+
+internal class AzdoListResponse<T> where T : class
+{
+    [JsonPropertyName("value")]
+    public required List<T> Value { get; set; }
+
+    [JsonPropertyName("count")]
+    public required int Count { get; set; }
+}

--- a/server/Tingle.Dependabot/Models/Azure/AzdoRepository.cs
+++ b/server/Tingle.Dependabot/Models/Azure/AzdoRepository.cs
@@ -14,10 +14,10 @@ public class AzdoRepository
     public required AzdoProject Project { get; set; }
 
     [JsonPropertyName("isDisabled")]
-    public required bool IsDisabled { get; set; }
+    public bool IsDisabled { get; set; }
 
     [JsonPropertyName("isFork")]
-    public required bool IsFork { get; set; }
+    public bool IsFork { get; set; }
 }
 
 public class AzdoListResponse<T> where T : class

--- a/server/Tingle.Dependabot/Models/Azure/AzdoRepository.cs
+++ b/server/Tingle.Dependabot/Models/Azure/AzdoRepository.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Tingle.Dependabot.Models.Azure;
+
+public class AzdoRepository
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("project")]
+    public required AzdoProject Project { get; set; }
+
+    [JsonPropertyName("isDisabled")]
+    public required bool IsDisabled { get; set; }
+
+    [JsonPropertyName("isFork")]
+    public required bool IsFork { get; set; }
+}
+
+public class AzdoListResponse<T> where T : class
+{
+    [JsonPropertyName("value")]
+    public required List<T> Value { get; set; }
+
+    [JsonPropertyName("count")]
+    public required int Count { get; set; }
+}

--- a/server/Tingle.Dependabot/Models/Azure/AzdoRepositoryItem.cs
+++ b/server/Tingle.Dependabot/Models/Azure/AzdoRepositoryItem.cs
@@ -1,0 +1,68 @@
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace Tingle.Dependabot.Models.Azure;
+
+public class AzdoRepositoryItem
+{
+    [JsonPropertyName("objectId")]
+    public required string ObjectId { get; set; }
+
+    [JsonPropertyName("originalObjectId")]
+    public string? OriginalObjectId { get; set; }
+
+    [JsonPropertyName("gitObjectType")]
+    public required AzdoRepositoryItemType GitObjectType { get; set; }
+
+    [JsonPropertyName("commitId")]
+    public required string CommitId { get; set; }
+
+    [JsonPropertyName("latestProcessedChange")]
+    public required AzdoCommitRef LatestProcessedChange { get; set; }
+
+    [JsonPropertyName("path")]
+    public required string Path { get; set; }
+
+    [JsonPropertyName("isFolder")]
+    public bool IsFolder { get; set; }
+
+    [JsonPropertyName("content")]
+    public required string Content { get; set; }
+
+    [JsonPropertyName("isSymLink")]
+    public bool IsSymbolicLink { get; set; }
+}
+
+[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+public enum AzdoRepositoryItemType
+{
+    [EnumMember(Value = "bad")]
+    Bad,
+
+    [EnumMember(Value = "blob")]
+    Blob,
+
+    [EnumMember(Value = "commit")]
+    Commit,
+
+    [EnumMember(Value = "ext2")]
+    Ext2,
+
+    [EnumMember(Value = "ofsDelta")]
+    OfsDelta,
+
+    [EnumMember(Value = "refDelta")]
+    RefDelta,
+
+    [EnumMember(Value = "tree")]
+    Tree,
+
+    [EnumMember(Value = "tag")]
+    Tag,
+}
+
+public class AzdoCommitRef
+{
+    [JsonPropertyName("commitId")]
+    public required string CommitId { get; set; }
+}

--- a/server/Tingle.Dependabot/Models/Azure/AzdoSubscriptionsQuery.cs
+++ b/server/Tingle.Dependabot/Models/Azure/AzdoSubscriptionsQuery.cs
@@ -1,0 +1,119 @@
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace Tingle.Dependabot.Models.Azure;
+
+public class AzdoSubscriptionsQuery
+{
+    [JsonPropertyName("consumerActionId")]
+    public string? ConsumerActionId { get; set; }
+
+    [JsonPropertyName("consumerId")]
+    public string? ConsumerId { get; set; }
+
+    [JsonPropertyName("consumerInputFilters")]
+    public List<AzdoSubscriptionsQueryInputFilter>? ConsumerInputFilters { get; set; }
+
+    [JsonPropertyName("eventType")]
+    public string? EventType { get; set; }
+
+    [JsonPropertyName("publisherId")]
+    public string? PublisherId { get; set; }
+
+    [JsonPropertyName("publisherInputFilters")]
+    public List<AzdoSubscriptionsQueryInputFilter>? PublisherInputFilters { get; set; }
+
+    [JsonPropertyName("subscriberId")]
+    public string? SubscriberId { get; set; }
+}
+
+public class AzdoSubscriptionsQueryInputFilter
+{
+    [JsonPropertyName("conditions")]
+    public List<AzdoSubscriptionsQueryInputFilterCondition>? Conditions { get; set; }
+}
+
+public class AzdoSubscriptionsQueryInputFilterCondition
+{
+    [JsonPropertyName("caseSensitive")]
+    public bool? CaseSensitive { get; set; }
+
+    [JsonPropertyName("inputId")]
+    public string? InputId { get; set; }
+
+    [JsonPropertyName("inputValue")]
+    public string? InputValue { get; set; }
+
+    [JsonPropertyName("operator")]
+    public AzdoSubscriptionsQueryInputFilterOperator Operator { get; set; }
+}
+
+[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+public enum AzdoSubscriptionsQueryInputFilterOperator
+{
+    [EnumMember(Value = "equals")]
+    Equals,
+    [EnumMember(Value = "notEquals")]
+    NotEquals
+}
+
+public class AzdoSubscriptionsQueryResponse : AzdoSubscriptionsQuery
+{
+    [JsonPropertyName("results")]
+    public required List<AzdoSubscription> Results { get; set; }
+}
+
+public class AzdoSubscription
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("status")]
+    public AzdoSubscriptionStatus Status { get; set; }
+
+    [JsonPropertyName("publisherId")]
+    public required string PublisherId { get; set; }
+
+    [JsonPropertyName("publisherInputs")]
+    public Dictionary<string, string> PublisherInputs { get; set; } = new();
+
+    [JsonPropertyName("consumerId")]
+    public string? ConsumerId { get; set; }
+
+    [JsonPropertyName("consumerActionId")]
+    public string? ConsumerActionId { get; set; }
+
+    [JsonPropertyName("consumerInputs")]
+    public Dictionary<string, string> ConsumerInputs { get; set; } = new();
+
+    [JsonPropertyName("eventType")]
+    public required string EventType { get; set; }
+
+    [JsonPropertyName("resourceVersion")]
+    public required string ResourceVersion { get; set; }
+
+    [JsonPropertyName("eventDescription")]
+    public string? EventDescription { get; set; }
+
+    [JsonPropertyName("actionDescription")]
+    public string? ActionDescription { get; set; }
+}
+
+[JsonConverter(typeof(JsonStringEnumMemberConverter))]
+public enum AzdoSubscriptionStatus
+{
+    [EnumMember(Value = "enabled")]
+    Enabled,
+
+    [EnumMember(Value = "onProbation")]
+    OnProbation,
+
+    [EnumMember(Value = "disabledByUser")]
+    DisabledByUser,
+
+    [EnumMember(Value = "disabledBySystem")]
+    DisabledBySystem,
+
+    [EnumMember(Value = "disabledByInactiveIdentity")]
+    DisabledByInactiveIdentity,
+}

--- a/server/Tingle.Dependabot/Models/Management/Project.cs
+++ b/server/Tingle.Dependabot/Models/Management/Project.cs
@@ -27,7 +27,7 @@ public class Project
     /// <example>https://dev.azure.com/tingle/dependabot</example>
     [Url]
     [Required]
-    public string? Url { get; set; }
+    public string? Url { get; set; } // TODO: change this to AzureDevOpsProjectUrl when we have converters for JSON and EfCore hence reduce the conversions all over the code
 
     /// <summary>
     /// Token for accessing the project with permissions for repositories, pull requests, and service hooks.

--- a/server/Tingle.Dependabot/Tingle.Dependabot.csproj
+++ b/server/Tingle.Dependabot/Tingle.Dependabot.csproj
@@ -33,8 +33,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.11" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.11" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="2.6.1" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.ServiceHooks.WebApi" Version="19.225.0-preview" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <!-- <PackageReference Include="Tingle.AspNetCore.ApplicationInsights" Version="4.2.1" /> -->
     <PackageReference Include="Tingle.EventBus.Transports.Azure.ServiceBus" Version="0.19.2" />

--- a/server/Tingle.Dependabot/Workflow/AzureDevOpsProvider.cs
+++ b/server/Tingle.Dependabot/Workflow/AzureDevOpsProvider.cs
@@ -191,7 +191,7 @@ public class AzureDevOpsProvider
                     Scheme = url.Scheme,
                     Host = url.Hostname,
                     Port = url.Port ?? -1,
-                    Path = $"{url.OrganizationName}/{url.ProjectIdOrName}/_apis/git/repositories/{repositoryIdOrName}",
+                    Path = $"{url.OrganizationName}/{url.ProjectIdOrName}/_apis/git/repositories/{repositoryIdOrName}/items",
                     Query = $"?path={path}&includeContent=true&latestProcessedChange=true&api-version=7.0"
                 }.Uri;
                 var request = new HttpRequestMessage(HttpMethod.Get, uri);

--- a/server/Tingle.Dependabot/Workflow/AzureDevOpsProvider.cs
+++ b/server/Tingle.Dependabot/Workflow/AzureDevOpsProvider.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.VisualStudio.Services.Common;
-using Microsoft.VisualStudio.Services.FormInput;
-using Microsoft.VisualStudio.Services.ServiceHooks.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
@@ -46,28 +43,21 @@ public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|
 
     public async Task<List<string>> CreateOrUpdateSubscriptionsAsync(Project project, CancellationToken cancellationToken = default)
     {
-        // get a connection to Azure DevOps
-        var url = (AzureDevOpsProjectUrl)project.Url!;
-        var connection = CreateVssConnection(url, project.Token!);
-
-        // get the projectId
-        var projectId = (await (await connection.GetClientAsync<ProjectHttpClient>(cancellationToken)).GetProject(url.ProjectIdOrName)).Id.ToString();
-
-        // fetch the subscriptions
-        var client = await connection.GetClientAsync<ServiceHooksPublisherHttpClient>(cancellationToken);
-        var subscriptions = (await client.QuerySubscriptionsAsync(new SubscriptionsQuery
+        // prepare the query
+        var projectId = project.ProviderId ?? throw new InvalidOperationException("ProviderId for the project cannot be null");
+        var query = new AzdoSubscriptionsQuery
         {
             PublisherId = "tfs",
-            PublisherInputFilters = new List<InputFilter>
+            PublisherInputFilters = new List<AzdoSubscriptionsQueryInputFilter>
             {
-                new InputFilter
+                new AzdoSubscriptionsQueryInputFilter
                 {
-                    Conditions = new List<InputFilterCondition>
+                    Conditions = new List<AzdoSubscriptionsQueryInputFilterCondition>
                     {
-                        new InputFilterCondition
+                        new AzdoSubscriptionsQueryInputFilterCondition
                         {
                             InputId = "projectId",
-                            Operator = InputFilterOperator.Equals,
+                            Operator = AzdoSubscriptionsQueryInputFilterOperator.Equals,
                             InputValue = projectId,
                         },
                     },
@@ -76,14 +66,28 @@ public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|
 
             ConsumerId = "webHooks",
             ConsumerActionId = "httpRequest",
-        })).Results;
+        };
 
+        // fetch the subscriptions
+        var url = (AzureDevOpsProjectUrl)project.Url!;
+        var uri = new UriBuilder
+        {
+            Scheme = url.Scheme,
+            Host = url.Hostname,
+            Port = url.Port ?? -1,
+            Path = $"{url.OrganizationName}/_apis/hooks/subscriptionsquery",
+            Query = "?api-version=7.0",
+        }.Uri;
+        var request = new HttpRequestMessage(HttpMethod.Post, uri) { Content = JsonContent.Create(query), };
+        var subscriptions = (await SendAsync<AzdoSubscriptionsQueryResponse>(project.Token!, request, cancellationToken)).Results;
+
+        // iterate each subscription checking if creation or update is required
         var webhookUrl = options.WebhookEndpoint!;
         var ids = new List<string>();
         foreach (var (eventType, resourceVersion) in SubscriptionEventTypes)
         {
             // find an existing one
-            Subscription? existing = null;
+            AzdoSubscription? existing = null;
             foreach (var sub in subscriptions)
             {
                 if (sub.EventType == eventType
@@ -104,11 +108,13 @@ public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|
                 existing.ResourceVersion = resourceVersion;
                 existing.PublisherInputs = MakeTfsPublisherInputs(eventType, projectId);
                 existing.ConsumerInputs = MakeWebHooksConsumerInputs(project, webhookUrl);
-                existing = await client.UpdateSubscriptionAsync(existing);
+                uri = new UriBuilder(uri) { Path = $"{url.OrganizationName}/_apis/hooks/subscriptions/{existing.Id}", }.Uri;
+                request = new HttpRequestMessage(HttpMethod.Put, uri) { Content = JsonContent.Create(existing), };
+                existing = await SendAsync<AzdoSubscription>(project.Token!, request, cancellationToken);
             }
             else
             {
-                existing = new Subscription
+                existing = new AzdoSubscription
                 {
                     EventType = eventType,
                     ResourceVersion = resourceVersion,
@@ -119,11 +125,13 @@ public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|
                     ConsumerActionId = "httpRequest",
                     ConsumerInputs = MakeWebHooksConsumerInputs(project, webhookUrl),
                 };
-                existing = await client.CreateSubscriptionAsync(existing);
+                uri = new UriBuilder(uri) { Path = $"{url.OrganizationName}/_apis/hooks/subscriptions", }.Uri;
+                request = new HttpRequestMessage(HttpMethod.Post, uri) { Content = JsonContent.Create(existing), };
+                existing = await SendAsync<AzdoSubscription>(project.Token!, request, cancellationToken);
             }
 
             // track the identifier of the subscription
-            ids.Add(existing.Id.ToString());
+            ids.Add(existing.Id!);
         }
 
         return ids;
@@ -144,7 +152,7 @@ public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|
         return await SendAsync<AzdoProject>(project.Token!, request, cancellationToken);
     }
 
-    public async Task<List<AzdoGitRepository>> GetRepositoriesAsync(Project project, CancellationToken cancellationToken)
+    public async Task<List<AzdoRepository>> GetRepositoriesAsync(Project project, CancellationToken cancellationToken)
     {
         var url = (AzureDevOpsProjectUrl)project.Url!;
         var uri = new UriBuilder
@@ -156,11 +164,11 @@ public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|
             Query = "?api-version=7.0",
         }.Uri;
         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-        var data = await SendAsync<AzdoListResponse<AzdoGitRepository>>(project.Token!, request, cancellationToken);
+        var data = await SendAsync<AzdoListResponse<AzdoRepository>>(project.Token!, request, cancellationToken);
         return data.Value;
     }
 
-    public async Task<AzdoGitRepository> GetRepositoryAsync(Project project, string repositoryIdOrName, CancellationToken cancellationToken)
+    public async Task<AzdoRepository> GetRepositoryAsync(Project project, string repositoryIdOrName, CancellationToken cancellationToken)
     {
         var url = (AzureDevOpsProjectUrl)project.Url!;
         var uri = new UriBuilder
@@ -172,7 +180,7 @@ public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|
             Query = "?api-version=7.0",
         }.Uri;
         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-        return await SendAsync<AzdoGitRepository>(project.Token!, request, cancellationToken);
+        return await SendAsync<AzdoRepository>(project.Token!, request, cancellationToken);
     }
 
     public async Task<GitItem?> GetConfigurationFileAsync(Project project, string repositoryIdOrName, CancellationToken cancellationToken = default)

--- a/server/Tingle.Dependabot/Workflow/AzureDevOpsProvider.cs
+++ b/server/Tingle.Dependabot/Workflow/AzureDevOpsProvider.cs
@@ -6,7 +6,7 @@ using Tingle.Dependabot.Models.Management;
 
 namespace Tingle.Dependabot.Workflow;
 
-public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|VisualStudio) libraries with direct usage of HttpClient
+public class AzureDevOpsProvider
 {
     // Possible/allowed paths for the configuration files in a repository.
     private static readonly IReadOnlyList<string> ConfigurationFilePaths = new[] {
@@ -26,11 +26,12 @@ public class AzureDevOpsProvider // TODO: replace the Microsoft.(TeamFoundation|
         ("ms.vss-code.git-pullrequest-comment-event", "2.0"),
     };
 
-    private readonly HttpClient httpClient = new(); // TODO: consider injecting this for logging and tracing purposes
+    private readonly HttpClient httpClient;
     private readonly WorkflowOptions options;
 
-    public AzureDevOpsProvider(IOptions<WorkflowOptions> optionsAccessor)
+    public AzureDevOpsProvider(HttpClient httpClient, IOptions<WorkflowOptions> optionsAccessor)
     {
+        this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
     }
 

--- a/server/Tingle.Dependabot/Workflow/SynchronizerConfigurationItem.cs
+++ b/server/Tingle.Dependabot/Workflow/SynchronizerConfigurationItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Tingle.Dependabot.Models.Azure;
 
 namespace Tingle.Dependabot.Workflow;
 
@@ -8,6 +9,16 @@ public readonly record struct SynchronizerConfigurationItem(string Id, string Na
                                          Microsoft.TeamFoundation.SourceControl.WebApi.GitRepository repo,
                                          Microsoft.TeamFoundation.SourceControl.WebApi.GitItem? item)
         : this(Id: repo.Id.ToString(),
+               Name: repo.Name,
+               Slug: slug,
+               CommitId: item?.LatestProcessedChange.CommitId,
+               Content: item?.Content)
+    { }
+
+    public SynchronizerConfigurationItem(string slug,
+                                         AzdoGitRepository repo,
+                                         Microsoft.TeamFoundation.SourceControl.WebApi.GitItem? item)
+        : this(Id: repo.Id,
                Name: repo.Name,
                Slug: slug,
                CommitId: item?.LatestProcessedChange.CommitId,

--- a/server/Tingle.Dependabot/Workflow/SynchronizerConfigurationItem.cs
+++ b/server/Tingle.Dependabot/Workflow/SynchronizerConfigurationItem.cs
@@ -6,7 +6,7 @@ namespace Tingle.Dependabot.Workflow;
 public readonly record struct SynchronizerConfigurationItem(string Id, string Name, string Slug, string? CommitId, string? Content)
 {
     public SynchronizerConfigurationItem(string slug,
-                                         AzdoGitRepository repo,
+                                         AzdoRepository repo,
                                          Microsoft.TeamFoundation.SourceControl.WebApi.GitItem? item)
         : this(Id: repo.Id,
                Name: repo.Name,

--- a/server/Tingle.Dependabot/Workflow/SynchronizerConfigurationItem.cs
+++ b/server/Tingle.Dependabot/Workflow/SynchronizerConfigurationItem.cs
@@ -7,7 +7,7 @@ public readonly record struct SynchronizerConfigurationItem(string Id, string Na
 {
     public SynchronizerConfigurationItem(string slug,
                                          AzdoRepository repo,
-                                         Microsoft.TeamFoundation.SourceControl.WebApi.GitItem? item)
+                                         AzdoRepositoryItem? item)
         : this(Id: repo.Id,
                Name: repo.Name,
                Slug: slug,

--- a/server/Tingle.Dependabot/Workflow/SynchronizerConfigurationItem.cs
+++ b/server/Tingle.Dependabot/Workflow/SynchronizerConfigurationItem.cs
@@ -6,16 +6,6 @@ namespace Tingle.Dependabot.Workflow;
 public readonly record struct SynchronizerConfigurationItem(string Id, string Name, string Slug, string? CommitId, string? Content)
 {
     public SynchronizerConfigurationItem(string slug,
-                                         Microsoft.TeamFoundation.SourceControl.WebApi.GitRepository repo,
-                                         Microsoft.TeamFoundation.SourceControl.WebApi.GitItem? item)
-        : this(Id: repo.Id.ToString(),
-               Name: repo.Name,
-               Slug: slug,
-               CommitId: item?.LatestProcessedChange.CommitId,
-               Content: item?.Content)
-    { }
-
-    public SynchronizerConfigurationItem(string slug,
                                          AzdoGitRepository repo,
                                          Microsoft.TeamFoundation.SourceControl.WebApi.GitItem? item)
         : this(Id: repo.Id,


### PR DESCRIPTION
Replace VSTS/TFS/AzureDevOps libraries with plain HttpClient usage because it is faster and easier to test