### PR TITLE
Add developer guide documentation; ignore extension build artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In this repository you'll find:
 1. Dependabot [updater](./updater) in Ruby. See [docs](./docs/updater.md).
 2. Dockerfile and build/image for running the updater via Docker [here](./updater/Dockerfile).
 3. Dependabot [server](./server/) in .NET/C#. See [docs](./docs/server.md).
-4. Azure DevOps [Extension](https://marketplace.visualstudio.com/items?itemName=tingle-software.dependabot) and [source](./extension).
+4. Azure DevOps [Extension](https://marketplace.visualstudio.com/items?itemName=tingle-software.dependabot) and [source](./extension). See [docs](./docs/extension.md).
 
 > The hosted version is available to sponsors (most, but not all). It includes hustle free runs where the infrastructure is maintained for you. Much like the GitHub hosted version. Alternatively, you can run and host your own [server](./docs/server.md). Once you sponsor, you can send out an email to an maintainer or wait till they reach out. This is meant to ease the burden until GitHub/Azure/Microsoft can get it working natively (which could also be never) and hopefully for free.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,14 @@ Security-only updates ia a mechanism to only create pull requests for dependenci
 
 A GitHub access token with `public_repo` access is required to perform the GitHub GraphQL for `securityVulnerabilities`.
 
-### Acknowledgements
+## Development Guide
+
+If you'd like to contribute to the project or just run it locally, view our development guides for:
+
+- [Azure DevOps extension](./docs/extension.md#development-guide)
+- [Dependabot updater](./docs/updater.md#development-guide)
+
+## Acknowledgements
 
 The work in this repository is based on inspired and occasionally guided by some predecessors in the same area:
 
@@ -78,6 +85,6 @@ The work in this repository is based on inspired and occasionally guided by some
 4. andrcun's work on GitLab: [code](https://gitlab.com/dependabot-gitlab/dependabot)
 5. WeWork's work for GitLab: [code](https://github.com/wemake-services/kira-dependencies)
 
-### Issues &amp; Comments
+## Issues &amp; Comments
 
 Please leave all comments, bugs, requests, and issues on the Issues page. We'll respond to your request ASAP!

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -1,0 +1,46 @@
+
+# Table of Contents
+
+- [Using the extension](#using-the-extension)
+- [Development guide](#development-guide)
+  - [Getting the development environment ready](#getting-the-development-environment-ready)
+  - [Building the extension](#building-the-extension)
+  - [Installing the extension](#installing-the-extension)
+  - [Running the unit tests](#running-the-unit-tests)
+
+# Using the extension
+
+See the extension [README.md](../extension/README.md).
+
+# Development guide
+
+## Getting the development environment ready
+First, ensure you have [Node.js](https://docs.docker.com/engine/install/) v18+ installed.
+Next, install project dependencies with npm:
+
+```bash
+cd extension
+npm install
+```
+
+## Building the extension
+```bash
+cd extension
+npm run build:prod
+npm run mv:prod
+```
+
+To generate the  Azure DevOps `.vsix` extension package for testing, you'll first need to [create a publisher account](https://learn.microsoft.com/en-us/azure/devops/extend/publish/overview?view=azure-devops#create-a-publisher) on the [Visual Studio Marketplace Publishing Portal](https://marketplace.visualstudio.com/manage/createpublisher?managePageRedirect=true). After this, override your publisher ID below and generate the extension with:
+
+```bash
+npx tfx-cli extension create --overrides-file overrides.local.json --override "{\"publisher\": \"your-publisher-id-here\"}" --json5
+```
+
+## Installing the extension
+To test the extension in Azure DevOps, you'll first need to build the extension `.vsix` file (see above). After this, [publish your extension](https://learn.microsoft.com/en-us/azure/devops/extend/publish/overview?view=azure-devops#publish-your-extension), then [install your extension](https://learn.microsoft.com/en-us/azure/devops/extend/publish/overview?view=azure-devops#install-your-extension).
+
+## Running the unit tests
+```bash
+cd extension
+npm run test
+```

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,4 +1,16 @@
-# Running the server
+
+# Table of Contents
+
+- [Why should I use the server?](#why-should-i-use-the-server)
+- [Composition](#composition)
+- [Deployment](#deployment)
+  - [Single click deployment](#single-click-deployment)
+  - [Deployment Parameters](#deployment-parameters)
+  - [Deployment with CLI](#deployment-with-cli)
+  - [Service Hooks and Subscriptions](#service-hooks-and-subscriptions)
+- [Keeping updated](#keeping-updated)
+
+# Why should I use the server?
 
 Running multiple pipelines in Azure DevOps can quickly become overwhelming especially when you have many repositories. In some cases, you might want to keep one pipeline to manage multiple repositories but that can quickly get opaque with over-generalization in templates.
 
@@ -11,17 +23,7 @@ The extension is a good place to start but when you need to roll out across all 
 5. Management UI similar to GitHub-hosted version. *Coming soon*
 6. Zero maintenance, after initial deployment. Also cheap.
 
-## Documentation
-
-- [Composition](#composition)
-- [Deployment](#deployment)
-  - [Deployment with Buttons](#single-click-deployment)
-  - [Deployment Parameters](#deployment-parameters)
-  - [Deployment with CLI](#deployment-with-cli)
-  - [Service Hooks and Subscriptions](#service-hooks-and-subscriptions)
-- [Keeping updated](#keeping-updated)
-
-## Composition
+# Composition
 
 The server is deployed in your Azure Subscription. To function properly, the server component is run as a single application in Azure Container Apps (Consumption Tier), backed by a single Azure SQL Server database (Basic tier), a single Service Bus namespace (Basic tier), and jobs scheduled using Azure Container Instances (Consumption Tier).
 
@@ -33,9 +35,9 @@ The current cost we have internally for this in the `westeurope` region:
 - Azure Container Apps: approx $15/month given about 80% idle time
 - **Total: approx $22/month** (expected to reduce when jobs are added to Azure Container Apps, see https://github.com/microsoft/azure-container-apps/issues/526)
 
-## Deployment
+# Deployment
 
-### Single click deployment
+## Single click deployment
 
 The easiest means of deployment is to use the relevant button below.
 
@@ -45,7 +47,7 @@ The easiest means of deployment is to use the relevant button below.
 
 You can also use the [server/main.json](../server/main.json) file, [server/main.bicep](../server/main.bicep) file, or pull either file from the [latest release](https://github.com/tinglesoftware/dependabot-azure-devops/releases/latest). You will need an Azure subscription and a resource group to deploy to.
 
-### Deployment Parameters
+## Deployment Parameters
 
 The deployment exposes the following parameters that can be tuned to suit the setup.
 
@@ -59,7 +61,7 @@ The deployment exposes the following parameters that can be tuned to suit the se
 
 > The template includes a User Assigned Managed Identity, which is used when performing Azure Resource Manager operations such as deletions. In the deployment it creates the role assignments that it needs. These role assignments are on the resource group that you deploy to.
 
-### Deployment with CLI
+## Deployment with CLI
 
 > Ensure the Azure CLI tools are installed and that you are logged in.
 
@@ -105,11 +107,11 @@ The parameters file (`main.parameters.json`):
 }
 ```
 
-### Service Hooks and Subscriptions
+## Service Hooks and Subscriptions
 
 To enable automatic pickup of configuration files, merge conflict resolution and commands via comments, subscriptions need to be setup on Azure DevOps. You should let the application create them on startup to because it is easier. See [code](https://github.com/tinglesoftware/dependabot-azure-devops/blob/b4e87bfeea133b8e9fa278c98157b7a0123bfdd3/server/Tingle.Dependabot/Workflow/AzureDevOpsProvider.cs#L18-L21) for the list of events subscribed to.
 
-## Keeping updated
+# Keeping updated
 
 If you wish to keep your deployment updated, you can create a private repository with this one as a git submodule, configure dependabot to update it then add a new workflow that deploys to your preferred host using a manual trigger (or one of your choice).
 

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -165,7 +165,7 @@ bundle install
 ```
 
 ## Building the Docker image
-Each package ecosystem must be built seperately; You only need to build images for the ecosystems that you plan on testing.
+Each package ecosystem must be built separately; You only need to build images for the ecosystems that you plan on testing.
 
 ```bash
 docker build \

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -1,3 +1,15 @@
+
+# Table of Contents
+
+- [Running the updater](#running-the-updater)
+  - [Environment variables](#environment-variables)
+- [Development guide](#development-guide)
+  - [Getting the development environment ready](#getting-the-development-environment-ready)
+  - [Building the Docker image](#building-the-docker-image)
+  - [Running your code changes](#running-your-code-changes)
+  - [Running the code linter](#running-the-code-linter)
+  - [Running the unit tests](#running-the-unit-tests)
+
 # Running the updater
 
 First, you need to pull the docker image locally to your machine:
@@ -138,3 +150,44 @@ To run the script, some environment variables are required.
 |AZURE_AUTO_COMPLETE_IGNORE_CONFIG_IDS|**_Optional_**. List of any policy configuration Id's which auto-complete should not wait for. Only applies to optional policies. Auto-complete always waits for required (blocking) policies.|
 |AZURE_AUTO_APPROVE_PR|**_Optional_**. Determines if the pull requests that dependabot creates should be automatically completed. When set to `true`, pull requests will be approved automatically.|
 |AZURE_AUTO_APPROVE_USER_TOKEN|**_Optional_**. A personal access token for the user to automatically approve the created PR. `AZURE_AUTO_APPROVE_PR` must be set to `true` for this to work.|
+
+# Development guide
+
+## Getting the development environment ready
+First, ensure you have [Docker](https://docs.docker.com/engine/install/) and [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installed.
+On Linux, you'll need the the build essentials and Ruby development packages too; These are typically `build-essentials` and `ruby-dev`.
+
+Next, install project build tools with bundle:
+
+```bash
+cd updater
+bundle install
+```
+
+## Building the Docker image
+Each package ecosystem must be built seperately; You only need to build images for the ecosystems that you plan on testing.
+
+```bash
+docker build \
+    -f updater/Dockerfile \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg ECOSYSTEM=<your-ecosystem> \
+    -t "ghcr.io/tinglesoftware/dependabot-updater-<your_ecosystem>:latest" \
+    .
+```
+
+## Running your code changes
+To test run your code changes, you'll first need to build the updater Docker image (see above), then run the updater Docker image in a container with all the required environment variables (see above).
+
+## Running the code linter
+```bash
+cd updater
+bundle exec rubocop
+bundle exec rubocop -a # to automatically fix any correctable offenses
+```
+
+## Running the unit tests
+```bash
+cd updater
+bundle exec rspec spec
+```

--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .taskkey
+task/**/*.js
+*.vsix


### PR DESCRIPTION
Add basic development guide documentation.
Ignore `*.js` and `*.visx` build artifacts in the extension directory.
