### PR TITLE
Fix GitHub rate limiting when generating pull request descriptions

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -61,6 +61,7 @@ async function run() {
     );
 
     const dependabotUpdaterOptions = {
+      azureDevOpsAccessToken: taskInputs.systemAccessToken,
       gitHubAccessToken: taskInputs.githubAccessToken,
       collectorImage: undefined, // TODO: Add config for this?
       proxyImage: undefined, // TODO: Add config for this?

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -39,6 +39,7 @@ export class DependabotCli {
   public async update(
     operation: IDependabotUpdateOperation,
     options?: {
+      azureDevOpsAccessToken?: string;
       gitHubAccessToken?: string;
       collectorImage?: string;
       proxyImage?: string;
@@ -85,6 +86,7 @@ export class DependabotCli {
         env: {
           DEPENDABOT_JOB_ID: jobId.replace(/-/g, '_'), // replace hyphens with underscores
           LOCAL_GITHUB_ACCESS_TOKEN: options?.gitHubAccessToken, // avoid rate-limiting when pulling images from GitHub container registries
+          LOCAL_AZURE_ACCESS_TOKEN: options?.azureDevOpsAccessToken, // technically not needed since we already supply this in our 'git_source' registry, but included for consistency
         },
       });
       if (dependabotResultCode != 0) {

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -233,6 +233,7 @@ function mapRegistryCredentialsFromDependabotConfigToJobConfig(
 ): any[] {
   let registryCredentials = new Array();
   if (taskInputs.systemAccessToken) {
+    // Required to authenticate with the Azure DevOps git repository when cloning the source code
     registryCredentials.push({
       type: 'git_source',
       host: taskInputs.hostname,
@@ -240,7 +241,17 @@ function mapRegistryCredentialsFromDependabotConfigToJobConfig(
       password: taskInputs.systemAccessToken,
     });
   }
+  if (taskInputs.githubAccessToken) {
+    // Required to avoid rate-limiting errors when generating pull request descriptions (e.g. fetching release notes, commit messages, etc)
+    registryCredentials.push({
+      type: 'git_source',
+      host: 'github.com',
+      username: 'x-access-token',
+      password: taskInputs.githubAccessToken,
+    });
+  }
   if (registries) {
+    // Required to authenticate with private package feeds when finding the latest version of dependencies
     for (const key in registries) {
       const registry = registries[key];
       registryCredentials.push({


### PR DESCRIPTION
Refs #1356.

Dependabot hits `api.github.com` to fetch project info, release notes, and commit messages for dependencies when generating pull request descriptions. Currently these requests are unauthenticated because we do not set the GitHub access token in the job credentials, which leads to errors like:

```log
2024-09-27T18:37:21.5657248Z   proxy | 2024/09/27 18:37:21 [952] Remote response: {"message":"API rate limit exceeded for xxx.xx.xx.x. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
2024-09-27T18:37:21.5695270Z updater | 2024/09/27 18:37:21 ERROR <job_update_0_npm_and_yarn_all> Error while generating PR message: GET https://api.github.com/repos/angular/angular/contents/packages/language-service: 403 - API rate limit exceeded for xxx.xx.xx.x . (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) // See: https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
2024-09-27T18:37:21.5697807Z updater | 2024/09/27 18:37:21 ERROR <job_update_0_npm_and_yarn_all> /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/octokit-7.2.0/lib/octokit/response/raise_error.rb:14:in `on_complete'
2024-09-27T18:37:21.5698373Z updater | /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/faraday-2.7.11/lib/faraday/middleware.rb:18:in `block in call'
```

This change adds a credential entry for `github.com` if the GitHub access token task input is set. 

This change also forwards the Azure DevOps access token to dependabot via the `LOCAL_AZURE_ACCESS_TOKEN` environment variable, which is used [here](https://github.com/dependabot/cli/blob/8793545f7b5dbf946aaee9372ffc12318573da81/cmd/dependabot/internal/cmd/update.go#L296). It doesn't currently change any behaviour since the token is already supplied explicitly in the job credentials; Just added for consistency.