### PR TITLE
Backport NuGet auth fix to `update_script`; Prevent NuGet leaking passwords in logs

### DIFF
--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -46,7 +46,10 @@ require "dependabot/terraform"
 require "tinglesoftware/dependabot/clients/azure"
 require "tinglesoftware/dependabot/vulnerabilities"
 
+# Fixes for NuGet feed auth issues
+# TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
 require "tinglesoftware/azure/artifacts_credential_provider"
+require "tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers"
 
 # These options try to follow the dry-run.rb script.
 # https://github.com/dependabot/dependabot-core/blob/main/bin/dry-run.rb

--- a/updater/bin/update_script_vnext.rb
+++ b/updater/bin/update_script_vnext.rb
@@ -10,8 +10,6 @@ require "tinglesoftware/dependabot/setup"
 require "tinglesoftware/dependabot/job"
 require "tinglesoftware/dependabot/commands/update_all_dependencies_synchronous_command"
 
-require "tinglesoftware/azure/artifacts_credential_provider"
-
 ENV["UPDATER_ONE_CONTAINER"] = "true" # The full end-to-end update will happen in a single container
 ENV["UPDATER_DETERMINISTIC"] = "true" # The list of dependencies to update will be consistent across multiple runs
 

--- a/updater/lib/tinglesoftware/dependabot/setup.rb
+++ b/updater/lib/tinglesoftware/dependabot/setup.rb
@@ -49,5 +49,9 @@ require "dependabot/swift"
 require "dependabot/devcontainers"
 
 # Overrides for dependabot core functionality that are currently not extensible
-require "tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers"
 require "tinglesoftware/dependabot/overrides/pull_request_creator/pr_name_prefixer"
+
+# Fixes for NuGet feed auth issues
+# TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
+require "tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers"
+require "tinglesoftware/azure/artifacts_credential_provider"


### PR DESCRIPTION
### What are you trying to accomplish?
- When using `update_script.rb`, all the `nuget.config` auth fixes should be applied.
- NuGet should not leak passwords to console output via username. e.g.
  ```log
  MSBuild auto-detection: using msbuild version 'Current' from '/usr/local/dotnet/current/sdk/8.0.300'.
  Using credentials from config. UserName: user
  An error occurred while retrieving package metadata for 'Microsoft.Graph.5.56.0' from source 'nuget_source_1'.
  ```

### Changes
- Require `nuget_config_credential_helpers.rb` in `update_script.rb`
- In `nuget_config_credential_helpers.rb`, if the username and password are the same value, we assume that "token" auth is being used and that the username is not significant, so redact username to something generic to avoid NuGet leaking sensitive information. Given current documentation in [README.md](https://github.com/tinglesoftware/dependabot-azure-devops?tab=readme-ov-file#credentials-for-private-registries-and-feeds), leaking was unlikely to actually happen, but it _could_ happen if `dependabot.yml` was misconfigured. 