### PR TITLE
Validate data length before reading request

### DIFF
--- a/extension/task/utils/resolveAzureDevOpsIdentities.ts
+++ b/extension/task/utils/resolveAzureDevOpsIdentities.ts
@@ -137,13 +137,20 @@ async function querySubjectHosted(organization: string, email: string): Promise<
       }
     });
 
-    if (isSuccessStatusCode(response.status)) {
-      const descriptor: string = response.data.value[0]?.descriptor || "";
-      const id = decodeBase64(descriptor.substring(descriptor.indexOf(".") + 1))
-      return {
-        id: id,
-        displayName: response.data.value[0]?.displayName,
-        input: email}
+    tl.debug(`Got Http Response: ${response.status}`);
+
+    if(!isSuccessStatusCode(response.status) || response.data.value.length === 0) {
+        throw new Error(
+            'Failed to resolve given email in organization'
+        );
+    }
+
+    const descriptor: string = response.data.value[0]?.descriptor || "";
+    const id = decodeBase64(descriptor.substring(descriptor.indexOf(".") + 1))
+    return {
+      id: id,
+      displayName: response.data.value[0]?.displayName,
+      input: email
     }
   } catch (error) {
     const responseStatusCode = error?.response?.status;


### PR DESCRIPTION
The function `querySubjectHosted` assumes the value array contains at least one item, but sometimes this is not the case.

When the current implementation is ran the DevOps plugin just halts without a proper exception message.