### PR TITLE
Enable sentry in `updater_script_vnext`

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -106,6 +106,7 @@ jobs:
         --build-arg BUILDKIT_INLINE_CACHE=1 \
         --build-arg ECOSYSTEM=${{ matrix.suite.ecosystem }} \
         --build-arg BASE_VERSION=${{ steps.docker-base-version.outputs.version }} \
+        --build-arg DEPENDABOT_UPDATER_VERSION=${{ steps.gitversion.outputs.nuGetVersionV2 }} \
         --label com.github.image.run.id=${{ github.run_id }} \
         --label com.github.image.run.number=${{ github.run_number }} \
         --label com.github.image.job.id=${{ github.job }} \

--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -1,5 +1,6 @@
 ARG ECOSYSTEM
 ARG BASE_VERSION=latest
+ARG DEPENDABOT_UPDATER_VERSION=unknown
 
 # The Dependabot docker images in https://github.com/dependabot/dependabot-core are no longer versioned like the Ruby Gems; instead they are versioned by the commit SHA of the release tag.
 # In production, the build pipeline automatically calculates BASE_VERSION to match the dependabot-omnibus version set in updater/Gemfile (see .github/workflows/updater.yml).
@@ -24,6 +25,9 @@ RUN bundle config set --local path 'vendor' && \
 # Add project
 COPY --chown=dependabot:dependabot LICENSE $DEPENDABOT_HOME
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
+
+# Add ENV
+ENV DEPENDABOT_UPDATER_VERSION=$DEPENDABOT_UPDATER_VERSION
 
 # ENTRYPOINT IS USED instead of CMD so as to avoid adding
 # 'bin/run.sh' before the file name when running the image

--- a/updater/lib/tinglesoftware/dependabot/setup.rb
+++ b/updater/lib/tinglesoftware/dependabot/setup.rb
@@ -3,12 +3,14 @@
 
 require "json"
 require "logger"
+require "sentry-ruby"
 
 require "dependabot"
 require "dependabot/logger"
 require "dependabot/logger/formats"
 require "dependabot/simple_instrumentor"
 require "dependabot/opentelemetry"
+require "dependabot/sentry"
 require "dependabot/environment"
 
 ENV["DEPENDABOT_JOB_ID"] = Time.now.to_i.to_s unless ENV["DEPENDABOT_JOB_ID"]
@@ -16,6 +18,17 @@ ENV["DEPENDABOT_JOB_ID"] = Time.now.to_i.to_s unless ENV["DEPENDABOT_JOB_ID"]
 Dependabot.logger = Logger.new($stdout).tap do |logger|
   logger.level = ENV["DEPENDABOT_DEBUG"].to_s == "true" ? :debug : :info
   logger.formatter = Dependabot::Logger::BasicFormatter.new
+end
+
+# TODO: connect error handler to the job, operation, or service so that the errors can be reported to Sentry here
+Sentry.init do |config|
+  config.dsn = "https://0abd35cde5ca89c8dbcfb766a5f5bc50@o4507686465830912.ingest.us.sentry.io/4507686484508672"
+  config.release = ENV.fetch("DEPENDABOT_UPDATER_VERSION", "unknown")
+  config.logger = Dependabot.logger
+
+  config.before_send = ->(event, hint) { Dependabot::Sentry.process_chain(event, hint) }
+  config.propagate_traces = false
+  config.instrumenter = ::Dependabot::OpenTelemetry.should_configure? ? :otel : :sentry
 end
 
 Dependabot::SimpleInstrumentor.subscribe do |*args|


### PR DESCRIPTION
This is the second step towards monitoring the updater. Useful in debugging of issues and general analytics. It follows what the GitHub hosted version has.

OpenTelemetry was setup in #1254. Next step is to connect the error handler.