### PR TITLE
Run `go install dependabot` async; stream logs to task output

### DIFF
--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -140,7 +140,7 @@ export class DependabotCli {
     console.info('Dependabot CLI install was not found, installing now with `go install dependabot`...');
     const goTool: ToolRunner = tool(which('go', true));
     goTool.arg(['install', this.toolImage]);
-    goTool.execSync();
+    await goTool.execAsync();
 
     // Depending on how Go is configured on the host agent, the "go/bin" path may not be in the PATH environment variable.
     // If dependabot still cannot be found using `which()` after install, we must manually resolve the path;


### PR DESCRIPTION
Run `go install dependabot` asynchronously so that logs are streamed to task output in real-time instead of blocking until the process has completed. This removes the hitch that happens when dependabot isn't already installed, which might give the user the impression nothing is happening.