### PR TITLE
Add support for the "pull-request-branch-name.separator" config option

### DIFF
--- a/docs/migrations/v1-to-v2.md
+++ b/docs/migrations/v1-to-v2.md
@@ -42,13 +42,31 @@ This was a customisation/workaround specific to the V1 update script that can no
 This is no longer required as the [custom] [Dependabot Updater image](../updater.md) is no longer used.
 
 ### Task Input `extraEnvironmentVariables` has been removed
-Due to the containerised design of Dependabot CLI, environment variables can no longer be passed from the task to the updater process. All Dependabot config must now set via `dependabot.yaml` or as task inputs. The following old environment variables have been converted to task inputs:
+Due to the containerised design of Dependabot CLI, environment variables can no longer be passed from the task to the updater process. All Dependabot config must now set via `dependabot.yaml` or as task inputs. See changes to environment variables below for more details.
 
-| Environment Variable | New Task Input |
+### Changes to environment variables
+The following environment variables are now configured using [pipeline system variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#system-variables):
+| Environment Variable | → | Pipeline Variable |
+|--|--|--|
+|`DEPENDABOT_DEBUG`| → |`System.Debug`|
+
+The following environment variables are now configured using task inputs:
+| Environment Variable | → | Task Input |
+|--|--|--|
+|`DEPENDABOT_AUTHOR_EMAIL`| → |`authorEmail`|
+|`DEPENDABOT_AUTHOR_NAME`| → |`authorName`|
+|`DEPENDABOT_UPDATER_OPTIONS`| → |`experiments`|
+
+The following environment variables have been removed entirely; the feature is no longer supported:
+
+| Removed Environment Variable | Reason |
 |--|--|
-|DEPENDABOT_AUTHOR_EMAIL|authorEmail|
-|DEPENDABOT_AUTHOR_NAME|authorName|
-
+|`DEPENDABOT_PR_NAME_PREFIX_STYLE`| Feature is not supported |
+|`DEPENDABOT_COMPATIBILITY_SCORE_BADGE`| Feature is not supported |
+|`DEPENDABOT_MESSAGE_HEADER`| Feature is not supported |
+|`DEPENDABOT_MESSAGE_FOOTER`| Feature is not supported |
+|`DEPENDABOT_SIGNATURE_KEY`| Feature is not supported |
+|`DEPENDABOT_JOB_ID`| Set automatically by extension |
 
 ## Todo before general availability
 Before removing the preview flag from V2 `task.json`, we need to:

--- a/docs/migrations/v1-to-v2.md
+++ b/docs/migrations/v1-to-v2.md
@@ -61,11 +61,11 @@ The following environment variables have been removed entirely; the feature is n
 
 | Removed Environment Variable | Reason |
 |--|--|
-|`DEPENDABOT_PR_NAME_PREFIX_STYLE`| Feature is not supported |
-|`DEPENDABOT_COMPATIBILITY_SCORE_BADGE`| Feature is not supported |
-|`DEPENDABOT_MESSAGE_HEADER`| Feature is not supported |
-|`DEPENDABOT_MESSAGE_FOOTER`| Feature is not supported |
-|`DEPENDABOT_SIGNATURE_KEY`| Feature is not supported |
+|`DEPENDABOT_PR_NAME_PREFIX_STYLE`| Feature is not supported; It is not an official configuration |
+|`DEPENDABOT_COMPATIBILITY_SCORE_BADGE`| Feature is not supported; It is not an official configuration |
+|`DEPENDABOT_MESSAGE_HEADER`| Feature is not supported; It is not an official configuration |
+|`DEPENDABOT_MESSAGE_FOOTER`| Feature is not supported; It is not an official configuration |
+|`DEPENDABOT_SIGNATURE_KEY`| Feature is not supported; It is not an official configuration |
 |`DEPENDABOT_JOB_ID`| Set automatically by extension |
 
 ## Todo before general availability

--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -239,7 +239,7 @@ export class AzureDevOpsWebApiClient {
 
       // TODO: Upload the pull request description as a 'changes.md' file attachment?
       //       This might be a way to work around the 4000 character limit for PR descriptions, but needs more investigation.
-      // https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-attachments/create?view=azure-devops-rest-7.1
+      //       https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-attachments/create?view=azure-devops-rest-7.1
 
       // Set the pull request auto-complete status
       if (pr.autoComplete) {

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -179,9 +179,8 @@ function mapGroupsFromDependabotConfigToJobConfig(dependencyGroups: Record<strin
 
 function mapAllowedUpdatesFromDependabotConfigToJobConfig(allowedUpdates: IDependabotAllowCondition[]): any[] {
   if (!allowedUpdates) {
-    return [
-      { 'dependency-type': 'all' }, // if not explicitly configured, allow all updates
-    ];
+    // If no allow conditions are specified, update all dependencies by default
+    return [{ 'dependency-type': 'all' }];
   }
   return allowedUpdates.map((allow) => {
     return {

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -4,6 +4,7 @@ import * as crypto from 'crypto';
 import * as path from 'path';
 import { AzureDevOpsWebApiClient } from '../azure-devops/AzureDevOpsWebApiClient';
 import { IPullRequestProperties } from '../azure-devops/interfaces/IPullRequestProperties';
+import { IDependabotUpdate } from '../dependabot/interfaces/IDependabotConfig';
 import { ISharedVariables } from '../getSharedVariables';
 import { IDependabotUpdateOperation } from './interfaces/IDependabotUpdateOperation';
 import { IDependabotUpdateOutputProcessor } from './interfaces/IDependabotUpdateOutputProcessor';
@@ -95,16 +96,21 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
           return true;
         }
 
+        // TODO: Add config for custom PR description header text? Task V1 supported this via DEPENDABOT_MESSAGE_HEADER
+        // TODO: Add config for custom PR description footer text? Task V1 supported this via DEPENDABOT_MESSAGE_FOOTER
+        // TODO: Add config for GitHub compatibility score badges? Task V1 supported this via DEPENDABOT_COMPATIBILITY_SCORE_BADGE
+
         // Create a new pull request
         const dependencies = getPullRequestDependenciesPropertyValueForOutputData(data);
         const targetBranch =
           update.config['target-branch'] || (await this.prAuthorClient.getDefaultBranch(project, repository));
+        const sourceBranch = getSourceBranchNameForUpdate(update.config, targetBranch, dependencies);
         const newPullRequestId = await this.prAuthorClient.createPullRequest({
           project: project,
           repository: repository,
           source: {
             commit: data['base-commit-sha'] || update.job.source.commit,
-            branch: getSourceBranchNameForUpdate(update.job['package-manager'], targetBranch, dependencies),
+            branch: sourceBranch,
           },
           target: {
             branch: targetBranch,
@@ -306,8 +312,11 @@ export function parsePullRequestProperties(
   );
 }
 
-function getSourceBranchNameForUpdate(packageEcosystem: string, targetBranch: string, dependencies: any): string {
-  const target = targetBranch?.replace(/^\/+|\/+$/g, ''); // strip leading/trailing slashes
+function getSourceBranchNameForUpdate(update: IDependabotUpdate, targetBranch: string, dependencies: any): string {
+  const prefix = 'dependabot'; // TODO: Add config for this? Task V1 supported this via DEPENDABOT_BRANCH_NAME_PREFIX
+  const separator = update['pull-request-branch-name'].separator || '/';
+  const packageEcosystem = update['package-ecosystem'];
+  const targetBranchName = targetBranch?.replace(/^\/+|\/+$/g, ''); // strip leading/trailing slashes
   if (dependencies['dependency-group-name']) {
     // Group dependency update
     // e.g. dependabot/nuget/main/microsoft-3b49c54d9e
@@ -317,12 +326,12 @@ function getSourceBranchNameForUpdate(packageEcosystem: string, targetBranch: st
       .update(dependencies['dependencies'].map((d) => `${d['dependency-name']}-${d['dependency-version']}`).join(','))
       .digest('hex')
       .substring(0, 10);
-    return `dependabot/${packageEcosystem}/${target}/${dependencyGroupName}-${dependencyHash}`;
+    return `${prefix}${separator}${packageEcosystem}${separator}${targetBranchName}${separator}${dependencyGroupName}-${dependencyHash}`;
   } else {
     // Single dependency update
     // e.g. dependabot/nuget/main/Microsoft.Extensions.Logging-1.0.0
     const leadDependency = dependencies.length === 1 ? dependencies[0] : null;
-    return `dependabot/${packageEcosystem}/${target}/${leadDependency['dependency-name']}-${leadDependency['dependency-version']}`;
+    return `${prefix}${separator}${packageEcosystem}${separator}${targetBranchName}${separator}${leadDependency['dependency-name']}-${leadDependency['dependency-version']}`;
   }
 }
 

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -96,10 +96,6 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
           return true;
         }
 
-        // TODO: Add config for custom PR description header text? Task V1 supported this via DEPENDABOT_MESSAGE_HEADER
-        // TODO: Add config for custom PR description footer text? Task V1 supported this via DEPENDABOT_MESSAGE_FOOTER
-        // TODO: Add config for GitHub compatibility score badges? Task V1 supported this via DEPENDABOT_COMPATIBILITY_SCORE_BADGE
-
         // Create a new pull request
         const dependencies = getPullRequestDependenciesPropertyValueForOutputData(data);
         const targetBranch =


### PR DESCRIPTION
Changes:
- Add support for the "pull-request-branch-name.separator" config option.
- Update V1 -> V2 migration documentation with [list of changes to environment variables](https://github.com/tinglesoftware/dependabot-azure-devops/blob/c8b5fd6a8a8f6fd6b49acfa47171a64fe2c1a778/docs/migrations/v1-to-v2.md#changes-to-environment-variables).

Example using "-" as the branch name separator:
![image](https://github.com/user-attachments/assets/da9b7f94-1c6d-4cdb-bf06-a7dca9bf0864)
