### PR TITLE
Fix allow condition "dependency-name" matching

### DIFF
--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -235,7 +235,9 @@ TYPE_HANDLERS = {
 
 def allow_conditions_for(dep)
   # Find where the name matches then get the type e.g. production, direct, etc
-  found = $options[:allow_conditions].find { |al| dep.name.match?(al["dependency-name"]) }
+  found = $options[:allow_conditions].find do |al|
+    Dependabot::Config::UpdateConfig.wildcard_match?(al["dependency-name"] || "*", dep.name)
+  end
   found ? found["dependency-type"] : "all" # when not specified, allow all types
 end
 


### PR DESCRIPTION
### What are you trying to accomplish?
Fix #1207

### Changes
- If an allow condition "dependency-name" is nil, use "*" so that it matches all dependency names; 
- Use wildcard matching instead of regex matching so that "\*" matches the name; previously you'd have to use ".*" for a match, which is not consistent with [official documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow).


### Considations
Technically, this is a breaking change for the project as any existing `dependabot.yml` configs using allow conditions dependency names with ".*" will be interepted differently now e.g. 

- Before this change "Microsoft.*" would match a dependency named "MicrosoftWindows" (wrong)
- After this change "Microsoft.*" would **not** match a depedency named "MicrosoftWindows" (correct)

I could revert the `wildcard_match?` change whilst still fixing the "wrong argument type nil" error if you would prefer not to change this behavior, the change would then only need to be:

```ruby
found = $options[:allow_conditions].find { |al| dep.name.match?(al["dependency-name"] || ".*") }
```

Let me know your thoughts on this.