### PR TITLE
Fix "Value cannot be null or empty string. (Parameter 'username')"

### DIFF
--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -46,7 +46,7 @@ require "dependabot/terraform"
 require "tinglesoftware/dependabot/clients/azure"
 require "tinglesoftware/dependabot/vulnerabilities"
 
-# Overides to fix various authentication related issues with private feeds
+# Overrides to fix various authentication related issues with private feeds
 # TODO: Remove these workarounds once auth can be moved out to the "proxy" component, like dependabot-cli does
 require "tinglesoftware/azure/artifacts_credential_provider"
 require "tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers"

--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -46,8 +46,8 @@ require "dependabot/terraform"
 require "tinglesoftware/dependabot/clients/azure"
 require "tinglesoftware/dependabot/vulnerabilities"
 
-# Fixes for NuGet feed auth issues
-# TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
+# Overides to fix various authentication related issues with private feeds
+# TODO: Remove these workarounds once auth can be moved out to the "proxy" component, like dependabot-cli does
 require "tinglesoftware/azure/artifacts_credential_provider"
 require "tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers"
 

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -24,11 +24,11 @@ module TingleSoftware
         return if private_nuget_feeds.empty?
 
         # Configure NuGet feed authentication
-        token_parts = cred["token"]&.split(":", 2)&.reject(&:empty?) || []
         ENV.store(
           "VSS_NUGET_EXTERNAL_FEED_ENDPOINTS",
           JSON.dump({
             "endpointCredentials" => private_nuget_feeds.map do |cred|
+              token_parts = cred["token"]&.split(":", 2)&.reject(&:empty?) || []
               {
                 "endpoint" => cred["url"],
                 # Use username/password auth if provided, otherwise fallback to token auth.

--- a/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
+++ b/updater/lib/tinglesoftware/azure/artifacts_credential_provider.rb
@@ -15,7 +15,7 @@ require "dependabot/shared_helpers"
 # See README.md (Credentials for private registries and feeds) for more details.
 #
 
-# TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
+# TODO: Remove this once auth can be moved out to the "proxy" component, like dependabot-cli does
 
 module TingleSoftware
   module Azure

--- a/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
+++ b/updater/lib/tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers.rb
@@ -20,7 +20,7 @@
 # See README.md (Credentials for private registries and feeds) for more details.
 #
 
-# TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
+# TODO: Remove this once auth can be moved out to the "proxy" component, like dependabot-cli does
 
 module Dependabot
   module Nuget

--- a/updater/lib/tinglesoftware/dependabot/setup.rb
+++ b/updater/lib/tinglesoftware/dependabot/setup.rb
@@ -67,7 +67,7 @@ require "dependabot/devcontainers"
 # Overrides for dependabot core functionality that are currently not extensible
 require "tinglesoftware/dependabot/overrides/pull_request_creator/pr_name_prefixer"
 
-# Overides to fix various authentication related issues with private feeds
+# Overrides to fix various authentication related issues with private feeds
 # TODO: Remove these workarounds once auth can be moved out to the "proxy" component, like dependabot-cli does
 require "tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers"
 require "tinglesoftware/azure/artifacts_credential_provider"

--- a/updater/lib/tinglesoftware/dependabot/setup.rb
+++ b/updater/lib/tinglesoftware/dependabot/setup.rb
@@ -67,7 +67,7 @@ require "dependabot/devcontainers"
 # Overrides for dependabot core functionality that are currently not extensible
 require "tinglesoftware/dependabot/overrides/pull_request_creator/pr_name_prefixer"
 
-# Fixes for NuGet feed auth issues
-# TODO: Remove this once https://github.com/dependabot/dependabot-core/pull/8927 is resolved or auth works natively.
+# Overides to fix various authentication related issues with private feeds
+# TODO: Remove these workarounds once auth can be moved out to the "proxy" component, like dependabot-cli does
 require "tinglesoftware/dependabot/overrides/nuget/nuget_config_credential_helpers"
 require "tinglesoftware/azure/artifacts_credential_provider"


### PR DESCRIPTION
### What are you trying to accomplish?
Fix error "Value cannot be null or empty string. (Parameter 'username')" when using a private NuGet feed with a token formatted as ":{{PAT}}".

Reported by users in these comments:
- https://github.com/tinglesoftware/dependabot-azure-devops/issues/1257#issuecomment-2260619241
- https://github.com/tinglesoftware/dependabot-azure-devops/issues/1257#issuecomment-2298981074

### Changes
The NuGet username is never set to null/empty; it defaults to "unused" if empty.
e.g.

```ruby
"PAT:12345" --> { "username": "PAT", "password": "12345" }
":12345"    --> { "username": "unused", "password": "12345" }
"12345"     --> { "username": "unused", "password": "12345" }
""          --> { "username": "unused", "password": "" }
```