### PR TITLE
NuGet feed auth support for Azure DevOps, Azure DevOps Server, and third-party NuGet servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,17 @@ updates:
 Note:
 
 1. `${{VARIABLE_NAME}}` notation is used liked described [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-encrypted-secrets-for-dependabot)
-BUT the values will be used from Environment Variables in the pipeline/environment. Template variables are not supported for this replacement. Replacement only works for values considered secret in the registries section i.e. `password`, `token`, and `key`
+BUT the values will be used from Environment Variables in the pipeline/environment. Template variables are not supported for this replacement. Replacement only works for values considered secret in the registries section i.e. `username`, `password`, `token`, and `key`
 
-2. When using a token, the notation should be `PAT:${{VARIABLE_NAME}}` for Azure DevOps feeds ([see why here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/50)). For third-party NuGet servers that require basic auth, the notation should be `${{USERNAME}}:${{PASSWORD}}` ([see why here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/1232#issuecomment-2247616424)).
+2. When using an Azure DevOps Artifact feed, only the `token` property is required. The token notation should be `PAT:${{VARIABLE_NAME}}` otherwise the wrong authentication mechanism is used by Dependabot, see [here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/50) for more details. 
+When working with Azure DevOps Artifacts, some extra permission steps need to be done:
 
-When working with Azure Artifacts, some extra permission steps need to be done:
+    1. The PAT should have *Packaging Read* permission.
+    2. The user owning the PAT must be granted permissions to access the feed either directly or via a group. An easy way for this is to give `Contributor` permissions the `[{project_name}]\Contributors` group under the `Feed Settings -> Permissions` page. The page has the url format: `https://dev.azure.com/{organization}/{project}/_packaging?_a=settings&feed={feed-name}&view=permissions`.
 
-1. The PAT should have *Packaging Read* permission.
-2. The user owning the PAT must be granted permissions to access the feed either directly or via a group. An easy way for this is to give `Contributor` permissions the `[{project_name}]\Contributors` group under the `Feed Settings -> Permissions` page. The page has the url format: `https://dev.azure.com/{organization}/{project}/_packaging?_a=settings&feed={feed-name}&view=permissions`.
+3. When using a NuGet package server secured with basic auth, the `username`, `password`, and `token` properties are all required. The token notation should be `${{USERNAME}}:${{PASSWORD}}`, see [here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/1232#issuecomment-2247616424) for more details.
+
+
 
 ## Security Advisories, Vulnerabilities, and Updates
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,19 @@ registries:
   my-analyzers:
     type: nuget-feed
     url: https://dev.azure.com/organization2/_packaging/my-analyzers/nuget/v3/index.json
-    token: PAT:${{ANOTHER_PAT}}
+    token: PAT:${{MY_OTHER_PAT}}
   artifactory:
     type: nuget-feed
     url: https://artifactory.com/api/nuget/v3/myfeed
-    token: PAT:${{DEPENDABOT_ARTIFACTORY_PAT}}
+    token: PAT:${{MY_ARTIFACTORY_PAT}}
+  telerik:
+    type: nuget-feed
+    url: https://nuget.telerik.com/v3/index.json
+    username: ${{MY_TELERIK_USERNAME}}
+    password: ${{MY_TELERIK_PASSWORD}}
+    token: ${{MY_TELERIK_USERNAME}}:${{MY_TELERIK_PASSWORD}}
 updates:
-...
+  ...
 ```
 
 Note:
@@ -55,7 +61,7 @@ Note:
 1. `${{VARIABLE_NAME}}` notation is used liked described [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-encrypted-secrets-for-dependabot)
 BUT the values will be used from Environment Variables in the pipeline/environment. Template variables are not supported for this replacement. Replacement only works for values considered secret in the registries section i.e. `password`, `token`, and `key`
 
-2. When using a token the notation should be `PAT:${{VARIABLE_NAME}}`. Otherwise the wrong authentication mechanism is used by dependabot, see [here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/50).
+2. When using a token, the notation should be `PAT:${{VARIABLE_NAME}}` for Azure DevOps feeds ([see why here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/50)). For third-party NuGet servers that require basic auth, the notation should be `${{USERNAME}}:${{PASSWORD}}` ([see why here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/1232#issuecomment-2247616424)).
 
 When working with Azure Artifacts, some extra permission steps need to be done:
 

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 6,
-    "Patch": 1
+    "Patch": 0
   },
   "instanceNameFormat": "Dependabot",
   "minimumAgentVersion": "2.105.0",

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 6,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "Dependabot",
   "minimumAgentVersion": "2.105.0",

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -285,7 +285,7 @@ function parseRegistries(config: any): Record<string, IDependabotRegistry> {
     }
 
     // parse username, password, key, and token while replacing tokens where necessary
-    parsed.username = registryConfig["username"];
+    parsed.username = convertPlaceholder(registryConfig["username"]);
     parsed.password = convertPlaceholder(registryConfig["password"]);
     parsed.key = convertPlaceholder(registryConfig["key"]);
     parsed.token = convertPlaceholder(registryConfig["token"]);

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -16,12 +16,7 @@ require "dependabot/shared_helpers"
 module TingleSoftware
   module Azure
     module ArtifactsCredentialProvider
-      def self.install_if_nuget_feeds_are_configured
-        credentials = JSON.parse(ENV.fetch("DEPENDABOT_EXTRA_CREDENTIALS", "[]"))
-        private_nuget_feeds = credentials.select do |cred|
-          cred["type"] == "nuget_feed"
-        end
-
+      def self.install_if_private_nuget_feeds_are_configured
         return if private_nuget_feeds.empty?
 
         # Configure NuGet feed authentication
@@ -48,8 +43,15 @@ module TingleSoftware
           %(sh -c "$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)"), allow_unsafe_shell_command: true
         )
       end
+
+      def self.private_nuget_feeds
+        credentials = JSON.parse(ENV.fetch("DEPENDABOT_EXTRA_CREDENTIALS", "[]"))
+        credentials.select do |cred|
+          cred["type"] == "nuget_feed" && (cred["username"] || cred["password"] || cred["token"])
+        end
+      end
     end
   end
 end
 
-TingleSoftware::Azure::ArtifactsCredentialProvider.install_if_nuget_feeds_are_configured
+TingleSoftware::Azure::ArtifactsCredentialProvider.install_if_private_nuget_feeds_are_configured

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -14,10 +14,12 @@ require "dependabot/shared_helpers"
 module TingleSoftware
   module Azure
     module ArtifactsCredentialProvider
+      ADO_PKG_FEED_HOSTS = %w(dev.azure.com pkgs.dev.azure.com).freeze
+
       def self.install_if_nuget_feeds_are_configured
         credentials = JSON.parse(ENV.fetch("DEPENDABOT_EXTRA_CREDENTIALS", "[]"))
         private_ado_nuget_feeds = credentials.select do |cred|
-          cred["type"] == "nuget_feed" && cred["url"].include?("dev.azure.com")
+          cred["type"] == "nuget_feed" && ADO_PKG_FEED_HOSTS.include?(URI(cred["url"]).host)
         end
 
         return if private_ado_nuget_feeds.empty?

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -33,7 +33,7 @@ module TingleSoftware
                 "endpoint" => cred["url"],
                 # Use username/password auth if provided, otherwise fallback to token auth.
                 # This provides maximum compatibility with Azure DevOps, DevOps Server, and other third-party feeds.
-                # When using DevOps PATs, the token is split into username/password parts; Username is not signficant.
+                # When using DevOps PATs, the token is split into username/password parts; Username is not significant.
                 # e.g. "PAT:12345" --> { "username": "PAT", "password": "12345" }
                 #      ":12345"    --> { "username": "", "password": "12345" }
                 "username" => cred["username"] || cred["token"]&.split(":")&.first,

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -45,8 +45,7 @@ module TingleSoftware
       end
 
       def self.private_nuget_feeds
-        credentials = JSON.parse(ENV.fetch("DEPENDABOT_EXTRA_CREDENTIALS", "[]"))
-        credentials.select do |cred|
+        JSON.parse(ENV.fetch("DEPENDABOT_EXTRA_CREDENTIALS", "[]")).select do |cred|
           cred["type"] == "nuget_feed" && (cred["username"] || cred["password"] || cred["token"])
         end
       end

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -149,14 +149,6 @@ module TingleSoftware
             "username" => ENV.fetch("AZURE_ACCESS_USERNAME", nil) || "x-access-token",
             "password" => ENV.fetch("AZURE_ACCESS_TOKEN", nil)
           },
-          # Access to DevOps private package artifact feeds
-          # https://github.com/dependabot/cli/blob/8793545f7b5dbf946aaee9372ffc12318573da81/cmd/dependabot/internal/cmd/update.go#L363C1-L382C3
-          {
-            "type" => "git_source",
-            "host" => "pkgs.dev.azure.com",
-            "username" => ENV.fetch("AZURE_ACCESS_USERNAME", nil) || "x-access-token",
-            "password" => ENV.fetch("AZURE_ACCESS_TOKEN", nil)
-          },
           # Access to other user-specified sources
           *JSON.parse(ENV.fetch("DEPENDABOT_EXTRA_CREDENTIALS", "[]"))
         ]


### PR DESCRIPTION
### What are you trying to accomplish?
Fixes #1232
Fixes #1234

After debugging through #1232, I've realised that `ArtifactsCredentialProvider` should not restrict itself to only "dev.azure.com" feeds; instead it should pass-through credentials to **all** NuGet feeds.

It should be possible to configure NuGet auth for Azure DevOps, Azure DevOps Server, and any third-party NuGet package servers using basic auth. For example, see https://github.com/tinglesoftware/dependabot-azure-devops/issues/1232#issuecomment-2247616424.

### Changes
- Updated [README.MD](https://github.com/tinglesoftware/dependabot-azure-devops/pull/1241/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with example of how to auth with a third-party NuGet server requiring basic auth.
- Remove host name whitelisting in `ArtifactsCredentialProvider` 
- `Job` no longer sets default credentials for "pkgs.dev.azure.com", use `DEPENDABOT_EXTRA_CREDENTIALS` instead.
- Extension task now replaces placeholder environment variable names for "registries.username" in dependabot.yml.