### PR TITLE
Simplify lookups of project id; Reduce APIs calls used to read/update project properties

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -86,7 +86,7 @@ async function run() {
       // This is required when doing a security-only update as dependabot requires the list of vulnerable dependencies to be updated.
       // Automatic discovery of vulnerable dependencies during a security-only update is not currently supported by dependabot-updater.
       const dependencyList = parseProjectDependencyListProperty(
-        await prAuthorClient.getProjectProperties(taskInputs.project),
+        await prAuthorClient.getProjectProperties(taskInputs.projectId),
         taskInputs.repository,
         update['package-ecosystem'],
       );
@@ -112,7 +112,8 @@ async function run() {
       }
 
       // If there are existing pull requests, run an update job for each one; this will resolve merge conflicts and close pull requests that are no longer needed
-      if (existingPullRequests && Object.keys(existingPullRequests).length > 0) {
+      const numberOfPullRequestsToUpdate = Object.keys(existingPullRequests).length;
+      if (numberOfPullRequestsToUpdate > 0) {
         if (!taskInputs.skipPullRequests) {
           for (const pullRequestId in existingPullRequests) {
             const updatePullRequestJob = DependabotJobBuilder.newUpdatePullRequestJob(
@@ -130,7 +131,9 @@ async function run() {
             }
           }
         } else {
-          warning(`Skipping update of existing pull requests as 'skipPullRequests' is set to 'true'`);
+          warning(
+            `Skipping update of ${numberOfPullRequestsToUpdate} existing pull request(s) as 'skipPullRequests' is set to 'true'`,
+          );
         }
       }
     }

--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -85,7 +85,6 @@ export class AzureDevOpsWebApiClient {
     repository: string,
     creator: string,
   ): Promise<IPullRequestProperties[]> {
-    console.info(`Fetching active pull request properties in '${project}/${repository}' for user id '${creator}'...`);
     try {
       const git = await this.connection.getGitApi();
       const pullRequests = await git.getPullRequests(
@@ -469,16 +468,14 @@ export class AzureDevOpsWebApiClient {
 
   /**
    * Get project properties
-   * @param project
+   * @param projectId
    * @param valueBuilder
    * @returns
    */
-  public async getProjectProperties(project: string): Promise<Record<string, string> | undefined> {
+  public async getProjectProperties(projectId: string): Promise<Record<string, string> | undefined> {
     try {
       const core = await this.connection.getCoreApi();
-      const projects = await core.getProjects();
-      const projectGuid = projects?.find((p) => p.name === project)?.id;
-      const properties = await core.getProjectProperties(projectGuid);
+      const properties = await core.getProjectProperties(projectId);
       return properties.map((p) => ({ [p.name]: p.value })).reduce((a, b) => ({ ...a, ...b }), {});
     } catch (e) {
       error(`Failed to get project properties: ${e}`);
@@ -495,20 +492,18 @@ export class AzureDevOpsWebApiClient {
    * @returns
    */
   public async updateProjectProperty(
-    project: string,
+    projectId: string,
     name: string,
     valueBuilder: (existingValue: string) => string,
   ): Promise<void> {
     try {
       // Get the existing project property value
       const core = await this.connection.getCoreApi();
-      const projects = await core.getProjects();
-      const projectGuid = projects?.find((p) => p.name === project)?.id;
-      const properties = await core.getProjectProperties(projectGuid);
+      const properties = await core.getProjectProperties(projectId);
       const propertyValue = properties?.find((p) => p.name === name)?.value;
 
       // Update the project property
-      await core.setProjectProperties(undefined, projectGuid, [
+      await core.setProjectProperties(undefined, projectId, [
         {
           op: 'add',
           path: '/' + name,

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -50,9 +50,8 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
    */
   public async process(update: IDependabotUpdateOperation, type: string, data: any): Promise<boolean> {
     console.debug(`Processing output '${type}' with data:`, data);
-    const sourceRepoParts = update.job.source.repo.split('/'); // "{organisation}/{project}/_git/{repository}""
-    const project = sourceRepoParts[1];
-    const repository = sourceRepoParts[3];
+    const project = this.taskInputs.project;
+    const repository = this.taskInputs.repository;
     switch (type) {
       // Documentation on the 'data' model for each output type can be found here:
       // See: https://github.com/dependabot/cli/blob/main/internal/model/update.go
@@ -62,7 +61,7 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
         if (this.taskInputs.storeDependencyList) {
           console.info(`Storing the dependency list snapshot for project '${project}'...`);
           await this.prAuthorClient.updateProjectProperty(
-            project,
+            this.taskInputs.projectId,
             DependabotOutputProcessor.PROJECT_PROPERTY_NAME_DEPENDENCY_LIST,
             function (existingValue: string) {
               const repoDependencyLists = JSON.parse(existingValue || '{}');

--- a/extension/tasks/dependabotV2/utils/getSharedVariables.ts
+++ b/extension/tasks/dependabotV2/utils/getSharedVariables.ts
@@ -19,6 +19,8 @@ export interface ISharedVariables {
   virtualDirectory: string;
   /** Organization name */
   organization: string;
+  /** Project ID */
+  projectId: string;
   /** Project name */
   project: string;
   /** Repository name */
@@ -86,6 +88,7 @@ export default function getSharedVariables(): ISharedVariables {
   let port: string = formattedOrganizationUrl.port;
   let virtualDirectory: string = extractVirtualDirectory(formattedOrganizationUrl);
   let organization: string = extractOrganization(organizationUrl);
+  let projectId: string = tl.getVariable('System.TeamProjectId');
   let project: string = encodeURI(tl.getVariable('System.TeamProject')); // encode special characters like spaces
   let repository: string = tl.getInput('targetRepositoryName');
   let repositoryOverridden = typeof repository === 'string';
@@ -148,6 +151,7 @@ export default function getSharedVariables(): ISharedVariables {
     port,
     virtualDirectory,
     organization,
+    projectId,
     project,
     repository,
     repositoryOverridden,


### PR DESCRIPTION
To read/update project properties, the project id is required; Currently we look this up using the [list projects API](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-7.1&tabs=HTTP) and then find the project that matches the name we have. This isn't ideal because it adds an extra API call; It is now read from the `System.TeamProjectId` [predefined system variable](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services).