### PR TITLE
Fix "cannot read properties of null" error when listing project properties

### DIFF
--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -479,7 +479,7 @@ export class AzureDevOpsWebApiClient {
       const projects = await core.getProjects();
       const projectGuid = projects?.find((p) => p.name === project)?.id;
       const properties = await core.getProjectProperties(projectGuid);
-      return properties.map((p) => ({ [p.name]: p.value })).reduce((a, b) => ({ ...a, ...b }), {});
+      return properties?.map((p) => ({ [p.name]: p.value }))?.reduce((a, b) => ({ ...a, ...b }), {});
     } catch (e) {
       error(`Failed to get project properties: ${e}`);
       console.debug(e); // Dump the error stack trace to help with debugging


### PR DESCRIPTION
Fix "cannot read properties of null" error when listing project properties for a project that doesn't have any properties yet.  `getProjectProperties` should just return `undefined` when there are no properties instead of throwing an error.

```log
##[error]Failed to get project properties: TypeError: Cannot read properties of null (reading 'map')
TypeError: Cannot read properties of null (reading 'map')
    at AzureDevOpsWebApiClient.getProjectProperties (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.35.923/utils/azure-devops/AzureDevOpsWebApiClient.js:372:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async run (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.35.923/index.js:63:104)
```