### PR TITLE
Log updated file diffs when 'skip pull requests' and 'debug' are set

### DIFF
--- a/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
+++ b/updater/lib/tinglesoftware/dependabot/api_clients/azure_api_client.rb
@@ -33,8 +33,9 @@ module TingleSoftware
           end
         end
 
-        def initialize(job:)
+        def initialize(job:, dependency_snapshot_resolver:)
           @job = job
+          @dependency_snapshot_resolver = dependency_snapshot_resolver
         end
 
         sig { params(dependency_change: ::Dependabot::DependencyChange, base_commit_sha: String).void }
@@ -185,17 +186,50 @@ module TingleSoftware
         sig { params(action: String, dependency_change: T.nilable(::Dependabot::DependencyChange)).void }
         def skip_pull_request(action, dependency_change)
           ::Dependabot.logger.info("Skipping pull request #{action} as it is disabled for this job.")
+          return unless job.debug_enabled?
+
           ::Dependabot.logger.debug("Staged file changes were:") if dependency_change
+          dependency_snapshot = @dependency_snapshot_resolver.call
           dependency_change&.updated_dependency_files&.each do |updated_file|
-            case updated_file.operation
-            when ::Dependabot::DependencyFile::Operation::CREATE
-              ::Dependabot.logger.debug(" 🟢 created '#{updated_file.name}' in '#{updated_file.directory}'")
-            when ::Dependabot::DependencyFile::Operation::UPDATE
-              ::Dependabot.logger.debug(" 🟡 updated '#{updated_file.name}' in '#{updated_file.directory}'")
-            when ::Dependabot::DependencyFile::Operation::DELETE
-              ::Dependabot.logger.debug(" 🔴 deleted '#{updated_file.name}' in '#{updated_file.directory}'")
-            end
+            log_file_diff(
+              dependency_snapshot.dependency_files.find { |f| f.name == updated_file.name },
+              updated_file
+            )
           end
+        end
+
+        def log_file_diff(original_file, updated_file)
+          return unless original_file
+          return if original_file.content == updated_file.content
+
+          summary = case updated_file.operation
+                    when ::Dependabot::DependencyFile::Operation::CREATE
+                      " + Created '#{updated_file.name}' in '#{updated_file.directory}'"
+                    when ::Dependabot::DependencyFile::Operation::UPDATE
+                      " ± Updated '#{updated_file.name}' in '#{updated_file.directory}'"
+                    when ::Dependabot::DependencyFile::Operation::DELETE
+                      " - Deleted '#{updated_file.name}' in '#{updated_file.directory}'"
+                    end
+
+          original_tmp_file = Tempfile.new("original")
+          original_tmp_file.write(original_file.content)
+          original_tmp_file.close
+
+          updated_tmp_file = Tempfile.new("updated")
+          updated_tmp_file.write(updated_file.content)
+          updated_tmp_file.close
+
+          diff = `diff -u #{original_tmp_file.path} #{updated_tmp_file.path}`.lines
+          added_lines = diff.count { |line| line.start_with?("+") }
+          removed_lines = diff.count { |line| line.start_with?("-") }
+
+          ::Dependabot.logger.debug(
+            summary + "\n" \
+                      "~~~\n" \
+                      "#{diff.join}\n" \
+                      "~~~\n" \
+                      "#{added_lines} insertions (+), #{removed_lines} deletions (-)"
+          )
         end
 
         def open_limit_reached_for_pull_requests

--- a/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
+++ b/updater/lib/tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command.rb
@@ -35,7 +35,10 @@ module TingleSoftware
           @service = ::Dependabot::Service.new(
             # Use the Azure DevOps API client rather than the (default) Dependabot Service API.
             # This allows us to perform pull request changes synchronously to within the context of this job.
-            client: TingleSoftware::Dependabot::ApiClients::AzureApiClient.new(job: job)
+            client: TingleSoftware::Dependabot::ApiClients::AzureApiClient.new(
+              job: job,
+              dependency_snapshot_resolver: proc { @dependency_snapshot }
+            )
           )
         end
 

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -505,6 +505,10 @@ module TingleSoftware
       def fail_on_exception
         ENV.fetch("DEPENDABOT_FAIL_ON_EXCEPTION", "true") == "true"
       end
+
+      def debug_enabled?
+        ENV.fetch("DEPENDABOT_DEBUG", nil) == "true"
+      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
When using `update_script_vnext.rb`, it should log updated file diffs like `update_script.rb` does when pull requests are skipped so that debugging problems is easier to do. 

### Changes
When `DEPENDABOT_SKIP_PULL_REQUESTS` and `DEPENDABOT_DEBUG` are both `true`, updated file diffs are logged. 
e.g.

```log
2024/07/22 04:38:12 INFO <job_12345> Creating a pull request for 'microsoft'
2024/07/22 04:38:12 INFO <job_12345> Skipping pull request creation as it is disabled for this job.
2024/07/22 04:38:12 DEBUG <job_12345> Staged file changes were:
2024/07/22 04:38:12 DEBUG <job_12345>  ± Updated 'WebApplicationNetCore/WebApplicationNetCore.csproj' in '/'
~~~
--- /tmp/original20240722-7-m2sap4      2024-07-22 04:38:12.679913488 +0000
+++ /tmp/updated20240722-7-6yx8xo       2024-07-22 04:38:12.679913488 +0000
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

~~~
2 insertions (+), 2 deletions (-)
```
