### PR TITLE
Fix PRs being incorrectly abandoned when using multiple package ecosystems

### DIFF
--- a/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
+++ b/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
@@ -27,6 +27,7 @@ module TingleSoftware
         # https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-properties
         module PullRequest
           module Properties
+            PACKAGE_MANAGER = "dependabot.package_manager"
             BASE_COMMIT_SHA = "dependabot.base_commit_sha"
             UPDATED_DEPENDENCIES = "dependabot.updated_dependencies"
           end
@@ -238,7 +239,7 @@ module TingleSoftware
 
         def pull_request_sync_state_data(pull_request, dependency_change, base_commit_sha, is_new_pr)
           # Update the pull request properties with our dependabot metadata
-          pull_request_replace_property_metadata(pull_request, dependency_change, base_commit_sha)
+          pull_request_replace_property_metadata(pull_request, job.package_manager, dependency_change, base_commit_sha)
 
           # Apply auto-complete and auto-approve settings
           pull_request_auto_complete(pull_request) if job.azure_set_auto_complete
@@ -368,7 +369,7 @@ module TingleSoftware
             )
         end
 
-        def pull_request_replace_property_metadata(pull_request, dependency_change, base_commit_sha)
+        def pull_request_replace_property_metadata(pull_request, package_manager, dependency_change, base_commit_sha)
           # Update the pull request property metadata with info about the updated dependencies.
           # This is used in `job.rb` to calculate "existing_pull_requests" in future jobs.
           pull_request_id = pull_request["pullRequestId"]
@@ -376,6 +377,8 @@ module TingleSoftware
           job.azure_client.pull_request_properties_update(
             pull_request_id.to_s,
             {
+              PullRequest::Properties::PACKAGE_MANAGER =>
+                package_manager,
               PullRequest::Properties::BASE_COMMIT_SHA =>
                 base_commit_sha.to_s,
               PullRequest::Properties::UPDATED_DEPENDENCIES =>

--- a/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
+++ b/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
@@ -109,10 +109,7 @@ module TingleSoftware
             ::Dependabot.logger.info(
               "Checking if PR ##{pr['pullRequestId']}: #{pr['title']} needs to be updated"
             )
-
             deps = pr["updated_dependencies"]
-            next if deps.nil? # Ignore PRs with no updated dependency info as we can't be sure what they are updating
-
             dependency_group_name = deps.is_a?(Hash) ? deps.fetch("dependency-group-name", nil) : nil
             dependency_names = (deps.is_a?(Array) ? deps : deps["dependencies"])&.map { |d| d["dependency-name"] } || []
 

--- a/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
+++ b/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
@@ -109,7 +109,10 @@ module TingleSoftware
             ::Dependabot.logger.info(
               "Checking if PR ##{pr['pullRequestId']}: #{pr['title']} needs to be updated"
             )
+
             deps = pr["updated_dependencies"]
+            next if deps.nil? # Ignore PRs with no updated dependency info as we can't be sure what they are updating
+
             dependency_group_name = deps.is_a?(Hash) ? deps.fetch("dependency-group-name", nil) : nil
             dependency_names = (deps.is_a?(Array) ? deps : deps["dependencies"])&.map { |d| d["dependency-name"] } || []
 

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -362,8 +362,6 @@ module TingleSoftware
       def existing_pull_request_for_dependency_names(dependency_names)
         open_pull_requests.find do |pr|
           deps = pr["updated_dependencies"]
-          next if deps.nil? # Ignore PRs with no updated dependency info as we can't be sure what they are updating
-
           dependency_names == (deps.is_a?(Array) ? deps : deps["dependencies"])&.map { |d| d["dependency-name"] }
         end
       end

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -362,6 +362,8 @@ module TingleSoftware
       def existing_pull_request_for_dependency_names(dependency_names)
         open_pull_requests.find do |pr|
           deps = pr["updated_dependencies"]
+          next if deps.nil? # Ignore PRs with no updated dependency info as we can't be sure what they are updating
+
           dependency_names == (deps.is_a?(Array) ? deps : deps["dependencies"])&.map { |d| d["dependency-name"] }
         end
       end


### PR DESCRIPTION
## What are you trying to accomplish?
If `dependabot.yml` has multiple package ecosystems configured (e.g. NuGet and NPM), the update process for the 2nd package ecosystem will abandon PRs created by the 1st package ecosystem with the close reason "dependencies removed".

Ideally, PRs should be isolated per package ecosystem.

## Changes
- A new "dependabot.package_manager" PR property is set on all created PRs which contains the associated package ecosystem for the update.
- "fetch_open_pull_requests" will ignore any PRs that are not for the current job package ecosystem