### PR TITLE
Update the server version/component to support directories and groups

### DIFF
--- a/server/Tingle.Dependabot.Tests/Models/DependabotConfigurationTests.cs
+++ b/server/Tingle.Dependabot.Tests/Models/DependabotConfigurationTests.cs
@@ -22,11 +22,12 @@ public class DependabotConfigurationTests
         Assert.NotNull(configuration);
         Assert.Equal(2, configuration.Version);
         Assert.NotNull(configuration.Updates);
-        Assert.Equal(2, configuration.Updates.Count);
+        Assert.Equal(3, configuration.Updates.Count);
 
         var first = configuration.Updates[0];
         Assert.Equal("/", first.Directory);
-        Assert.Equal("docker", first.PackageEcosystem);
+        Assert.Null(first.Directories);
+        Assert.Equal("nuget", first.PackageEcosystem);
         Assert.Equal(DependabotScheduleInterval.Weekly, first.Schedule?.Interval);
         Assert.Equal(new TimeOnly(3, 0), first.Schedule?.Time);
         Assert.Equal(DependabotScheduleDay.Sunday, first.Schedule?.Day);
@@ -36,6 +37,7 @@ public class DependabotConfigurationTests
 
         var second = configuration.Updates[1];
         Assert.Equal("/client", second.Directory);
+        Assert.Null(second.Directories);
         Assert.Equal("npm", second.PackageEcosystem);
         Assert.Equal(DependabotScheduleInterval.Daily, second.Schedule?.Interval);
         Assert.Equal(new TimeOnly(3, 15), second.Schedule?.Time);
@@ -43,6 +45,17 @@ public class DependabotConfigurationTests
         Assert.Equal("Etc/UTC", second.Schedule?.Timezone);
         Assert.Equal("deny", second.InsecureExternalCodeExecution);
         Assert.Equal(["reg1", "reg2"], second.Registries);
+
+        var third = configuration.Updates[2];
+        Assert.Null(third.Directory);
+        Assert.Equal(["**/*"], third.Directories);
+        Assert.Equal("docker", third.PackageEcosystem);
+        Assert.Equal(DependabotScheduleInterval.Daily, third.Schedule?.Interval);
+        Assert.Equal(new TimeOnly(2, 00), third.Schedule?.Time);
+        Assert.Equal(DependabotScheduleDay.Monday, third.Schedule?.Day);
+        Assert.Equal("Etc/UTC", third.Schedule?.Timezone);
+        Assert.Null(third.InsecureExternalCodeExecution);
+        Assert.Null(third.Registries);
     }
 
     [Fact]
@@ -95,7 +108,7 @@ public class DependabotConfigurationTests
         Assert.NotNull(val.ErrorMessage);
         Assert.Equal("Registries: 'dummy1,dummy2' have not been referenced by any update", val.ErrorMessage);
 
-        // fails: registrynot configured
+        // fails: registry not configured
         configuration.Updates[0].Registries?.AddRange(["dummy1", "dummy2", "dummy3"]);
         results = [];
         actual = RecursiveValidator.TryValidateObject(configuration, results);

--- a/server/Tingle.Dependabot.Tests/Models/DependabotUpdateTests.cs
+++ b/server/Tingle.Dependabot.Tests/Models/DependabotUpdateTests.cs
@@ -1,0 +1,43 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Tingle.Dependabot.Models.Dependabot;
+using Xunit;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Tingle.Dependabot.Tests.Models;
+
+public class DependabotUpdateTests
+{
+    [Fact]
+    public void Validation_Works()
+    {
+        var update = new DependabotUpdate
+        {
+            PackageEcosystem = "npm",
+            Directory = "/",
+            Directories = null,
+            Schedule = new()
+            {
+                Interval = DependabotScheduleInterval.Monthly,
+                Time = new(2, 0),
+            },
+        };
+
+        // works as expected
+        var results = new List<ValidationResult>();
+        var actual = RecursiveValidator.TryValidateObject(update, results);
+        Assert.True(actual);
+        Assert.Empty(results);
+
+        // fails: directory and directories not provided
+        update.Directory = null;
+        update.Directories = null;
+        results = [];
+        actual = RecursiveValidator.TryValidateObject(update, results);
+        Assert.False(actual);
+        var val = Assert.Single(results);
+        Assert.Equal([nameof(update.Directory), nameof(update.Directories)], val.MemberNames);
+        Assert.NotNull(val.ErrorMessage);
+        Assert.Equal("Either 'directory' or 'directories' must be provided", val.ErrorMessage);
+    }
+}

