### PR TITLE
Allow overriding the value for the updater version per ecosystem hence fix the one for NuGet to 1.24

### DIFF
--- a/server/Tingle.Dependabot/Workflow/UpdateRunner.cs
+++ b/server/Tingle.Dependabot/Workflow/UpdateRunner.cs
@@ -70,10 +70,12 @@ internal partial class UpdateRunner
 
         // prepare the container
         var volumeName = "working-dir";
+        var ecosystem = job.PackageEcosystem!;
+        var updaterImageTag = options.UpdaterImageTags.GetValueOrDefault(ecosystem, project.UpdaterImageTag ?? options.UpdaterImageTag);
         var container = new ContainerAppContainer
         {
             Name = UpdaterContainerName,
-            Image = $"ghcr.io/tinglesoftware/dependabot-updater-{job.PackageEcosystem}:{project.UpdaterImageTag ?? options.UpdaterImageTag}",
+            Image = $"ghcr.io/tinglesoftware/dependabot-updater-{ecosystem}:{updaterImageTag}",
             Resources = job.Resources!,
             Args = { useV2 ? "update_files" : "update_script", },
             VolumeMounts = { new ContainerAppVolumeMount { VolumeName = volumeName, MountPath = options.WorkingDirectory, }, },
@@ -113,7 +115,7 @@ internal partial class UpdateRunner
             Tags =
             {
                 ["purpose"] = "dependabot",
-                ["ecosystem"] = job.PackageEcosystem,
+                ["ecosystem"] = ecosystem,
                 ["repository"] = job.RepositorySlug,
                 ["directory"] = job.Directory,
                 ["machine-name"] = Environment.MachineName,

--- a/server/Tingle.Dependabot/Workflow/WorkflowOptions.cs
+++ b/server/Tingle.Dependabot/Workflow/WorkflowOptions.cs
@@ -31,6 +31,14 @@ public class WorkflowOptions
     public string? UpdaterImageTag { get; set; }
 
     /// <summary>
+    /// Versions of the updater docker container images to use per ecosystem.
+    /// Keeping this value fixed in code is important so that the code that depends on it always works.
+    /// If no value is provided for an ecosystem, the default version is used.
+    /// </summary>
+    /// <example>1.20</example>
+    public Dictionary<string, string?> UpdaterImageTags { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Root working directory where file are written during job scheduling and execution.
     /// This directory is the root for all jobs.
     /// Subdirectories are created for each job and further for each usage type.

--- a/server/main.bicep
+++ b/server/main.bicep
@@ -107,6 +107,10 @@ resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2023-0
       '${managedIdentity.id}': {/*ttk bug*/ }
     }
   }
+
+  // override the default updater image tag for nuget jobs
+  // TODO: remove this here and on Azure once the authentication issues are resolved (https://github.com/tinglesoftware/dependabot-azure-devops/issues/921)
+  resource nugetVersion 'keyValues' = { name: 'Workflow:UpdaterImageTags:nuget', properties: { contentType: 'text/plain', value: '1.24' } }
 }
 
 /* Storage Account */

--- a/server/main.json
+++ b/server/main.json
@@ -152,6 +152,18 @@
       ]
     },
     {
+      "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
+      "apiVersion": "2023-03-01",
+      "name": "[format('{0}/{1}', parameters('name'), 'Workflow:UpdaterImageTags:nuget')]",
+      "properties": {
+        "contentType": "text/plain",
+        "value": "1.24"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.AppConfiguration/configurationStores', parameters('name'))]"
+      ]
+    },
+    {
       "copy": {
         "name": "shares",
         "count": "[length(variables('fileShares'))]"


### PR DESCRIPTION
This allows passing security and other updates to other ecosystems and the server component while fixing the updater job version for an ecosystem. For example, nuget with private feeds works with 1.24