### PR TITLE
Fix nuget.config not using correct credentials during NuGet updates of .NET Framework projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,40 @@ When working with Azure DevOps Artifacts, some extra permission steps need to be
 3. When using a NuGet package server secured with basic auth, the `username`, `password`, and `token` properties are all required. The token notation should be `${{USERNAME}}:${{PASSWORD}}`, see [here](https://github.com/tinglesoftware/dependabot-azure-devops/issues/1232#issuecomment-2247616424) for more details.
 
 
+4. When your project contains a `nuget.config` file with custom package source configuration, the `key` property is required for each nuget-feed registry. The key must match between `dependabot.yml` and `nuget.config` otherwise the package source will be duplicated, package source mappings will be ignored, and auth errors will occur during dependency discovery.
+
+   If your `nuget.config` looks like this:
+     ```xml
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <clear />
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+          <add key="my-organisation1-nuget" value="https://dev.azure.com/my-organization/_packaging/my-nuget-feed/nuget/v3/index.json" />
+        </packageSources>
+        <packageSourceMapping>
+          <packageSource key="nuget.org">
+            <package pattern="*" />
+          </packageSource>
+          <packageSource key="my-organisation-nuget">
+            <package pattern="Organisation.*" />
+          </packageSource>
+        </packageSourceMapping>
+      </configuration>
+      ```
+
+    Then your `dependabot.yml` registry should look like this:
+
+    ```yml
+    version: 2
+    registries:
+      my-org:
+        type: nuget-feed
+        key: my-organisation1-nuget
+        url: https://dev.azure.com/my-organization/_packaging/my-nuget-feed/nuget/v3/index.json
+        token: PAT:${{MY_DEPENDABOT_ADO_PAT}}
+    ```
+    
 
 ## Security Advisories, Vulnerabilities, and Updates
 

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -5,11 +5,15 @@ require "dependabot/shared_helpers"
 
 #
 # This module auto installs the Azure Artifacts Credential Provider if any NuGet feeds are configured.
-# Without it, package feed authentication is not passed down to the native helper tools (i.e. NuGet, MSBuild, dotnet).
+# Without it, package feed authentication is not passed down to the native helper tools (i.e. dotnet).
 # See: https://github.com/tinglesoftware/dependabot-azure-devops/pull/1233 for more info.
+#
+# This module primarily fixes auth in .NET [Core] projects; .NET Framework project auth is handled by nuget.config.
+# See: tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb for more info.
 #
 # This credential provider is required for ALL private NuGet feeds, even if they are not hosted in Azure DevOps.
 # See README.md (Credentials for private registries and feeds) for more details.
+#
 
 # TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
 
@@ -29,8 +33,9 @@ module TingleSoftware
                 # Use username/password auth if provided, otherwise fallback to token auth.
                 # This provides maximum compatibility with Azure DevOps, DevOps Server, and other third-party feeds.
                 # When using DevOps PATs, the token is split into username/password parts; Username is not significant.
-                # e.g. "PAT:12345" --> { "username": "PAT", "password": "12345" }
-                #      ":12345"    --> { "username": "", "password": "12345" }
+                # e.g. token "PAT:12345" --> { "username": "PAT", "password": "12345" }
+                #            ":12345"    --> { "username": "", "password": "12345" }
+                #            "12345"     --> { "username": "12345", "password": "12345" }
                 "username" => cred["username"] || cred["token"]&.split(":")&.first,
                 "password" => cred["password"] || cred["token"]&.split(":")&.last
               }

--- a/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
+++ b/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
@@ -57,8 +57,7 @@ module Dependabot
           # Ensures that package source ordering and package source mappings in the user's nuget.config are respected.
           .reject { |c| c["key"] }
           .each_with_index.filter_map do |c, i|
-            source_key = c["key"] || "nuget_source_#{i + 1}"
-            "<add key=\"#{source_key}\" value=\"#{c['url']}\" />"
+            "<add key=\"nuget_source_#{i + 1}\" value=\"#{c['url']}\" />"
           end
       end
 

--- a/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
+++ b/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
@@ -55,7 +55,7 @@ module Dependabot
         credentials.each_with_index.filter_map do |c, i|
           # Ignore package sources that have a key (name), as these are already defined in the user's nuget.config file.
           # Ensures that package source ordering and package source mappings in the user's nuget.config are respected.
