### PR TITLE
Fix auto-approval; missing module name

### DIFF
--- a/updater/lib/tinglesoftware/dependabot/clients/azure.rb
+++ b/updater/lib/tinglesoftware/dependabot/clients/azure.rb
@@ -83,7 +83,7 @@ module TingleSoftware
             user: credentials&.fetch("username", nil),
             password: token,
             idempotent: true,
-            **SharedHelpers.excon_defaults(
+            **::Dependabot::SharedHelpers.excon_defaults(
               headers: auth_header
             )
           )
@@ -102,7 +102,7 @@ module TingleSoftware
             user: credentials&.fetch("username", nil),
             password: token,
             idempotent: true,
-            **SharedHelpers.excon_defaults(
+            **::Dependabot::SharedHelpers.excon_defaults(
               headers: auth_header.merge(
                 {
                   "Content-Type" => "application/json"


### PR DESCRIPTION
Fixes #1198. Regression from https://github.com/tinglesoftware/dependabot-azure-devops/pull/1188.
Missing module name for `SharedHelpers`.