### PR TITLE
Enable opentelemetry in `updater_script_vnext`

### DIFF
--- a/updater/lib/tinglesoftware/dependabot/setup.rb
+++ b/updater/lib/tinglesoftware/dependabot/setup.rb
@@ -8,6 +8,7 @@ require "dependabot"
 require "dependabot/logger"
 require "dependabot/logger/formats"
 require "dependabot/simple_instrumentor"
+require "dependabot/opentelemetry"
 require "dependabot/environment"
 
 ENV["DEPENDABOT_JOB_ID"] = Time.now.to_i.to_s unless ENV["DEPENDABOT_JOB_ID"]
@@ -27,6 +28,8 @@ Dependabot::SimpleInstrumentor.subscribe do |*args|
     puts "🚨 #{payload[:body]}" if payload[:body] && error_codes.include?(payload[:status])
   end
 end
+
+Dependabot::OpenTelemetry.configure
 
 # Ecosystems
 require "dependabot/python"


### PR DESCRIPTION
This is the first step towards adding telemetry to the updater. Useful in debugging of issues and general analytics. It follows what the GitHub hosted version has.