### PR TITLE
Fix typo in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,7 @@ updates:
       patterns:
       - "Tingle.AspNetCore.*"
       - "Tingle.Extensions.*"
-    xuint:
+    xunint:
       patterns: ["Xunit*"]
 
 - package-ecosystem: "npm" # See documentation for possible values


### PR DESCRIPTION
xUnit dependency group name had a typo.