### PR TITLE
Add contributing guide; update developer guides

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
-skip = .git,*.pdf,*.svg,pnpm-lock.yaml,yarn.lock,package-lock.json
+skip = .git,package-lock.json,node_modules
 # some modules, parts of regexes, and variable names to ignore, some
 # misspellings in fixtures/external responses we do not own
-ignore-words-list = caf,bu,nwo,nd,kernal,crate,unparseable,couldn,defintions
+ignore-words-list = NWO,kernal

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,6 @@
 # dependencies
 node_modules
 package-lock.json
-pnpm-lock.yaml
 
 # outputs
 bin
@@ -21,6 +20,7 @@ out
 .github/ISSUE_TEMPLATE/**
 .vscode/settings.json
 README.md
+CONTRIBUTING.md
 docs/**/*.md
 .rubocop*.yml
 advisories-example.json

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -56,8 +56,6 @@ npm run format              # to automatically fix formatting issues
 
 ## Spelling
 
-Changes cannot contain common misspellings; Check for misspellings using `codespell`:
-
 ```bash
 pip install codespell
 codespell                   # to check for misspellings

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,65 @@
+Thank you for contributing to the Dependabot for Azure DevOps project.
+
+# Table of Contents
+
+- [Contribution workflow](#contribution-workflow)
+- [Development environment](#development-environment)
+- [Submitting pull requests](#submitting-pull-requests)
+  - [Unit tests](#unit-tests)
+  - [Static code analyzers and linters](#static-code-analyzers-and-linters)
+  - [Formatters](#formatters)
+  - [Spelling](#spelling)
+
+# Contribution workflow
+
+1. Fork the project.
+1. Get the [development environment running](#development-environment).
+1. Make your feature addition or bug fix.
+1. Make sure all [required quality checks](#required-workflow-tasks) have passed.
+1. Send a pull request.
+
+# Development environment
+
+Before contributing, you'll need to configure your local development environment; View the corresponding development guide for the component you'd like to contribute to:
+
+- [Azure DevOps Extension](./docs/extension.md#development-guide)
+- [Dependabot Server](./docs/server.md#development-guide)
+- [Dependabot Updater image](./docs/updater.md#development-guide)
+
+# Submitting pull requests
+
+If you plan on submitting a pull request, there are several quality checks that must pass; It is recommended that you run these before submitting the pull request. The checks are:
+
+## Unit tests
+
+All existing unit tests must pass.
+View the corresponding unit test instructions for the component you'd like to test:
+
+- [Azure DevOps Extension](./docs/extension.md#running-the-unit-tests)
+- [Dependabot Server](./docs/server.md#running-the-unit-tests)
+- [Dependabot Updater image](./docs/updater.md#running-the-unit-tests)
+
+## Static code analyzers and linters
+
+Some components use static code analyzers and linters.
+View the corresponding instructions for each component:
+
+- [Dependabot Updater image](./docs/updater.md#running-the-code-linter)
+
+## Formatters
+
+```bash
+npm install
+npm run format:check        # to check for formatting issues
+npm run format              # to automatically fix formatting issues
+```
+
+## Spelling
+
+Changes cannot contain common misspellings; Check for misspellings using `codespell`:
+
+```bash
+pip install codespell
+codespell                   # to check for misspellings
+codespell --write-changes   # to automatically fix misspellings
+```

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ We aim to support all [official configuration options](https://docs.github.com/e
 - Private feed/registry authentication may not work with all package ecyosystems. See [problems with authentication](https://github.com/tinglesoftware/dependabot-azure-devops/discussions/1317) for more.
 
 ## Migration Guide
-- [Extension Task V1 → V2](./docs/migrations/v1-to-v2)
+- [Extension Task V1 → V2](./docs/migrations/v1-to-v2.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ In this repository you'll find:
    * [Updater Docker image](#updater-docker-image)
    * [Server](#server)
 - [Migration Guide](#migration-guide)
-- [Development Guide](#development-guide)
+- [Contributing](#contributing)
+   * [Reporting issues and feature requests](#reporting-issues-and-feature-requests)
+   * [Submitting pull requests](#submitting-pull-requests)
 - [Acknowledgements](#acknowledgements)
-- [Issues &amp; Comments](#issues-amp-comments)
 
 ## Getting started
 
@@ -205,13 +206,18 @@ We aim to support all [official configuration options](https://docs.github.com/e
 ## Migration Guide
 - [Extension Task V1 → V2](./docs/migrations/v1-to-v2)
 
-## Development Guide
+## Contributing
 
-If you'd like to contribute to the project or just run it locally, view our development guides for:
+:wave: Want to give us feedback on Dependabot for Azure DevOps, or contribute to it? That's great - thank you so much!
 
-- [Azure DevOps Extension](./docs/extension.md#development-guide)
-- [Dependabot Server](./docs/server.md#development-guide)
-- [Dependabot Updater image](./docs/updater.md#development-guide) **(Deprecated since v2.0)**
+### Reporting issues and feature requests
+
+Please leave all issues, bugs, and feature requests on the [issues page](https://github.com/tinglesoftware/dependabot-azure-devops/issues). We'll respond ASAP!
+Use the [discussions page](https://github.com/tinglesoftware/dependabot-azure-devops/discussions) for all other questions and comments.
+
+### Submitting pull requests
+
+Please refer to the [contributing guidelines](./CONTRIBUTING.MD) for more information on how to get started.
 
 ## Acknowledgements
 
@@ -222,9 +228,3 @@ The work in this repository is based on inspired and occasionally guided by some
 3. Chris' work: [code](https://github.com/chris5287/dependabot-for-azuredevops)
 4. andrcun's work on GitLab: [code](https://gitlab.com/dependabot-gitlab/dependabot)
 5. WeWork's work for GitLab: [code](https://github.com/wemake-services/kira-dependencies)
-
-## Issues &amp; Comments
-
-Please leave all issues, bugs, and feature requests on the [issues page](https://github.com/tinglesoftware/dependabot-azure-devops/issues). We'll respond ASAP!
-
-Use the [discussions page](https://github.com/tinglesoftware/dependabot-azure-devops/discussions) for all other questions and comments.

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -20,7 +20,7 @@ Refer to the extension [README.md](../extension/README.md).
 
 ## Getting the development environment ready
 
-Install [Node.js](https://docs.docker.com/engine/install/) v18 or higher; Install project dependencies using NPM:
+Install [Node.js](https://docs.docker.com/engine/install/) (18+), [Go](https://go.dev/doc/install) (1.22+), and [Docker](https://docs.docker.com/engine/install/) (with Linux containers); Install project dependencies using NPM:
 
 ```bash
 cd extension
