### PR TITLE
Fix for group PRs being closed on refresh when nothing has changed

### DIFF
--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -370,7 +370,7 @@ module TingleSoftware
                           # If we are updating an existing group PR, we must only return PRs that match the group name
                           # of the current job. This is because "refresh_group_update_pull_request.rb" will mark all
                           # dependencies of all other group PRs as "handled" to prevent multiple PRs from being reated
-                          # during the refresh. However, when we operate in the "do everthing in a single job" mode,
+                          # during the refresh. However, when we operate in the "do everything in a single job" mode,
                           # this has the side effect of causing Dependabot to think the other group PRs have already
                           # been handled; it then closes them with "update_no_longer_possible". We don't want this.
                           .select { |d| update_group_name.nil? || d["dependency-group-name"] == update_group_name }


### PR DESCRIPTION
## What are you trying to accomplish?

If you have more than one group PR open. e.g.

![image](https://github.com/user-attachments/assets/4dad3d3f-a7e6-46f0-b79e-2c3953a81f48)

When you run the vNext update script it will update the first group PR, but then close every other group PR with the reason "update_no_longer_possible". e.g.

```log
+---------------------------------------------------------------------------------------------------------------+
|                                      Changes to Dependabot Pull Requests                                      |
+-----------------------------------+---------------------------------------------------------------------------+
| updated                           | Microsoft.AspNetCore.Authentication.OpenIdConnect ( from 8.0.6 to 8.0.7 ) |
| closed: update_no_longer_possible | MSTest.TestAdapter,MSTest.TestFramework                                   |
+-----------------------------------+---------------------------------------------------------------------------+
```

The group PRs should not be closed in this scenario, since nothing had actually changed.

## Changes
 - When updating an open group PR, `job.existing_group_pull_requests` will now only return open PRs that exactly match the group name of the job; previously it returned all open group PRs. This change prevents Dependabot from marking the other group PRs as "handled" during the refresh, which then results in the PRs being closed later in the update process.

After the change, the other group PRs are not closed; the result in the above scenario is:

```log
+----------------------------------------------------------------------------------------------------+
|                                Changes to Dependabot Pull Requests                                 |
+---------+------------------------------------------------------------------------------------------+
| updated | Microsoft.AspNetCore.Authentication.OpenIdConnect ( from 8.0.6 to 8.0.7 )                |
| updated | MSTest.TestAdapter ( from 3.4.3 to 3.5.0 ), MSTest.TestFramework ( from 3.4.3 to 3.5.0 ) |
+---------+------------------------------------------------------------------------------------------+
```