### PR TITLE
Remove temp Nuget Image Tag Version

### DIFF
--- a/server/Tingle.Dependabot/Program.cs
+++ b/server/Tingle.Dependabot/Program.cs
@@ -14,10 +14,6 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(30)); /* default is 5 seconds */
 
-// Add Azure AppConfiguration
-builder.Configuration.AddStandardAzureAppConfiguration(builder.Environment);
-builder.Services.AddAzureAppConfiguration();
-builder.Services.AddSingleton<IStartupFilter, AzureAppConfigurationStartupFilter>(); // Use IStartupFilter to setup AppConfiguration middleware correctly
 
 // Add Serilog
 builder.Services.AddSerilog(builder =>

--- a/server/Tingle.Dependabot/appsettings.json
+++ b/server/Tingle.Dependabot/appsettings.json
@@ -12,7 +12,6 @@
   },
   "AllowedHosts": "*",
 
-  "AzureAppConfig:Endpoint": null, // only set a value in production or in secrets
   "ConnectionStrings:Sql": "Server=(localdb)\\mssqllocaldb;Database=dependabot;Trusted_Connection=True;MultipleActiveResultSets=true",
 
   "DataProtection": {

--- a/server/main.bicep
+++ b/server/main.bicep
@@ -103,10 +103,6 @@ resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2023-0
       '${managedIdentity.id}': {/*ttk bug*/ }
     }
   }
-
-  // override the default updater image tag for nuget jobs
-  // TODO: remove this here and on Azure once the authentication issues are resolved (https://github.com/tinglesoftware/dependabot-azure-devops/issues/921)
-  resource nugetVersion 'keyValues' = { name: 'Workflow:UpdaterImageTags:nuget$Production', properties: { value: '1.24' } }
 }
 
 /* Storage Account */

--- a/server/main.bicep
+++ b/server/main.bicep
@@ -91,19 +91,6 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-11-01' = {
   resource authorizationRule 'AuthorizationRules' existing = { name: 'RootManageSharedAccessKey' }
 }
 
-/* AppConfiguration */
-resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2023-03-01' = {
-  name: name
-  location: location
-  properties: { softDeleteRetentionInDays: 0 /* Free does not support this */ }
-  sku: { name: 'free' }
-  identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: {
-      '${managedIdentity.id}': {/*ttk bug*/ }
-    }
-  }
-}
 
 /* Storage Account */
 resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
@@ -278,7 +265,6 @@ resource app 'Microsoft.App/containerApps@2023-05-01' = {
 
             { name: 'PROJECT_SETUPS', secretRef: 'project-setups' }
 
-            { name: 'AzureAppConfig__Endpoint', value: appConfiguration.properties.endpoint }
             { name: 'AzureAppConfig__Label', value: 'Production' }
 
             { name: 'ApplicationInsights__ConnectionString', secretRef: 'connection-strings-application-insights' }


### PR DESCRIPTION
Remove the override for nuget packages back to 1.24 as #921 is now resolved

Apologies if I'm incorrect on this but it looks like this was the only reason for having an AppConfiguration Resource at all. I've also attempted to remove all references to this from the C# project.