### PR TITLE
Adding the ability to specify a custom path to a configuration file

### DIFF
--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -52,7 +52,6 @@
       "type": "string",
       "groupName": "advanced",
       "label": "Overrides the default path to the configuration file",
-      "defaultValue": "false",
       "required": false,
       "helpMarkDown": "When set, provided path will used to find configuration yaml file instead of the default ones."
     },

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -48,6 +48,15 @@
   ],
   "inputs": [
     {
+      "name": "configFilePath",
+      "type": "string",
+      "groupName": "advanced",
+      "label": "Overrides the default path to the configuration file",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "When set, provided path will used to find configuration yaml file instead of the default ones."
+    },
+    {
       "name": "useUpdateScriptvNext",
       "type": "boolean",
       "groupName": "advanced",

--- a/extension/task/utils/getSharedVariables.ts
+++ b/extension/task/utils/getSharedVariables.ts
@@ -75,6 +75,10 @@ export interface ISharedVariables {
   /** Tag of the docker image to be pulled */
   dockerImageTag: string;
 
+  /** Custom path to the configuration file */
+  configFilePath: string;
+  configFilePathOverridden: boolean
+
   /** Dependabot command to run */
   command: string;
 }
@@ -162,6 +166,8 @@ export default function getSharedVariables(): ISharedVariables {
     ? "update_script_vnext"
     : "update_script";
 
+  let configFilePath: string = tl.getInput("configFilePath");
+  let configFilePathOverridden: boolean = typeof configFilePath === "string";
   return {
     organizationUrl: formattedOrganizationUrl,
     protocol,
@@ -203,6 +209,9 @@ export default function getSharedVariables(): ISharedVariables {
 
     dockerImageTag,
 
-    command
+    command,
+
+    configFilePath,
+    configFilePathOverridden
   };
 }

--- a/extension/task/utils/parseConfigFile.ts
+++ b/extension/task/utils/parseConfigFile.ts
@@ -24,7 +24,7 @@ import axios from "axios";
  * @returns {IDependabotConfig} config - the dependabot configuration
  */
 async function parseConfigFile(variables: ISharedVariables): Promise<IDependabotConfig> {
-  const possibleFilePaths = [
+  const possibleFilePaths = variables.configFilePathOverridden ? [variables.configFilePath] : [
     "/.azuredevops/dependabot.yml",
     "/.azuredevops/dependabot.yaml",
 


### PR DESCRIPTION
This adds the ability to provide a custom path to the configuration file in the azure devops extension

## Changes
- Added new task input with name "configFilePath" to enable passings custom path to the configuration file