### PR TITLE
Use correct version of dependabot-updater base image when running the 'updater' workflow

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -88,6 +88,13 @@ jobs:
       # remove this after at least one release tagged 'latest'
       continue-on-error: true
 
+    - name: Update Dockerfile with correct dependabot-updater image tag
+      run: |
+        tag_name=$(grep -oP "(?<=gem \"dependabot-omnibus\", \"~>).*(?=\")" updater/Gemfile)
+        tag_sha=$(curl "https://api.github.com/repos/dependabot/dependabot-core/tags" | jq -r "[.[]|select(.name==\"v$tag_name\")][0].commit.sha")
+        sed -i "s/dependabot\/dependabot-updater-\$ECOSYSTEM[:.a-z0-9]*/dependabot\/dependabot-updater-\$ECOSYSTEM:$tag_sha/g" updater/Dockerfile
+        echo "Dockerfile updated to use dependabot-updater image tag '$tag_sha' (v$tag_name)"
+
     - name: Build image
       run: |
         docker build \

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Update Dockerfile with correct dependabot-updater image tag
       run: |
         tag_name=$(grep -oP "(?<=gem \"dependabot-omnibus\", \"~>).*(?=\")" updater/Gemfile)
-        tag_sha=$(curl "https://api.github.com/repos/dependabot/dependabot-core/tags" | jq -r "[.[]|select(.name==\"v$tag_name\")][0].commit.sha")
+        tag_sha=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' --url "https://api.github.com/repos/dependabot/dependabot-core/tags" | jq -r "[.[]|select(.name==\"v$tag_name\")][0].commit.sha")
         sed -i "s/dependabot\/dependabot-updater-\$ECOSYSTEM[:.a-z0-9]*/dependabot\/dependabot-updater-\$ECOSYSTEM:$tag_sha/g" updater/Dockerfile
         echo "Dockerfile updated to use dependabot-updater image tag '$tag_sha' (v$tag_name)"
 

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -88,12 +88,13 @@ jobs:
       # remove this after at least one release tagged 'latest'
       continue-on-error: true
 
-    - name: Update Dockerfile with correct dependabot-updater image tag
+    - name: Get dependabot-updater image tag version
+      id: docker-base-version
       run: |
         tag_name=$(grep -oP "(?<=gem \"dependabot-omnibus\", \"~>).*(?=\")" updater/Gemfile)
         tag_sha=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' --url "https://api.github.com/repos/dependabot/dependabot-core/tags" | jq -r "[.[]|select(.name==\"v$tag_name\")][0].commit.sha")
-        sed -i "s/dependabot\/dependabot-updater-\$ECOSYSTEM[:.a-z0-9]*/dependabot\/dependabot-updater-\$ECOSYSTEM:$tag_sha/g" updater/Dockerfile
-        echo "Dockerfile updated to use dependabot-updater image tag '$tag_sha' (v$tag_name)"
+        echo "Using dependabot-updater image tag '$tag_sha' (v$tag_name)"
+        echo "version={$tag_sha}" >> $GITHUB_OUTPUT
 
     - name: Build image
       run: |
@@ -101,6 +102,7 @@ jobs:
         -f updater/Dockerfile \
         --build-arg BUILDKIT_INLINE_CACHE=1 \
         --build-arg ECOSYSTEM=${{ matrix.suite.ecosystem }} \
+        --build-arg BASE_VERSION=${{ steps.docker-base-version.outputs.version }} \
         --label com.github.image.run.id=${{ github.run_id }} \
         --label com.github.image.run.number=${{ github.run_number }} \
         --label com.github.image.job.id=${{ github.job }} \

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -94,7 +94,7 @@ jobs:
         tag_name=$(grep -oP "(?<=gem \"dependabot-omnibus\", \"~>).*(?=\")" updater/Gemfile)
         tag_sha=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' --url "https://api.github.com/repos/dependabot/dependabot-core/tags" | jq -r "[.[]|select(.name==\"v$tag_name\")][0].commit.sha")
         echo "Using dependabot-updater image tag '$tag_sha' (v$tag_name)"
