### PR TITLE
Add missing EFCore migration for directories and groups support

### DIFF
--- a/server/Tingle.Dependabot/Migrations/20240824085208_DirectoriesAndGroups.Designer.cs
+++ b/server/Tingle.Dependabot/Migrations/20240824085208_DirectoriesAndGroups.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Tingle.Dependabot.Models;
 
@@ -11,9 +12,11 @@ using Tingle.Dependabot.Models;
 namespace Tingle.Dependabot.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240824085208_DirectoriesAndGroups")]
+    partial class DirectoriesAndGroups
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/Tingle.Dependabot/Migrations/20240824085208_DirectoriesAndGroups.cs
+++ b/server/Tingle.Dependabot/Migrations/20240824085208_DirectoriesAndGroups.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tingle.Dependabot.Migrations
+{
+    /// <inheritdoc />
+    public partial class DirectoriesAndGroups : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UpdateJobs_PackageEcosystem_Directory",
+                table: "UpdateJobs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UpdateJobs_PackageEcosystem_Directory_EventBusId",
+                table: "UpdateJobs");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Directory",
+                table: "UpdateJobs",
+                type: "nvarchar(450)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Directories",
+                table: "UpdateJobs",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UpdateJobs_PackageEcosystem_Directory_Directories",
+                table: "UpdateJobs",
+                columns: new[] { "PackageEcosystem", "Directory", "Directories" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UpdateJobs_PackageEcosystem_Directory_Directories_EventBusId",
+                table: "UpdateJobs",
+                columns: new[] { "PackageEcosystem", "Directory", "Directories", "EventBusId" },
+                unique: true,
+                filter: "[Directory] IS NOT NULL AND [Directories] IS NOT NULL AND [EventBusId] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UpdateJobs_PackageEcosystem_Directory_Directories",
+                table: "UpdateJobs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UpdateJobs_PackageEcosystem_Directory_Directories_EventBusId",
+                table: "UpdateJobs");
+
+            migrationBuilder.DropColumn(
+                name: "Directories",
+                table: "UpdateJobs");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Directory",
+                table: "UpdateJobs",
+                type: "nvarchar(450)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UpdateJobs_PackageEcosystem_Directory",
+                table: "UpdateJobs",
+                columns: new[] { "PackageEcosystem", "Directory" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UpdateJobs_PackageEcosystem_Directory_EventBusId",
+                table: "UpdateJobs",
+                columns: new[] { "PackageEcosystem", "Directory", "EventBusId" },
+                unique: true,
+                filter: "[EventBusId] IS NOT NULL");
+        }
+    }
+}


### PR DESCRIPTION
I added support for directories and groups in https://github.com/tinglesoftware/dependabot-azure-devops/issues/1294 but forgot to add the database migration. Possibly because I do not have unit tests against the actual database.