--- a/server/Tingle.Dependabot.Tests/PeriodicTasks/MissedTriggerCheckerTaskTests.cs
+++ b/server/Tingle.Dependabot.Tests/PeriodicTasks/MissedTriggerCheckerTaskTests.cs
@@ -119,6 +119,7 @@ public class MissedTriggerCheckerTaskTests(ITestOutputHelper outputHelper)
                 {
                     PackageEcosystem = "npm",
                     Directory = "/",
+                    Directories = null,
                     Schedule = new DependabotUpdateSchedule
                     {
                         Interval = DependabotScheduleInterval.Daily,
@@ -129,7 +130,8 @@ public class MissedTriggerCheckerTaskTests(ITestOutputHelper outputHelper)
                 new RepositoryUpdate
                 {
                     PackageEcosystem = "npm",
-                    Directory = "/legacy",
+                    Directory = null,
+                    Directories = ["/legacy"],
                     Schedule = new DependabotUpdateSchedule
                     {
                         Interval = DependabotScheduleInterval.Daily,

--- a/server/Tingle.Dependabot.Tests/PeriodicTasks/UpdateJobsCleanerTaskTests.cs
+++ b/server/Tingle.Dependabot.Tests/PeriodicTasks/UpdateJobsCleanerTaskTests.cs
@@ -34,6 +34,7 @@ public class UpdateJobsCleanerTaskTests(ITestOutputHelper outputHelper)
                 Created = DateTimeOffset.UtcNow.AddMinutes(-19),
                 PackageEcosystem = "npm",
                 Directory = "/",
+                Directories = null,
                 Resources = new(0.25, 0.2),
                 AuthKey = Guid.NewGuid().ToString("n"),
                 Status = UpdateJobStatus.Succeeded,
@@ -47,6 +48,7 @@ public class UpdateJobsCleanerTaskTests(ITestOutputHelper outputHelper)
                 Created = DateTimeOffset.UtcNow.AddHours(-100),
                 PackageEcosystem = "nuget",
                 Directory = "/",
+                Directories = null,
                 Resources = new(0.25, 0.2),
                 AuthKey = Guid.NewGuid().ToString("n"),
                 Status = UpdateJobStatus.Succeeded,
@@ -59,7 +61,8 @@ public class UpdateJobsCleanerTaskTests(ITestOutputHelper outputHelper)
                 RepositorySlug = "test-repo",
                 Created = DateTimeOffset.UtcNow.AddMinutes(-30),
                 PackageEcosystem = "docker",
-                Directory = "/",
+                Directory = null,
+                Directories = ["**/*"],
                 Resources = new(0.25, 0.2),
                 AuthKey = Guid.NewGuid().ToString("n"),
                 Status = UpdateJobStatus.Running,
@@ -90,6 +93,7 @@ public class UpdateJobsCleanerTaskTests(ITestOutputHelper outputHelper)
                 Created = DateTimeOffset.UtcNow.AddDays(-80),
                 PackageEcosystem = "npm",
                 Directory = "/",
+                Directories = null,
                 Resources = new(0.25, 0.2),
                 AuthKey = Guid.NewGuid().ToString("n"),
             });
@@ -102,6 +106,7 @@ public class UpdateJobsCleanerTaskTests(ITestOutputHelper outputHelper)
                 Created = DateTimeOffset.UtcNow.AddDays(-100),
                 PackageEcosystem = "nuget",
                 Directory = "/",
+                Directories = null,
                 Resources = new(0.25, 0.2),
                 AuthKey = Guid.NewGuid().ToString("n"),
             });