-        echo "version={$tag_sha}" >> $GITHUB_OUTPUT
+        echo "version=$tag_sha" >> $GITHUB_OUTPUT
 
     - name: Build image
       run: |

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -177,8 +177,8 @@ docker build \
     .
 ```
 
-In some scenarios, you may want to set `BASE_VERSION` to a specifc version instead of "latest".
-See [updater/Dockerfile](../updater/Dockerfile) for a more detailed explaination.
+In some scenarios, you may want to set `BASE_VERSION` to a specific version instead of "latest".
+See [updater/Dockerfile](../updater/Dockerfile) for a more detailed explanation.
 
 ## Running your code changes
 To test run your code changes, you'll first need to build the updater Docker image (see above), then run the updater Docker image in a container with all the required environment variables (see above).

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -172,9 +172,13 @@ docker build \
     -f updater/Dockerfile \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     --build-arg ECOSYSTEM=<your-ecosystem> \
+    --build-arg BASE_VERSION=latest \
     -t "ghcr.io/tinglesoftware/dependabot-updater-<your_ecosystem>:latest" \
     .
 ```
+
+In some scenarios, you may want to set `BASE_VERSION` to a specifc version instead of "latest".
+See [updater/Dockerfile](../updater/Dockerfile) for a more detailed explaination.
 
 ## Running your code changes
 To test run your code changes, you'll first need to build the updater Docker image (see above), then run the updater Docker image in a container with all the required environment variables (see above).

