### PR TITLE
Fix "pull request cannot be activated because the source and/or the target branch no longer exists" error

### DIFF
--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -65,7 +65,8 @@ export class AzureDevOpsWebApiClient {
         throw new Error(`Repository '${project}/${repository}' not found`);
       }
 
-      return repo.defaultBranch;
+      // Strip reference prefix from the branch name, the caller doesn't need to know this
+      return repo.defaultBranch?.toLowerCase()?.replace('refs/heads/', '');
     } catch (e) {
       error(`Failed to get default branch for '${project}/${repository}': ${e}`);
       console.debug(e); // Dump the error stack trace to help with debugging

--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -66,7 +66,7 @@ export class AzureDevOpsWebApiClient {
       }
 
       // Strip reference prefix from the branch name, the caller doesn't need to know this
-      return repo.defaultBranch?.toLowerCase()?.replace('refs/heads/', '');
+      return repo.defaultBranch?.replace(/^refs\/heads\//i, '');
     } catch (e) {
       error(`Failed to get default branch for '${project}/${repository}': ${e}`);
       console.debug(e); // Dump the error stack trace to help with debugging


### PR DESCRIPTION
Fixes #1365.

If `target-branch` is not specified in `dependabot.yml`, the repository default branch is used. Currently the default branch name includes the "/refs/heads/" prefix, which was not intentional. This change removes the prefix so that only the actual branch name is returned.