@@ -113,7 +118,8 @@ public class UpdateJobsCleanerTaskTests(ITestOutputHelper outputHelper)
                 RepositorySlug = "test-repo",
                 Created = DateTimeOffset.UtcNow.AddDays(-120),
                 PackageEcosystem = "docker",
-                Directory = "/",
+                Directory = null,
+                Directories = ["**/*"],
                 Resources = new(0.25, 0.2),
                 AuthKey = Guid.NewGuid().ToString("n"),
             });
@@ -168,6 +174,7 @@ public class UpdateJobsCleanerTaskTests(ITestOutputHelper outputHelper)
                 {
                     PackageEcosystem = "npm",
                     Directory = "/",
+                    Directories = null,
                     Schedule = new DependabotUpdateSchedule
                     {
                         Interval = DependabotScheduleInterval.Daily,
@@ -177,7 +184,8 @@ public class UpdateJobsCleanerTaskTests(ITestOutputHelper outputHelper)
                 new RepositoryUpdate
                 {
                     PackageEcosystem = "npm",
-                    Directory = "/legacy",
+                    Directory = null,
+                    Directories = ["/legacy"],
                     Schedule = new DependabotUpdateSchedule
                     {
                         Interval = DependabotScheduleInterval.Daily,

--- a/server/Tingle.Dependabot.Tests/Samples/dependabot.yml
+++ b/server/Tingle.Dependabot.Tests/Samples/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'docker' # See documentation for possible values
+  - package-ecosystem: 'nuget' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
@@ -31,6 +31,10 @@ updates:
       update-types: ['version-update:semver-major']
     - dependency-name: '@types/react-dom'
       update-types: ['version-update:semver-major']
+  - package-ecosystem: 'docker' # See documentation for possible values
+    directories: ['**/*'] # Location of package manifests
+    schedule:
+      interval: 'daily'
 registries:
   reg1:
     type: nuget-feed

--- a/server/Tingle.Dependabot/Consumers/TriggerUpdateJobsEventConsumer.cs
+++ b/server/Tingle.Dependabot/Consumers/TriggerUpdateJobsEventConsumer.cs
@@ -57,7 +57,12 @@ internal class TriggerUpdateJobsEventConsumer(MainDbContext dbContext, UpdateRun
             var ecosystem = update.PackageEcosystem!;
 
             // check if there is an existing one
-            var job = await dbContext.UpdateJobs.SingleOrDefaultAsync(j => j.PackageEcosystem == ecosystem && j.Directory == update.Directory && j.EventBusId == eventBusId, cancellationToken);
+            var job = await (from j in dbContext.UpdateJobs
+                             where j.PackageEcosystem == ecosystem
+                             where j.Directory == update.Directory
+                             where j.Directories == update.Directories
+                             where j.EventBusId == eventBusId
+                             select j).SingleOrDefaultAsync(cancellationToken);
             if (job is not null)
             {
                 logger.SkippingTriggerJobAlreadyExists(repositoryId: repository.Id,
@@ -89,6 +94,7 @@ internal class TriggerUpdateJobsEventConsumer(MainDbContext dbContext, UpdateRun
                     Commit = repository.LatestCommit,
                     PackageEcosystem = ecosystem,
                     Directory = update.Directory,
+                    Directories = update.Directories,
                     Resources = resources,
                     AuthKey = Guid.NewGuid().ToString("n"),
 

--- a/server/Tingle.Dependabot/Consumers/UpdateJobEventsConsumer.cs
+++ b/server/Tingle.Dependabot/Consumers/UpdateJobEventsConsumer.cs
@@ -71,7 +71,11 @@ internal class UpdateJobEventsConsumer(MainDbContext dbContext, UpdateRunner upd
         var repository = await dbContext.Repositories.SingleOrDefaultAsync(r => r.Id == job.RepositoryId, cancellationToken);
         if (repository is not null)
         {
-            var update = repository.Updates.SingleOrDefault(u => u.PackageEcosystem == job.PackageEcosystem && u.Directory == job.Directory);
+            var update = (from u in repository.Updates
+                          where u.PackageEcosystem == job.PackageEcosystem
+                          where u.Directory == job.Directory
+                          where u.Directories == job.Directories
+                          select u).SingleOrDefault();
             if (update is not null && update.LatestJobId == job.Id)
             {
                 update.LatestJobStatus = job.Status;

--- a/server/Tingle.Dependabot/Controllers/UpdateJobsController.cs
+++ b/server/Tingle.Dependabot/Controllers/UpdateJobsController.cs
@@ -103,7 +103,11 @@ public class UpdateJobsController(MainDbContext dbContext, IEventPublisher publi
         var repository = await dbContext.Repositories.SingleAsync(r => r.Id == job.RepositoryId);
 
         // update the database
-        var update = repository.Updates.SingleOrDefault(u => u.PackageEcosystem == job.PackageEcosystem && u.Directory == job.Directory);
+        var update = (from u in repository.Updates
+            where u.PackageEcosystem == job.PackageEcosystem
+            where u.Directory == job.Directory
+            where u.Directories == job.Directories
+            select u).SingleOrDefault();
         if (update is not null)
         {
             update.Files = model.Data?.DependencyFiles ?? [];

--- a/server/Tingle.Dependabot/Models/Dependabot/DependabotConfiguration.cs
+++ b/server/Tingle.Dependabot/Models/Dependabot/DependabotConfiguration.cs
@@ -38,16 +38,18 @@ public class DependabotConfiguration : IValidatableObject
     }
 }
 
-public record DependabotUpdate
+public record DependabotUpdate : IValidatableObject
 {
     /// <summary>Ecosystem for the update.</summary>
     [Required]
     [JsonPropertyName("package-ecosystem")]
     public string? PackageEcosystem { get; set; }
 
-    [Required]
     [JsonPropertyName("directory")]
     public string? Directory { get; set; }
+
+    [JsonPropertyName("directories")]
+    public List<string>? Directories { get; set; }
 
     [Required]
     [JsonPropertyName("schedule")]
@@ -61,6 +63,10 @@ public record DependabotUpdate
 
     [JsonPropertyName("allow")]
     public List<DependabotAllowDependency>? Allow { get; set; }
+    
+    [JsonPropertyName("groups")]
+    public List<DependabotGroupDependency>? Groups { get; set; }
+
     [JsonPropertyName("ignore")]
     public List<DependabotIgnoreDependency>? Ignore { get; set; }
     [JsonPropertyName("commit-message")]
@@ -81,6 +87,16 @@ public record DependabotUpdate
     public bool Vendor { get; set; } = false;
     [JsonPropertyName("versioning-strategy")]
     public string VersioningStrategy { get; set; } = "auto";
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrWhiteSpace(Directory) && (Directories is null || Directories.Count == 0))
+        {
+            yield return new ValidationResult(
+                "Either 'directory' or 'directories' must be provided",
+                memberNames: [nameof(Directory), nameof(Directories)]);
+        }
+    }
 }
 
 public class DependabotUpdateSchedule
@@ -117,6 +133,20 @@ public class DependabotUpdateSchedule
             _ => throw new NotImplementedException(),
         };
     }
+}
+
+public class DependabotGroupDependency
+{
+    [JsonPropertyName("applies-to")]
+    public string? AppliesTo { get; set; }
+    [JsonPropertyName("dependency-type")]
+    public string? DependencyType { get; set; }
+    [JsonPropertyName("patterns")]
+    public List<string>? Patterns { get; set; }
+    [JsonPropertyName("exclude-patterns")]
+    public List<string>? ExcludePatterns { get; set; }
+    [JsonPropertyName("update-types")]
+    public List<string>? UpdateTypes { get; set; }
 }
 
 public class DependabotAllowDependency : IValidatableObject

--- a/server/Tingle.Dependabot/Models/MainDbContext.cs
+++ b/server/Tingle.Dependabot/Models/MainDbContext.cs
@@ -61,8 +61,8 @@ public class MainDbContext(DbContextOptions<MainDbContext> options) : DbContext(
             builder.HasIndex(j => j.Created).IsDescending(); // faster filtering
             builder.HasIndex(j => j.ProjectId);
             builder.HasIndex(j => j.RepositoryId);
-            builder.HasIndex(j => new { j.PackageEcosystem, j.Directory, }); // faster filtering
-            builder.HasIndex(j => new { j.PackageEcosystem, j.Directory, j.EventBusId, }).IsUnique();
+            builder.HasIndex(j => new { j.PackageEcosystem, j.Directory, j.Directories }); // faster filtering
+            builder.HasIndex(j => new { j.PackageEcosystem, j.Directory, j.Directories, j.EventBusId, }).IsUnique();
             builder.HasIndex(j => j.AuthKey).IsUnique();
 
             builder.OwnsOne(j => j.Resources);

--- a/server/Tingle.Dependabot/Models/Management/UpdateJob.cs
+++ b/server/Tingle.Dependabot/Models/Management/UpdateJob.cs
@@ -49,9 +49,11 @@ public class UpdateJob
     [JsonIgnore] // only for internal use
     public string? PackageEcosystem { get; set; }
 
-    /// <summary>Identifier of the repository update.</summary>
-    [Required]
+    /// <summary>Directory targeted by the repository update.</summary>
     public string? Directory { get; set; }
+
+    /// <summary>Directories targeted by the repository update.</summary>
+    public List<string>? Directories { get; set; }
 
     /// <summary>Resources provisioned for the update.</summary>
     [Required]

--- a/server/main.bicep
+++ b/server/main.bicep
@@ -103,10 +103,6 @@ resource appConfiguration 'Microsoft.AppConfiguration/configurationStores@2023-0
       '${managedIdentity.id}': {/*ttk bug*/ }
     }
   }
-
-  // override the default updater image tag for nuget jobs
-  // TODO: remove this here and on Azure once the authentication issues are resolved (https://github.com/tinglesoftware/dependabot-azure-devops/issues/921)
-  resource nugetVersion 'keyValues' = { name: 'Workflow:UpdaterImageTags:nuget$Production', properties: { value: '1.24' } }
 }
 
 /* Storage Account */

--- a/server/main.json
+++ b/server/main.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.29.47.4906",
+      "templateHash": "3661784367808800983"
+    }
+  },
   "parameters": {
     "location": {
       "type": "string",
@@ -141,17 +148,6 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', parameters('name'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.AppConfiguration/configurationStores/keyValues",
-      "apiVersion": "2023-03-01",
-      "name": "[format('{0}/{1}', parameters('name'), 'Workflow:UpdaterImageTags:nuget$Production')]",
-      "properties": {
-        "value": "1.24"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.AppConfiguration/configurationStores', parameters('name'))]"
       ]
     },
     {


### PR DESCRIPTION
The extension already supports the directories and groups using `update_script_vnext` but the server lies behind. This standardizes support.

The image tag override for NuGet is removed from the bicep resources because the `1.24` image no longer exists and because we no longer need to override it. If you had deployed the app configuration instance, either manually remove the configuration entry from the Azure portal or redeploy using complete mode (defaults to incremental which does not delete).