--- a/update-files.ps1
+++ b/update-files.ps1
@@ -1,13 +1,3 @@
-# Find the current version for dependabot-omnibus
-$gemfileContent = Get-Content -Path "updater/Gemfile" -Raw
-$versionLine = $gemfileContent | Select-String 'gem "dependabot-omnibus", "(.*)"' | Select-Object -ExpandProperty Line
-$version = [regex]::Match($versionLine, '"~>(\d+\.\d+\.\d+)"').Groups[1].Value
-Write-Output "Found dependabot-omnibus version: $version"
-
-# # Update the version in the Dockerfile
-# $dockerfile = Get-Content -Path "updater/Dockerfile" -Raw
-# $dockerfile = ($dockerfile -replace '(?<=ARG DEPENDABOT_VERSION=)(\d+\.\d+\.\d+)', $version).Trim()
-# $dockerfile | Set-Content -Path "updater/Dockerfile"
 
 # Prepare the list of files to be downloaded
 $files = @(

--- a/update-files.ps1
+++ b/update-files.ps1
@@ -1,3 +1,13 @@
+# Find the current version for dependabot-omnibus
+$gemfileContent = Get-Content -Path "updater/Gemfile" -Raw
+$versionLine = $gemfileContent | Select-String 'gem "dependabot-omnibus", "(.*)"' | Select-Object -ExpandProperty Line
+$version = [regex]::Match($versionLine, '"~>(\d+\.\d+\.\d+)"').Groups[1].Value
+Write-Output "Found dependabot-omnibus version: $version"
+
+# # Update the version in the Dockerfile
+# $dockerfile = Get-Content -Path "updater/Dockerfile" -Raw
+# $dockerfile = ($dockerfile -replace '(?<=ARG DEPENDABOT_VERSION=)(\d+\.\d+\.\d+)', $version).Trim()
+# $dockerfile | Set-Content -Path "updater/Dockerfile"
 
 # Prepare the list of files to be downloaded
 $files = @(

--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -1,6 +1,9 @@
-# The docker images in https://github.com/dependabot/dependabot-core are no longer versioned like the ruby Gems
-#TODO: find out how to lock the base image version without the ruby Gem version
 ARG ECOSYSTEM
+
+# The Dependabot docker images in https://github.com/dependabot/dependabot-core are no longer versioned like the Ruby Gems.
+# In production, the build pipeline automatically updates the image tag to match the version in updater/Gemfile (see .github/workflows/updater.yml).
+# In local/dev,  the "latest" tag will be used by default. You can override this by specifying a dependabot-core release tag commit SHA as the image tag.
+#                e.g. for v0.264.0, use "ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM:e8d8a1268ea61304e939ba9ab963e249cac5b241"
 FROM ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM
 
 LABEL org.opencontainers.image.source="https://github.com/tinglesoftware/dependabot-azure-devops"

--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -1,10 +1,11 @@
 ARG ECOSYSTEM
+ARG BASE_VERSION=latest
 
-# The Dependabot docker images in https://github.com/dependabot/dependabot-core are no longer versioned like the Ruby Gems.
-# In production, the build pipeline automatically updates the image tag to match the version in updater/Gemfile (see .github/workflows/updater.yml).
-# In local/dev,  the "latest" tag will be used by default. You can override this by specifying a dependabot-core release tag commit SHA as the image tag.
-#                e.g. for v0.264.0, use "ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM:e8d8a1268ea61304e939ba9ab963e249cac5b241"
-FROM ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM
+# The Dependabot docker images in https://github.com/dependabot/dependabot-core are no longer versioned like the Ruby Gems; instead they are versioned by the commit SHA of the release tag.
+# In production, the build pipeline automatically calculates BASE_VERSION to match the dependabot-omnibus version set in updater/Gemfile (see .github/workflows/updater.yml).
+# In local/dev,  the "latest" tag will be used by default. You can override this by setting BASE_VERSION to the commit SHA of a dependabot-core release tag.
+#                e.g. for v0.264.0, use BASE_VERSION="e8d8a1268ea61304e939ba9ab963e249cac5b241"
+FROM ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM:$BASE_VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/tinglesoftware/dependabot-azure-devops"
 


### PR DESCRIPTION
### What are you trying to accomplish?
The "updater" action/workflow should use the dependabot-updater base image that corresponds to the version of dependabot-omnibus set in `updater/Gemfile`. Currently "latest" will always be used, which can create problems as seen in https://github.com/tinglesoftware/dependabot-azure-devops/issues/1190#issuecomment-2212026759 

### Summary of changes
A new task has been added to `.github/workflows/updater.yml` that will read `updater/Gemfile`, extract the current version of dependabot-omnibus, find the git commit SHA for that version tag, then pass it to `updater/Dockerfile` as an argument.

In local/dev environment, the "latest" image tag is still used. Instructions have been added to the Dockerfile.

### Script testing
I have not tested this in a proper github action run, but have executed the script on a Ubunutu host.

#### When run on main branch
```log
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15153  100 15153    0     0  30652      0 --:--:-- --:--:-- --:--:-- 30612
Dockerfile updated to use dependabot-updater image tag '24cc74a45208bb67bc8c1790ce2594f7940919bf' (v0.263.0)
```
Dockerfile:
```dockerfile
# The Dependabot docker images in https://github.com/dependabot/dependabot-core are no longer versioned like the Ruby Gems.
# In production, the build pipeline automatically updates the image tag to match the version in updater/Gemfile (see .github/workflows/updater.yml).
# In local/dev,  the "latest" tag will be used by default. You can override this by specifying a dependabot-core release tag commit SHA as the image tag.
#                e.g. for v0.264.0, use "ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM:24cc74a45208bb67bc8c1790ce2594f7940919bf"
FROM ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM:24cc74a45208bb67bc8c1790ce2594f7940919bf
```

#### When run on https://github.com/tinglesoftware/dependabot-azure-devops/pull/1191 branch
```log
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15153  100 15153    0     0  91445      0 --:--:-- --:--:-- --:--:-- 91283
Dockerfile updated to use dependabot-updater image tag 'e8d8a1268ea61304e939ba9ab963e249cac5b241' (v0.264.0)
```
Dockerfile:
```dockerfile
# The Dependabot docker images in https://github.com/dependabot/dependabot-core are no longer versioned like the Ruby Gems.
# In production, the build pipeline automatically updates the image tag to match the version in updater/Gemfile (see .github/workflows/updater.yml).
# In local/dev,  the "latest" tag will be used by default. You can override this by specifying a dependabot-core release tag commit SHA as the image tag.
#                e.g. for v0.264.0, use "ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM:24cc74a45208bb67bc8c1790ce2594f7940919bf"
FROM ghcr.io/dependabot/dependabot-updater-$ECOSYSTEM:e8d8a1268ea61304e939ba9ab963e249cac5b241
```
