### PR TITLE
Fix logging error when creating new PR and the open PR limit has been reached

### DIFF
--- a/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
+++ b/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
@@ -233,7 +233,7 @@ module TingleSoftware
         end
 
         def log_open_limit_reached_for_pull_requests
-          ::Dependabot.logger.log(
+          ::Dependabot.logger.info(
             "Skipping pull request creation as the open pull request limit (#{job.open_pull_requests_limit}) " \
             "has been reached."
           )

--- a/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
+++ b/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
@@ -232,6 +232,13 @@ module TingleSoftware
           )
         end
 
+        def log_open_limit_reached_for_pull_requests
+          ::Dependabot.logger.log(
+            "Skipping pull request creation as the open pull request limit (#{job.open_pull_requests_limit}) " \
+            "has been reached."
+          )
+        end
+
         sig { params(error_type: T.any(String, Symbol), error_details: T.nilable(T::Hash[T.untyped, T.untyped])).void }
         def record_update_job_error(error_type:, error_details:)
           # No implementation required for Azure DevOps, errors are dumped to output console already

--- a/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
+++ b/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
@@ -39,8 +39,8 @@ module TingleSoftware
 
         sig { params(dependency_change: ::Dependabot::DependencyChange, base_commit_sha: String).void }
         def create_pull_request(dependency_change, base_commit_sha) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-          return open_limit_reached_for_pull_requests if job.open_pull_request_limit_reached?
-          return skip_pull_request("creation", dependency_change) if job.skip_pull_requests
+          return log_skipped_pull_request("creation", dependency_change) if job.skip_pull_requests
+          return log_open_limit_reached_for_pull_requests if job.open_pull_request_limit_reached?
 
           ::Dependabot.logger.info(
             "Creating pull request for '#{dependency_change.pr_message.pr_name}'."
@@ -104,7 +104,7 @@ module TingleSoftware
 
         sig { params(dependency_change: ::Dependabot::DependencyChange, base_commit_sha: String).void }
         def update_pull_request(dependency_change, base_commit_sha) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-          return skip_pull_request("update", dependency_change) if job.skip_pull_requests
+          return log_skipped_pull_request("update", dependency_change) if job.skip_pull_requests
 
           # Find the pull request to update
           dependency_names = dependency_change.updated_dependencies.map(&:name).join(",")
@@ -162,7 +162,7 @@ module TingleSoftware
 
         sig { params(dependency_names: T.any(String, T::Array[String]), reason: T.any(String, Symbol)).void }
         def close_pull_request(dependency_names, reason)
-          return skip_pull_request("close", nil) if job.skip_pull_requests
+          return log_skipped_pull_request("close", nil) if job.skip_pull_requests
 
           # Find the pull request to close
           pull_request = job.existing_pull_request_for_dependency_names(dependency_names)
@@ -172,7 +172,7 @@ module TingleSoftware
           # Comment on the PR explaining why it was closed
           pull_request_add_comment_with_close_reason(pull_request, dependency_names, reason)
 
-          return skip_pull_request("close", nil) unless job.close_pull_requests
+          return log_skipped_pull_request("close", nil) unless job.close_pull_requests
 
           # Delete the source branch
           # Do this first to avoid hanging branches
@@ -183,7 +183,7 @@ module TingleSoftware
         end
 
         sig { params(action: String, dependency_change: T.nilable(::Dependabot::DependencyChange)).void }
-        def skip_pull_request(action, dependency_change)
+        def log_skipped_pull_request(action, dependency_change)
           ::Dependabot.logger.info("Skipping pull request #{action} as it is disabled for this job.")
           ::Dependabot.logger.debug("Staged file changes were:") if dependency_change
           dependency_change&.updated_dependency_files&.each do |updated_file|
@@ -198,8 +198,8 @@ module TingleSoftware
           end
         end
 
-        def open_limit_reached_for_pull_requests
-          ::Dependabot.logger.log(
+        def log_open_limit_reached_for_pull_requests
+          ::Dependabot.logger.info(
             "Skipping pull request creation as the open pull request limit (#{job.open_pull_requests_limit}) " \
             "has been reached."
           )


### PR DESCRIPTION
## What are you trying to accomplish?
When the open pull request limit is reached, the update process throws an errors, which is not expected.

```log
2024/07/21 23:24:56 INFO <job_1721601109> Submitting Verify.Xunit pull request for creation
2024/07/21 23:24:56 ERROR <job_1721601109> Error processing Verify.Xunit (ArgumentError)
2024/07/21 23:24:56 ERROR <job_1721601109> comparison of String with 1 failed
2024/07/21 23:24:56 ERROR <job_1721601109> /usr/local/lib/ruby/3.3.0/logger.rb:653:in `<'
2024/07/21 23:24:56 ERROR <job_1721601109> /usr/local/lib/ruby/3.3.0/logger.rb:653:in `add'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb:202:in `open_limit_reached_for_pull_requests'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb:42:in `create_pull_request'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/call_validation_2_7.rb:734:in `bind_call'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/call_validation_2_7.rb:734:in `block in create_validator_procedure_fast2'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/service.rb:57:in `create_pull_request'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/call_validation_2_7.rb:734:in `bind_call'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/call_validation_2_7.rb:734:in `block in create_validator_procedure_fast2'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:261:in `create_pull_request'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:143:in `check_and_create_pull_request'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:64:in `check_and_create_pr_with_error_handling'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:39:in `block in perform'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:39:in `each'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:39:in `perform'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:182:in `run_ungrouped_dependency_updates'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/call_validation.rb:270:in `bind_call'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/call_validation.rb:270:in `validate_call'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:85:in `perform'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/call_validation.rb:270:in `bind_call'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/call_validation.rb:270:in `validate_call'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11485/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:45:in `run'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb:158:in `run_updates_for'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb:142:in `update_all_dependencies'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb:51:in `perform_job'
2024/07/21 23:24:56 ERROR <job_1721601109> /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:37:in `run'
2024/07/21 23:24:56 ERROR <job_1721601109> bin/update_script_vnext.rb:26:in `<main>'

```

## Changes
 - Fixed typo, `Dependabot.logger.log` should be `Dependabot.logger.info`
 - Tidied up function names for better clarity