### PR TITLE
Remove docker demand and rely on `tl.which`

### DIFF
--- a/extension/task/index.ts
+++ b/extension/task/index.ts
@@ -31,6 +31,7 @@ async function run() {
     // For each update run docker container
     for (const update of updates) {
       // Prepare the docker task
+      // tl.which throws an error if the tool is not found
       let dockerRunner: ToolRunner = tl.tool(tl.which("docker", true));
       dockerRunner.arg(["run"]); // run command
       dockerRunner.arg(["--rm"]); // remove after execution

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -11,7 +11,7 @@
   "visibility": ["Build", "Release"],
   "runsOn": ["Agent", "DeploymentGroup"],
   "author": "Tingle Software",
-  "demands": ["docker"],
+  "demands": [],
   "version": {
     "Major": 1,
     "Minor": 6,


### PR DESCRIPTION
This should allow private agents with non-standard discovery.

Fixes: #1242 