-          next unless c["url"]
+          next if c["key"]
 
           "<add key=\"nuget_source_#{i + 1}\" value=\"#{c['url']}\" />"
         end

--- a/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
+++ b/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
@@ -49,8 +49,6 @@ module Dependabot
             </configuration>
           NUGET_XML
         )
-
-        puts File.read(user_nuget_config_path)
       end
 
       def self.package_sources_xml_lines(credentials)

--- a/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
+++ b/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
@@ -1,0 +1,93 @@
+# typed: strong
+# frozen_string_literal: true
+
+# src: https://github.com/dependabot/dependabot-core/blob/8441dbad1bb13149f897cdbe92c11d36f98c8248/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb
+
+#
+# This module overrides the dependabot-core nuget.config credential helper with our own implementation that fixes:
+#  - https://github.com/tinglesoftware/dependabot-azure-devops/issues/1243
+#
+# Without this override, updates via MSBuild/NuGet.exe to .NET Framework projects (i.e. packages.config projects)
+# fail to authenticate with private NuGet feeds when:
+#  - The NuGet feed is hosted in Azure DevOps; The password is invalid if token notation is "PAT:12345"
+#  - The NuGet feed is secured with basic auth (e.g. nuget.telerik.com); The username was hardcoded to "user"
+#  - The source repository already contains a nuget.config file; All feed config and package source mappings are ignored
+#
+# This module primarily fixes auth in .NET Framework projects; .NET [Core] projects auth is handled differently.
+# See: tinglesoftware/azure/artifacts_credential_provider.rb for more info.
+#
+# This credential provider is required for ALL private NuGet feeds, even if they are not hosted in Azure DevOps.
+# See README.md (Credentials for private registries and feeds) for more details.
+#
+
+# TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
+
+module Dependabot
+  module Nuget
+    module NuGetConfigCredentialHelpers
+      def self.add_credentials_to_nuget_config(credentials)
+        return unless File.exist?(user_nuget_config_path)
+
+        nuget_credentials = credentials.select { |cred| cred["type"] == "nuget_feed" }
+        return if nuget_credentials.empty?
+
+        # When updating via MSBuild/NuGet.exe, dependabot temporarily overrides $HOME/.nuget/NuGet/NuGet.Config.
+        # The idea here is that we should only add missing package sources and missing credentials.
+
+        File.rename(user_nuget_config_path, temporary_nuget_config_path)
+        File.write(
+          user_nuget_config_path,
+          <<~NUGET_XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                #{package_sources_xml_lines(nuget_credentials).join("\n    ").strip}
+              </packageSources>
+              <packageSourceCredentials>
+                #{package_source_credentials_xml_lines(nuget_credentials).join("\n    ").strip}
+              </packageSourceCredentials>
+            </configuration>
+          NUGET_XML
+        )
+
+        puts File.read(user_nuget_config_path)
+      end
+
+      def self.package_sources_xml_lines(credentials)
+        credentials
+          # Reject package sources that have a key (name), as these are already defined in the user's nuget.config file.
+          # Ensures that package source ordering and package source mappings in the user's nuget.config are respected.
+          .reject { |c| c["key"] }
+          .each_with_index.filter_map do |c, i|
+            source_key = c["key"] || "nuget_source_#{i + 1}"
+            "<add key=\"#{source_key}\" value=\"#{c['url']}\" />"
+          end
+      end
+
+      def self.package_source_credentials_xml_lines(credentials) # rubocop:disable Metrics/PerceivedComplexity
+        credentials
+          .select { |c| c["token"] || c["username"] || c["password"] }
+          .each_with_index.flat_map do |c, i|
+            # Use the package source key (name) if provided, otherwise fallback to a auto-generated key.
+            # We want preserve the package source key (name) if it is already defined in the user's nuget.config file.
+            # This ensures that package source mappings in the user's nuget.config are respected.
+            source_key = c["key"] || "nuget_source_#{i + 1}"
+            # Use username/password auth if provided, otherwise fallback to token auth.
+            # This provides maximum compatibility with Azure DevOps, DevOps Server, and other third-party feeds.
+            # When using DevOps PATs, the token is split into username/password parts; Username is not significant.
+            # e.g. token "PAT:12345" --> { "username": "PAT", "password": "12345" }
+            #            ":12345"    --> { "username": "", "password": "12345" }
+            #            "12345"     --> { "username": "12345", "password": "12345" }
+            source_username = c["username"] || c["token"]&.split(":")&.first
+            source_password = c["password"] || c["token"]&.split(":")&.last
+            [
+              "<#{source_key}>",
+              "  <add key=\"Username\" value=\"#{source_username}\" />",
+              "  <add key=\"ClearTextPassword\" value=\"#{source_password}\" />",
+              "</#{source_key}>"
+            ]
+          end
+      end
+    end
+  end
+end

