### PR TITLE
Fix all dependencies being [incorrectly] allowed whenever using allow conditions

### DIFF
--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -235,10 +235,12 @@ TYPE_HANDLERS = {
 
 def allow_conditions_for(dep)
   # Find where the name matches then get the type e.g. production, direct, etc
-  found = $options[:allow_conditions].find do |al|
+  condition = $options[:allow_conditions].find do |al|
     Dependabot::Config::UpdateConfig.wildcard_match?(al["dependency-name"] || "*", dep.name)
   end
-  found ? found["dependency-type"] : "all" # when not specified, allow all types
+  return nil unless condition
+
+  condition["dependency-type"] || "all" # when not specified, allow all types
 end
 
 #################################################################


### PR DESCRIPTION
### What are you trying to accomplish?
Fix https://github.com/tinglesoftware/dependabot-azure-devops/issues/652#issuecomment-1668990238

Given this config:
```yml
updates:
  - package-ecosystem: nuget
    allow:
      - dependency-name: Newtonsoft.Json
        dependency-type: all
```

Updating a package named `AWSSDK.Lambda` would be allowed; but it shouldn't be since at least one allow rule is defined, but none match the dependency name. 

This happens because `allow_conditions_for` returns `"all"` by default, even if there are no conditions matching the dependency name

### Changes
- `allow_conditions_for` now returns `nil` if there are **no** allow rules matching the dependency name
- `allow_conditions_for` now returns `"all"` if there **is** an allow rule matching the dependency name, but it doesn't have a `dependency-type` property.
