### PR TITLE
Pass commit options via an ENV in JSON hence no need to parse the config file in Ruby

### DIFF
--- a/docs/updater.md
+++ b/docs/updater.md
@@ -19,6 +19,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS=<your-extra-credentials> \
            -e DEPENDABOT_ALLOW_CONDITIONS=<your-allowed-packages> \
            -e DEPENDABOT_IGNORE_CONDITIONS=<your-ignored-packages> \
+           -e DEPENDABOT_COMMIT_MESSAGE_OPTIONS=<your-commit-message-options> \
            -e DEPENDABOT_BRANCH_NAME_SEPARATOR=<your-custom-separator> \
            -e DEPENDABOT_MILESTONE=<your-work-item-id> \
            -e DEPENDABOT_UPDATER_OPTIONS=<your-updater-options> \
@@ -49,6 +50,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]' \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{"dependency-name":"django*","dependency-type":"direct"}]' \
            -e DEPENDABOT_IGNORE_CONDITIONS='[{"dependency-name":"@types/*"}]' \
+           -e DEPENDABOT_COMMIT_MESSAGE_OPTIONS='{"prefix":"(dependabot)"}' \
            -e DEPENDABOT_BRANCH_NAME_SEPARATOR='/' \
            -e DEPENDABOT_MILESTONE=123 \
            -e DEPENDABOT_UPDATER_OPTIONS='goprivate=true,kubernetes_updates=true' \
@@ -76,6 +78,7 @@ docker run --rm -t \
            -e DEPENDABOT_EXTRA_CREDENTIALS='[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]' \
            -e DEPENDABOT_ALLOW_CONDITIONS='[{"dependency-name":"django*","dependency-type":"direct"}]' \
            -e DEPENDABOT_IGNORE_CONDITIONS='[{"dependency-name":"@types/*"}]' \
+           -e DEPENDABOT_COMMIT_MESSAGE_OPTIONS='{"prefix":"(dependabot)"}' \
            -e DEPENDABOT_BRANCH_NAME_SEPARATOR='/' \
            -e DEPENDABOT_MILESTONE=123 \
            -e DEPENDABOT_UPDATER_OPTIONS='goprivate=true,kubernetes_updates=true' \
@@ -108,6 +111,7 @@ To run the script, some environment variables are required.
 |DEPENDABOT_EXTRA_CREDENTIALS|**_Optional_**. The extra credentials in JSON format. Extra credentials can be used to access private NuGet feeds, docker registries, maven repositories, etc. For example a private registry authentication (For example FontAwesome Pro: `[{"type":"npm_registry","token":"<redacted>","registry":"npm.fontawesome.com"}]`)|
 |DEPENDABOT_ALLOW_CONDITIONS|**_Optional_**. The dependencies whose updates are allowed, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":"django*",\"dependency-type\":\"direct\"}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow) for more.|
 |DEPENDABOT_IGNORE_CONDITIONS|**_Optional_**. The dependencies to be ignored, in JSON format. This can be used to control which packages can be updated. For example: `[{\"dependency-name\":\"express\",\"versions\":[\"4.x\",\"5.x\"]}]`. See [official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) for more.|