@@ -58,6 +58,7 @@ To run a specific task version:
 npm run start:V1 # runs dependabotV1 task
 npm run start:V2 # runs dependabotV2 task
 ```
+
 ## Running the unit tests
 
 ```bash

--- a/docs/migrations/v1-to-v2.md
+++ b/docs/migrations/v1-to-v2.md
@@ -21,7 +21,7 @@ The task now uses [Dependabot CLI](https://github.com/dependabot/cli) to perform
 > **It is strongly recommended that you complete (or abandon) all active Depedabot pull requests created in V1 before migrating to V2.** Due to changes in Dependabot dependency metadata, V2 pull requests are not compatible with V1 (and vice versa). Migrating to V2 before completing existing pull requests will lead to duplication of pull requests.
 
 ### New pipeline agent requirements; "Go" must be installed
-Dependabot CLI requires [Go](https://go.dev/doc/install) (1.22+) and [Docker](https://docs.docker.com/get-started/get-docker/) (with Linux containers).
+Dependabot CLI requires [Go](https://go.dev/doc/install) (1.22+) and [Docker](https://docs.docker.com/engine/install/) (with Linux containers).
 If you use [Microsoft-hosted agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software), we recommend using the [ubuntu-latest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) image, which meets all task requirements.
 For self-hosted agents, you will need to install Go 1.22+.
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -9,6 +9,9 @@
    * [Deployment with CLI](#deployment-with-cli)
    * [Service Hooks and Subscriptions](#service-hooks-and-subscriptions)
 - [Keeping updated](#keeping-updated)
+- [Development guide](#development-guide)
+   * [Getting the development environment ready](#getting-the-development-environment-ready)
+   * [Running the unit tests](#running-the-unit-tests)
 
 # Why should I use the server?
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -118,3 +118,22 @@ To enable automatic pickup of configuration files, merge conflict resolution and
 If you wish to keep your deployment updated, you can create a private repository with this one as a git submodule, configure dependabot to update it then add a new workflow that deploys to your preferred host using a manual trigger (or one of your choice).
 
 You can also choose to watch the repository so as to be notified when a new release is published.
+
+# Development guide
+
+## Getting the development environment ready
+
+Install [.NET 8](https://dotnet.microsoft.com/en-us/download) and [Docker](https://docs.docker.com/engine/install/) (with Linux containers); Install project dependencies using `dotnet` or Visual Studio [Code]:
+
+```bash
+cd server
+dotnet restore Tingle.Dependabot
+dotnet restore Tingle.Dependabot.Tests
+```
+
+## Running the unit tests
+
+```bash
+cd server
+dotnet test Tingle.Dependabot.Tests
+```

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -1,6 +1,6 @@
 
 > [!WARNING]
-> **Deprecated;** Use of the Dependabot Updater image is no longer recommended since v2.0; The "updater" component is considered an internal to Dependabot and is not intended to be run directly by end-users. There are known limitations with this image, see [unsupported features and configuration](../README.md#unsupported-features-and-configurations) for more details.
+> **Deprecated;** Use of the Dependabot Updater image is no longer recommended since v2.0; The "updater" component is considered internal to Dependabot and is not intended to be run directly by end-users. There are known limitations with this image, see [unsupported features and configuration](../README.md#unsupported-features-and-configurations) for more details.
 
 # Table of Contents
 
@@ -144,7 +144,7 @@ The following environment variables are required when running the container.
 
 ## Getting the development environment ready
 
-Install [Docker](https://docs.docker.com/engine/install/) and [Ruby](https://www.ruby-lang.org/en/documentation/installation/).
+Install [Docker](https://docs.docker.com/engine/install/) (with Linux containers) and [Ruby](https://www.ruby-lang.org/en/documentation/installation/) (3.3).
 
 > [!NOTE]
 > If developing in Linux, you'll also need the the build essentials and Ruby development packages; These are typically `build-essentials` and `ruby-dev`.
@@ -187,6 +187,7 @@ bundle exec rubocop
 
 > [!TIP]
 > To automatically fix correctable linting issues, use `bundle exec rubocop -a`
+
 ## Running the unit tests
 
 ```bash

--- a/extension/README.md
+++ b/extension/README.md
@@ -37,7 +37,7 @@ steps:
 
 ## Task Requirements
 
-The task uses [dependabot-cli](https://github.com/dependabot/cli), which requires [Go](https://go.dev/doc/install) (1.22+) and [Docker](https://docs.docker.com/get-started/get-docker/) (with Linux containers) be installed on the pipeline agent.
+The task uses [dependabot-cli](https://github.com/dependabot/cli), which requires [Go](https://go.dev/doc/install) (1.22+) and [Docker](https://docs.docker.com/engine/install/) (with Linux containers) be installed on the pipeline agent.
 If you use [Microsoft-hosted agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software), we recommend using the [ubuntu-latest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) image, which meets all task requirements.
 
 Dependabot uses Docker containers, which may take time to install if not already cached. Subsequent dependabot tasks in the same job will be faster after initially pulling the images. An alternative way to run your pipelines faster is by leveraging Docker caching in Azure Pipelines (See [#113](https://github.com/tinglesoftware/dependabot-azure-devops/issues/113#issuecomment-894771611)). 


### PR DESCRIPTION
Adds a [contributing guide](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors#about-contributing-guidelines) that covers development environment setup and how to locally run the various pull request quality checks (i.e. unit tests, rubocop, codespell, prettier).

Preview: https://github.com/tinglesoftware/dependabot-azure-devops/blob/99b1190446c25576694a6889ac8c0016659468e6/CONTRIBUTING.MD

I have also removed a few entries from `.codespellrc` and `.prettierignore` that don't seem to exist (anymore?).