--- a/updater/lib/tinglesoftware/dependabot/overrides/pull_request_creator/pr_name_prefixer.rb
+++ b/updater/lib/tinglesoftware/dependabot/overrides/pull_request_creator/pr_name_prefixer.rb
@@ -1,31 +1,28 @@
 # typed: strict
 # frozen_string_literal: true
 
+# src: https://github.com/dependabot/dependabot-core/blob/8441dbad1bb13149f897cdbe92c11d36f98c8248/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+
+#
+# This module overrides the dependabot-core PR name prefixer with our own implementation that allows setting the styler.
+# Without this override, there is no way for the end-user to explicitly set the PR name prefix styler implementation.
+#
+
+# TODO: Remove this if/when dependabot makes this user-configurable or removes this feature entirely.
+
 require "dependabot/pull_request_creator"
 
 module Dependabot
   class PullRequestCreator
     class PrNamePrefixer
-      extend T::Sig
-
-      #
-      # Dependabot currently does provide an extension point for setting the PR name prefix styler.
-      # To work around this, we override the dependabot-core definitions and provide our own implementation.
-      #
-      # TODO: If/when dependabot make this user-configurable, remove this override.
-      #
-
-      sig { returns(T::Boolean) }
       def using_angular_commit_messages?
         ENV.fetch("DEPENDABOT_PR_NAME_PREFIX_STYLE", nil) == "angular"
       end
 
-      sig { returns(T::Boolean) }
       def using_eslint_commit_messages?
         ENV.fetch("DEPENDABOT_PR_NAME_PREFIX_STYLE", nil) == "eslint"
       end
 
-      sig { returns(T::Boolean) }
       def using_gitmoji_commit_messages?
         ENV.fetch("DEPENDABOT_PR_NAME_PREFIX_STYLE", nil) == "gitmoji"
       end

--- a/updater/lib/tinglesoftware/dependabot/setup.rb
+++ b/updater/lib/tinglesoftware/dependabot/setup.rb
@@ -49,4 +49,5 @@ require "dependabot/swift"
 require "dependabot/devcontainers"
 
 # Overrides for dependabot core functionality that are currently not extensible
+require "tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers"
 require "tinglesoftware/dependabot/overrides/pull_request_creator/pr_name_prefixer"


### PR DESCRIPTION
### What are you trying to accomplish?
Fixes #1243

It should be possible to update dependencies in a .NET Framework project when using:
- Private Azure DevOps NuGet package feeds (e.g. dev.azure.com); or
- Private NuGet package feeds secured with basic auth (e.g. nuget.telerik.com); or
- User defined `nuget.config` package sources and package source mappings

### Changes
- Updated [README.MD](https://github.com/tinglesoftware/dependabot-azure-devops/pull/1248/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with example of how to configure private NuGet auth when the source repo contains a `nuget.config` file.
- Added `NuGetConfigCredentialHelpers`, which overrides the default `nuget.config` proxy code within dependabot-core with better code that handles more auth scenarios (see code comments for more info).
  - Compare the [original code](https://github.com/dependabot/dependabot-core/blob/8441dbad1bb13149f897cdbe92c11d36f98c8248/nuget/lib/dependabot/nuget/nuget_config_credential_helpers.rb#L23-L56) with the [updated code](https://github.com/tinglesoftware/dependabot-azure-devops/blob/e02288b9cfbe8954877987b9563f4f3e7c87997c/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb#L28-L88).