+|DEPENDABOT_COMMIT_MESSAGE_OPTIONS|**_Optional_**. The commit message options, in JSON format. For example: `{\"prefix\":\"(dependabot)\"}`. See [official docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message) for more.|
 |DEPENDABOT_LABELS|**_Optional_**. The custom labels to be used, in JSON format. This can be used to override the default values. For example: `[\"npm dependencies\",\"triage-board\"]`. See [official docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#setting-custom-labels) for more.|
 |DEPENDABOT_REVIEWERS|**_Optional_**. The identifiers of the users to review the pull requests, in JSON format. These shall be added as optional approvers. For example: `[\"23d9f23d-981e-4a0c-a975-8e5c665914ec\",\"62b67ef1-58e9-4be9-83d3-690a6fc67d6b\"]`.
 |DEPENDABOT_ASSIGNEES|**_Optional_**. The identifiers of the users to be assigned to the pull requests, in JSON format. These shall be added as required approvers. For example: `[\"be9321e2-f404-4ffa-8d6b-44efddb04865\"]`. |

--- a/extension/task/IDependabotConfig.ts
+++ b/extension/task/IDependabotConfig.ts
@@ -48,6 +48,7 @@ export interface IDependabotUpdate {
    * Assignees.
    */
   assignees?: string;
+  commitMessage?: string;
   /**
    * The milestone to associate pull requests with.
    */
@@ -92,7 +93,7 @@ export interface IDependabotRegistry {
    * The protocol is optional. If not specified, `https://` is assumed.
    */
   url?: string | null | undefined;
-  "index-url"?: string | null | undefined; // only flor python_index
+  "index-url"?: string | null | undefined; // only for python_index
 
   /**
    * The URL of the registry to use to access the dependencies.

--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -110,6 +110,12 @@ async function run() {
         dockerRunner.arg(["-e", `DEPENDABOT_IGNORE_CONDITIONS=${ignore}`]);
       }
 
+      // Set the commit message options
+      let commitMessage = update.commitMessage;
+      if (commitMessage) {
+        dockerRunner.arg(["-e", `DEPENDABOT_COMMIT_MESSAGE_OPTIONS=${commitMessage}`]);
+      }
+
       // Set the requirements that should not be unlocked
       if (variables.excludeRequirementsToUnlock) {
         dockerRunner.arg(["-e", `DEPENDABOT_EXCLUDE_REQUIREMENTS_TO_UNLOCK=${variables.excludeRequirementsToUnlock}`]);

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -191,6 +191,9 @@ function parseUpdates(config: any): IDependabotUpdate[] {
       assignees: update["assignees"]
         ? JSON.stringify(update["assignees"])
         : undefined,
+      commitMessage: update["commit-message"]
+        ? JSON.stringify(update["commit-message"])
+        : undefined,
     };
 
     if (!dependabotUpdate.packageEcosystem) {

--- a/server/Tingle.Dependabot/Models/Dependabot/DependabotConfiguration.cs
+++ b/server/Tingle.Dependabot/Models/Dependabot/DependabotConfiguration.cs
@@ -63,6 +63,8 @@ public record DependabotUpdate
     public List<DependabotAllowDependency>? Allow { get; set; }
     [JsonPropertyName("ignore")]
     public List<DependabotIgnoreDependency>? Ignore { get; set; }
+    [JsonPropertyName("commit-message")]
+    public DependabotCommitMessage? CommitMessage { get; set; }
     [JsonPropertyName("labels")]
     public List<string>? Labels { get; set; }
     [JsonPropertyName("milestone")]
@@ -151,6 +153,18 @@ public class DependabotIgnoreDependency : IValidatableObject
             yield return new ValidationResult("Each entry under 'ignore' must have one of 'dependency-name', 'versions', or 'update-types' set");
         }
     }
+}
+
+public class DependabotCommitMessage
+{
+    [JsonPropertyName("prefix")]
+    public string? Prefix { get; set; }
+
+    [JsonPropertyName("prefix-development")]
+    public string? PrefixDevelopment { get; set; }
+
+    [JsonPropertyName("include")]
+    public string? Include { get; set; }
 }
 
 public class DependabotPullRequestBranchName

--- a/server/Tingle.Dependabot/Workflow/UpdateRunner.cs
+++ b/server/Tingle.Dependabot/Workflow/UpdateRunner.cs
@@ -275,6 +275,7 @@ internal partial class UpdateRunner
               .AddIfNotDefault("DEPENDABOT_VERSIONING_STRATEGY", update.VersioningStrategy)
               .AddIfNotDefault("DEPENDABOT_ALLOW_CONDITIONS", ToJson(update.Allow))
               .AddIfNotDefault("DEPENDABOT_IGNORE_CONDITIONS", ToJson(update.Ignore))
+              .AddIfNotDefault("DEPENDABOT_COMMIT_MESSAGE_OPTIONS", ToJson(update.CommitMessage))
               .AddIfNotDefault("DEPENDABOT_LABELS", ToJson(update.Labels))
               .AddIfNotDefault("DEPENDABOT_BRANCH_NAME_SEPARATOR", update.PullRequestBranchName?.Separator)
               .AddIfNotDefault("DEPENDABOT_MILESTONE", update.Milestone?.ToString());


### PR DESCRIPTION
In depndabot's version [0.237.0](https://github.com/dependabot/dependabot-core/releases/tag/v0.237.0), types have been introduced in numerous types. In particular, the changes in `Dependabot::Config::UpdateConfig` and `Dependabot::Config::File` result in failing builds when parsing the configuration file because of extra properties (registries). 

To solve the issue:
1. Pass the value in `ignore` via ENV as done in #884 
2. Pass the value in `commit-message` via ENV (this PR)

Consequently, this fixes BOM issues with `commit-message` and removes the need to parse the configuration file in the Ruby script.

Fixes: #861 