### PR TITLE
Fix "undefined is not iterable" error when listing active pull requests

### DIFF
--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -96,17 +96,20 @@ export class AzureDevOpsWebApiClient {
         },
         project,
       );
+      if (!pullRequests || pullRequests.length === 0) {
+        return [];
+      }
 
       return await Promise.all(
-        pullRequests?.map(async (pr) => {
-          const properties = (await git.getPullRequestProperties(repository, pr.pullRequestId, project))?.value;
+        pullRequests.map(async (pr) => {
+          const properties = (await git.getPullRequestProperties(repository, pr.pullRequestId, project))?.value || {};
           return {
             id: pr.pullRequestId,
             properties:
-              Object.keys(properties)?.map((key) => {
+              Object.keys(properties).map((key) => {
                 return {
                   name: key,
-                  value: properties[key].$value,
+                  value: properties[key]?.$value,
                 };
               }) || [],
           };


### PR DESCRIPTION
Fix "undefined is not iterable" error when listing active pull requests for a project when there aren't any pull requests yet, or the pull requests don't have any properties. `getActivePullRequestProperties` should just return an empty array when there are no pull requests instead of throwing an error.

```log
##[error]Failed to list active pull request properties: TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at Function.all (<anonymous>)
    at AzureDevOpsWebApiClient.getActivePullRequestProperties (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.35.923/utils/azure-devops/AzureDevOpsWebApiClient.js:74:34)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async run (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.35.923/index.js:36:44)

```