### PR TITLE
Remove Image Tag OverRide For Nuget as #921 is fixed and 1.24 no longer available

### DIFF
--- a/server/main.bicep
+++ b/server/main.bicep
@@ -104,9 +104,7 @@ resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2023-0
     }
   }
 
-  // override the default updater image tag for nuget jobs
-  // TODO: remove this here and on Azure once the authentication issues are resolved (https://github.com/tinglesoftware/dependabot-azure-devops/issues/921)
-  resource nugetVersion 'keyValues' = { name: 'Workflow:UpdaterImageTags:nuget$Production', properties: { value: '1.24' } }
+
 }
 
 /* Storage Account */


### PR DESCRIPTION
As per title, also had another PR that looks to remove AppConfiguration all together but slightly more intwined than i expected, this fixes the immediate issue that server deployments dont actually currently work out of the box because 1.24 is no longer available.