### PR TITLE
Fix error when attempting to update a pre-1.30 pull request using the new vNext script

### DIFF
--- a/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
+++ b/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
@@ -104,7 +104,7 @@ module TingleSoftware
           end
         end
 
-        def update_all_existing_pull_requests # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+        def update_all_existing_pull_requests # rubocop:disable Metrics/PerceivedComplexity
           job.open_pull_requests.each do |pr|
             ::Dependabot.logger.info(
               "Checking if PR ##{pr['pullRequestId']}: #{pr['title']} needs to be updated"

--- a/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
+++ b/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
@@ -111,15 +111,7 @@ module TingleSoftware
             )
 
             deps = pr["updated_dependencies"]
-            if deps.nil?
-              # If the PR does not have a updated dependencies property, it was created using 1.29 or earlier.
-              # Because of the more complex nature of the new dependency snapshotting, we cannot update these PRs.
-              ::Dependabot.logger.warn(
-                "PR ##{pr['pullRequestId']}: #{pr['title']} was created using an older version of Dependabot, " \
-                "it must be updated manually or closed."
-              )
-              next
-            end
+            next if deps.nil? # Ignore PRs with no updated dependency info as we can't be sure what they are updating
 
             dependency_group_name = deps.is_a?(Hash) ? deps.fetch("dependency-group-name", nil) : nil
             dependency_names = (deps.is_a?(Array) ? deps : deps["dependencies"])&.map { |d| d["dependency-name"] } || []

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -362,6 +362,8 @@ module TingleSoftware
       def existing_pull_request_for_dependency_names(dependency_names)
         open_pull_requests.find do |pr|
           deps = pr["updated_dependencies"]
+          next if deps.nil?
+
           dependency_names == (deps.is_a?(Array) ? deps : deps["dependencies"])&.map { |d| d["dependency-name"] }
         end
       end

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -230,14 +230,10 @@ module TingleSoftware
       end
 
       def _dependency_groups
-        groups = [JSON.parse(ENV.fetch("DEPENDABOT_DEPENDENCY_GROUPS", "[]"))].flatten.filter_map do |group|
-          return nil if group.keys.empty?
-
-          # Dependabot.yml config differs from the dependency group model, so we need to remap them
-          # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+        groups = JSON.parse(ENV.fetch("DEPENDABOT_DEPENDENCY_GROUPS", "{}")).map do |k, v|
           {
-            "name" => group.keys.first.to_s,
-            "rules" => group.values.first
+            "name" => k,
+            "rules" => v
           }
         end
         return groups if groups.count.nonzero?

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -230,10 +230,14 @@ module TingleSoftware
       end
 
       def _dependency_groups
-        groups = JSON.parse(ENV.fetch("DEPENDABOT_DEPENDENCY_GROUPS", "{}")).map do |k, v|
+        groups = [JSON.parse(ENV.fetch("DEPENDABOT_DEPENDENCY_GROUPS", "[]"))].flatten.filter_map do |group|
+          return nil if group.keys.empty?
+
+          # Dependabot.yml config differs from the dependency group model, so we need to remap them
+          # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
           {
-            "name" => k,
-            "rules" => v
+            "name" => group.keys.first.to_s,
+            "rules" => group.values.first
           }
         end
         return groups if groups.count.nonzero?

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -362,7 +362,7 @@ module TingleSoftware
       def existing_pull_request_for_dependency_names(dependency_names)
         open_pull_requests.find do |pr|
           deps = pr["updated_dependencies"]
-          next if deps.nil?
+          next if deps.nil? # Ignore PRs with no updated dependency info as we can't be sure what they are updating
 
           dependency_names == (deps.is_a?(Array) ? deps : deps["dependencies"])&.map { |d| d["dependency-name"] }
         end


### PR DESCRIPTION
## What are you trying to accomplish?
If you have an open Dependabot PR that was created with v1.29 or earlier and then run the "vNext" update script from v1.30, the update fails; The script should ignore any PRs which are not compatible with the new update script.

```log
2024/07/19 06:07:16 INFO <job_1721369191> Found 1 open pull requests(s):
2024/07/19 06:07:16 INFO <job_1721369191>  - #6489: Bump Microsoft.AspNetCore.Authentication.OpenIdConnect from 8.0.6 to 8.0.7
2024/07/19 06:07:16 INFO <job_1721369191> Checking if PR #6489: Bump Microsoft.AspNetCore.Authentication.OpenIdConnect from 8.0.6 to 8.0.7 needs to be updated
2024/07/19 06:07:16 ERROR <job_1721369191> undefined method `[]' for nil
2024/07/19 06:07:16 ERROR <job_1721369191> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb:114:in `block in update_all_existing_pull_requests'
2024/07/19 06:07:16 ERROR <job_1721369191> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb:108:in `each'
2024/07/19 06:07:16 ERROR <job_1721369191> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb:108:in `update_all_existing_pull_requests'
2024/07/19 06:07:16 ERROR <job_1721369191> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb:48:in `perform_job'
2024/07/19 06:07:16 ERROR <job_1721369191> /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:37:in `run'
2024/07/19 06:07:16 ERROR <job_1721369191> bin/update_script_vnext.rb:26:in `<main>'
2024/07/19 06:07:16 INFO Results:
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
+---------------+
|    Errors     |
+---------------+
| unknown_error |
+---------------+

```

## Changes
 - PRs that do not have the "updated_dependencies" PR property are skipped when checking for existing PRs to update

