### PR TITLE
Fix missing module name when referencing RequirementsUpdateStrategy

### DIFF
--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -178,10 +178,10 @@ end
 unless ENV["DEPENDABOT_VERSIONING_STRATEGY"].to_s.strip.empty?
   # [Hash<String, Symbol>]
   VERSIONING_STRATEGIES = {
-    "lockfile-only" => RequirementsUpdateStrategy::LockfileOnly,
-    "widen" => RequirementsUpdateStrategy::WidenRanges,
-    "increase" => RequirementsUpdateStrategy::BumpVersions,
-    "increase-if-necessary" => RequirementsUpdateStrategy::BumpVersionsIfNecessary
+    "lockfile-only" => Dependabot::RequirementsUpdateStrategy::LockfileOnly,
+    "widen" => Dependabot::RequirementsUpdateStrategy::WidenRanges,
+    "increase" => Dependabot::RequirementsUpdateStrategy::BumpVersions,
+    "increase-if-necessary" => Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary
   }.freeze
   strategy_raw = ENV.fetch("DEPENDABOT_VERSIONING_STRATEGY", nil)
   $options[:requirements_update_strategy] = case strategy_raw
@@ -195,8 +195,8 @@ unless ENV["DEPENDABOT_VERSIONING_STRATEGY"].to_s.strip.empty?
   # https://github.com/dependabot/dependabot-core/blob/5926b243b2875ad0d8c0a52c09210c4f5f274c5e/composer/lib/dependabot/composer/update_checker/requirements_updater.rb#L23-L24
   if $package_manager == "npm_and_yarn" || $package_manager == "composer"
     strategy = $options[:requirements_update_strategy]
-    if strategy.nil? || strategy == RequirementsUpdateStrategy::LockfileOnly
-      $options[:requirements_update_strategy] = RequirementsUpdateStrategy::BumpVersions
+    if strategy.nil? || strategy == Dependabot::RequirementsUpdateStrategy::LockfileOnly
+      $options[:requirements_update_strategy] = Dependabot::RequirementsUpdateStrategy::BumpVersions
     end
   end
 
@@ -204,8 +204,8 @@ unless ENV["DEPENDABOT_VERSIONING_STRATEGY"].to_s.strip.empty?
   # https://github.com/dependabot/dependabot-core/blob/ca9f236591ba49fa6e2a8d5f06e538614033a628/pub/lib/dependabot/pub/update_checker.rb#L110
   if $package_manager == "pub"
     strategy = $options[:requirements_update_strategy]
-    if strategy == RequirementsUpdateStrategy::LockfileOnly
-      $options[:requirements_update_strategy] = RequirementsUpdateStrategy::BumpVersions
+    if strategy == Dependabot::RequirementsUpdateStrategy::LockfileOnly
+      $options[:requirements_update_strategy] = Dependabot::RequirementsUpdateStrategy::BumpVersions
     end
   end
 end


### PR DESCRIPTION
Fixes #1046. 

References to `RequirementsUpdateStrategy` were missing the Dependabot module name and causing "uninitialized constant" errors when `DEPENDABOT_VERSIONING_STRATEGY` was set.

### Error
```log
warning: parser/current is loading parser/ruby33, which recognizes 3.3.3-compliant syntax, but you are running 3.3.1.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
GitHub access token has been provided.
bin/update_script.rb:183:in `<main>': uninitialized constant RequirementsUpdateStrategy (NameError)

    "lockfile-only" => RequirementsUpdateStrategy::LockfileOnly,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
```