### PR TITLE
Fix "cannot read properties of undefined" (reading 'filter')

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -108,7 +108,7 @@ async function run() {
       );
       const allDependenciesUpdateOutputs = await dependabot.update(allDependenciesJob, dependabotUpdaterOptions);
       if (!allDependenciesUpdateOutputs || allDependenciesUpdateOutputs.filter((u) => !u.success).length > 0) {
-        allDependenciesUpdateOutputs.filter((u) => !u.success).forEach((u) => exception(u.error));
+        allDependenciesUpdateOutputs?.filter((u) => !u.success)?.forEach((u) => exception(u.error));
         failedJobs++;
       }
 
@@ -127,7 +127,7 @@ async function run() {
             );
             const updatePullRequestOutputs = await dependabot.update(updatePullRequestJob, dependabotUpdaterOptions);
             if (!updatePullRequestOutputs || updatePullRequestOutputs.filter((u) => !u.success).length > 0) {
-              updatePullRequestOutputs.filter((u) => !u.success).forEach((u) => exception(u.error));
+              updatePullRequestOutputs?.filter((u) => !u.success)?.forEach((u) => exception(u.error));
               failedJobs++;
             }
           }


### PR DESCRIPTION
Fix "cannot read properties of undefined" error that happens if the Dependabot process exits with a non-zero result code or otherwise does not return any outputs.

```log
##vso[task.complete result=Failed;]Cannot read properties of undefined (reading 'filter')
##vso[task.issue type=error;source=TaskInternal;]An unhandled exception occurred: TypeError: Cannot read properties of undefined (reading 'filter')
TypeError: Cannot read properties of undefined (reading 'filter')
    at run (/home/rhys/development/dependabot-azure-devops/extension/tasks/dependabotV2/index.js:78:46)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```