### PR TITLE
Automatically install the Azure Artifacts Credential Provider if DevOps NuGet feeds are configured

### DIFF
--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -46,6 +46,8 @@ require "dependabot/terraform"
 require "tinglesoftware/dependabot/clients/azure"
 require "tinglesoftware/dependabot/vulnerabilities"
 
+require "tinglesoftware/nuget/credentials_provider"
+
 # These options try to follow the dry-run.rb script.
 # https://github.com/dependabot/dependabot-core/blob/main/bin/dry-run.rb
 

--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -46,7 +46,7 @@ require "dependabot/terraform"
 require "tinglesoftware/dependabot/clients/azure"
 require "tinglesoftware/dependabot/vulnerabilities"
 
-require "tinglesoftware/nuget/credentials_provider"
+require "tinglesoftware/azure/artifacts_credential_provider"
 
 # These options try to follow the dry-run.rb script.
 # https://github.com/dependabot/dependabot-core/blob/main/bin/dry-run.rb

--- a/updater/bin/update_script_vnext.rb
+++ b/updater/bin/update_script_vnext.rb
@@ -10,7 +10,7 @@ require "tinglesoftware/dependabot/setup"
 require "tinglesoftware/dependabot/job"
 require "tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command"
 
-require "tinglesoftware/nuget/credentials_provider"
+require "tinglesoftware/azure/artifacts_credential_provider"
 
 ENV["UPDATER_ONE_CONTAINER"] = "true" # The full end-to-end update will happen in a single container
 ENV["UPDATER_DETERMINISTIC"] = "true" # The list of dependencies to update will be consistent across multiple runs

--- a/updater/bin/update_script_vnext.rb
+++ b/updater/bin/update_script_vnext.rb
@@ -10,6 +10,8 @@ require "tinglesoftware/dependabot/setup"
 require "tinglesoftware/dependabot/job"
 require "tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command"
 
+require "tinglesoftware/nuget/credentials_provider"
+
 ENV["UPDATER_ONE_CONTAINER"] = "true" # The full end-to-end update will happen in a single container
 ENV["UPDATER_DETERMINISTIC"] = "true" # The list of dependencies to update will be consistent across multiple runs
 

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -39,7 +39,7 @@ module TingleSoftware
 
         # Install cred provider from https://github.com/microsoft/artifacts-credprovider
         puts ::Dependabot::SharedHelpers.run_shell_command(
-          "sh -c \"$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)\"", allow_unsafe_shell_command: true
+          %(sh -c "$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)"), allow_unsafe_shell_command: true
         )
       end
     end

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -29,8 +29,9 @@ module TingleSoftware
             "endpointCredentials" => private_ado_nuget_feeds.map do |cred|
               {
                 "endpoint" => cred["url"],
-                "username" => "unused",
-                "password" => cred["token"].delete_prefix("PAT:") # Credentials provider expects the raw token
+                # Use username/password auth if provided, otherwise assume PAT token auth.
+                "username" => cred["username"] || "unused",
+                "password" => cred["password"] || cred["token"].split(":").last # Strip any "PAT:" or ":" prefixes
               }
             end
           })

--- a/updater/lib/tinglesoftware/nuget/credentials_provider.rb
+++ b/updater/lib/tinglesoftware/nuget/credentials_provider.rb
@@ -3,6 +3,14 @@
 
 require "dependabot/shared_helpers"
 
+#
+# This module automatically installs the NuGet credential provider if any of the "extra credentials" are NuGet feeds.
+# Without it, private Azure DevOps NuGet feeds fail to auth and users have to deal with complicated workarounds.
+# See: https://github.com/tinglesoftware/dependabot-azure-devops/pull/1233 for more info.
+#
+
+# TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
+
 module TingleSoftware
   module NuGet
     module CredentialsProvider
@@ -32,7 +40,4 @@ module TingleSoftware
   end
 end
 
-# Automatically install the NuGet credential provider if any of the "extra credentials" are NuGet feeds.
-# Without it, private Azure DevOps NuGet feeds fail to auth and users have to deal with complicated workarounds.
-# TODO: Remove this entire file once https://github.com/dependabot/dependabot-core/pull/8927 is resolved.
 TingleSoftware::NuGet::CredentialsProvider.install_if_nuget_feeds_are_configured

--- a/updater/lib/tinglesoftware/nuget/credentials_provider.rb
+++ b/updater/lib/tinglesoftware/nuget/credentials_provider.rb
@@ -1,0 +1,38 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/shared_helpers"
+
+module TingleSoftware
+  module NuGet
+    module CredentialsProvider
+      def self.install_if_nuget_feeds_are_configured
+        credentials = JSON.parse(ENV.fetch("DEPENDABOT_EXTRA_CREDENTIALS", "[]"))
+        private_nuget_feeds = credentials.select { |cred| cred["type"] == "nuget_feed" }
+        return if private_nuget_feeds.empty?
+
+        ENV.store(
+          "VSS_NUGET_EXTERNAL_FEED_ENDPOINTS",
+          JSON.dump({
+            "endpointCredentials" => private_nuget_feeds.map do |cred|
+              {
+                "endpoint" => cred["url"],
+                "username" => "unused",
+                "password" => cred["token"].delete_prefix("PAT:") # Credentials provider expects the raw token
+              }
+            end
+          })
+        )
+
+        puts ::Dependabot::SharedHelpers.run_shell_command(
+          "sh -c \"$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)\"", allow_unsafe_shell_command: true
+        )
+      end
+    end
+  end
+end
+
+# Automatically install the NuGet credential provider if any of the "extra credentials" are NuGet feeds.
+# Without it, private Azure DevOps NuGet feeds fail to auth and users have to deal with complicated workarounds.
+# TODO: Remove this entire file once https://github.com/dependabot/dependabot-core/pull/8927 is resolved.
+TingleSoftware::NuGet::CredentialsProvider.install_if_nuget_feeds_are_configured


### PR DESCRIPTION
### What are you trying to accomplish?
Allow users to authenticate with private Azure DevOps NuGet feeds without any additional configuration or complicated workarounds. Ideally auth should "just work" like it did in v1.24.

Reduce the number of issues users are having with private NuGet feed auth. e.g. see comments in:

 - https://github.com/tinglesoftware/dependabot-azure-devops/issues/921#issuecomment-2162273558
 - https://github.com/tinglesoftware/dependabot-azure-devops/issues/1201#issuecomment-2242074907
 - https://github.com/tinglesoftware/dependabot-azure-devops/issues/1206#issuecomment-2245030650
 - https://github.com/tinglesoftware/dependabot-azure-devops/issues/1232#issuecomment-2245129307

###  Changes
If `DEPENDABOT_EXTRA_CREDENTIALS` contains credentials for an Azure DevOps NuGet feed, the workaround detailed in https://github.com/tinglesoftware/dependabot-azure-devops/issues/921#issuecomment-2162273558 will be applied-- more specifically, `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` will be set using the configured credentials, then the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) is installed to the container.

This automatically runs for both `update_script.rb` and `update_script_vnext.rb`.

This module can be easily deleted once https://github.com/dependabot/dependabot-core/pull/8927 or some other dependabot-core native auth solution becomes available.