### PR TITLE
Update extension task node version from v16 to v20.1

### DIFF
--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -255,7 +255,7 @@
   ],
   "dataSourceBindings": [],
   "execution": {
-    "Node16": {
+    "Node20_1": {
       "target": "index.js"
     }
   }

--- a/extension/task/task.json
+++ b/extension/task/task.json
@@ -18,7 +18,7 @@
     "Patch": 0
   },
   "instanceNameFormat": "Dependabot",
-  "minimumAgentVersion": "2.105.0",
+  "minimumAgentVersion": "3.232.1",
   "groups": [
     {
       "name": "security_updates",


### PR DESCRIPTION
Possible fix for #1312.

The current extension task executes under `Node16`, which doesn't support `URL.canParse` (added in `18.17.0`).
https://nodejs.org/docs/latest-v18.x/api/url.html#urlcanparseinput-base

The latest Microsoft docs suggest using `Node20_1` to keep up to date with the latest `azure-pipelines-task-lib`.
https://learn.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?view=azure-devops#prerequisites

Increasing the Node version to 20 also increases the minimum agent version, which reduces compatibility with old (on-premise?) DevOps agents, mentioned here:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode20.md#specify-minimumagentversion

Migration notes for upgrading to Node 20 are here:
https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/migrateNode20.md

It might also just be easier to just substitute `URL.canParse` with a check that works in Node v16 to avoid this upgrade entirely.

