### PR TITLE
Fix "cannot read property of undefined" error; Fix GitHub image pull rate-limiting

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -61,6 +61,7 @@ async function run() {
     );
 
     const dependabotUpdaterOptions = {
+      gitHubAccessToken: taskInputs.githubAccessToken,
       collectorImage: undefined, // TODO: Add config for this?
       proxyImage: undefined, // TODO: Add config for this?
       updaterImage: undefined, // TODO: Add config for this?

--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -101,7 +101,7 @@ async function run() {
         updateId,
         update,
         dependabotConfig.registries,
-        dependencyList['dependencies'],
+        dependencyList?.['dependencies'],
         existingPullRequestDependencies,
       );
       const allDependenciesUpdateOutputs = await dependabot.update(allDependenciesJob, dependabotUpdaterOptions);

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -83,8 +83,8 @@ export class DependabotCli {
         failOnStdErr: false,
         ignoreReturnCode: true,
         env: {
-          'DEPENDABOT_JOB_ID': jobId.replace(/-/g, '_'), // replace hyphens with underscores
-          'LOCAL_GITHUB_ACCESS_TOKEN': options?.gitHubAccessToken, // avoid rate-limiting when pulling images from GitHub container registries
+          DEPENDABOT_JOB_ID: jobId.replace(/-/g, '_'), // replace hyphens with underscores
+          LOCAL_GITHUB_ACCESS_TOKEN: options?.gitHubAccessToken, // avoid rate-limiting when pulling images from GitHub container registries
         },
       });
       if (dependabotResultCode != 0) {

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -39,6 +39,7 @@ export class DependabotCli {
   public async update(
     operation: IDependabotUpdateOperation,
     options?: {
+      gitHubAccessToken?: string;
       collectorImage?: string;
       proxyImage?: string;
       updaterImage?: string;
@@ -81,6 +82,10 @@ export class DependabotCli {
       const dependabotResultCode = await dependabotTool.execAsync({
         failOnStdErr: false,
         ignoreReturnCode: true,
+        env: {
+          'DEPENDABOT_JOB_ID': jobId.replace(/-/g, '_'), // replace hyphens with underscores
+          'LOCAL_GITHUB_ACCESS_TOKEN': options?.gitHubAccessToken, // avoid rate-limiting when pulling images from GitHub container registries
+        },
       });
       if (dependabotResultCode != 0) {
         error(`Dependabot failed with exit code ${dependabotResultCode}`);


### PR DESCRIPTION
Bug fixes for:
- Fix "cannot read property of undefined" error when there is no dependency list stored for the project yet (i.e. [a first-time run](https://dev.azure.com/tingle/dependabot/_build/results?buildId=74147&view=results)).
- Forward the GitHub access token to dependabot-cli; avoids rate-limiting when pulling Docker images
- Set Dependabot job id, which helps when debugging log output containing multiple jobs
