### PR TITLE
Raise error and fail task if dependency list project property cannot be updated [when configured]

### DIFF
--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -499,7 +499,7 @@ export class AzureDevOpsWebApiClient {
     projectId: string,
     name: string,
     valueBuilder: (existingValue: string) => string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       // Get the existing project property value
       const core = await this.connection.getCoreApi();
@@ -514,9 +514,12 @@ export class AzureDevOpsWebApiClient {
           value: valueBuilder(propertyValue || ''),
         },
       ]);
+
+      return true;
     } catch (e) {
       error(`Failed to update project property '${name}': ${e}`);
       console.debug(e); // Dump the error stack trace to help with debugging
+      return false;
     }
   }
 }

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -59,8 +59,8 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
       case 'update_dependency_list':
         // Store the dependency list snapshot in project properties, if configured
         if (this.taskInputs.storeDependencyList) {
-          console.info(`Storing the dependency list snapshot for project '${project}'...`);
-          await this.prAuthorClient.updateProjectProperty(
+          console.info(`Updating the dependency list snapshot for project '${project}'...`);
+          return await this.prAuthorClient.updateProjectProperty(
             this.taskInputs.projectId,
             DependabotOutputProcessor.PROJECT_PROPERTY_NAME_DEPENDENCY_LIST,
             function (existingValue: string) {
@@ -75,7 +75,6 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
               return JSON.stringify(repoDependencyLists);
             },
           );
-          console.info(`Dependency list snapshot was updated for project '${project}'`);
         }
 
         return true;


### PR DESCRIPTION
### Changes

- If an error occurs when updating the dependency list project property, bubble the error up the stack so that the task eventually fails; Currently it just assumes the update was successful, which makes it difficult for the user to know that there was a problem.
- If the task fails, the task result message now shows the total number of failed "update tasks" (i.e. outputs that could not be processed) rather than the number of failed "update jobs"; This more accurately summaries the number of errors that happen during the overall update process.

```log
Storing the dependency list snapshot for project 'Dependabot'...
##[error]Failed to update project property 'Dependabot.DependencyList': Error: Failed request: (401)
Error: Failed request: (401)
    at RestClient.<anonymous> (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.35.947/node_modules/typed-rest-client/RestClient.js:204:31)
    at Generator.next (<anonymous>)
    at fulfilled (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.35.947/node_modules/typed-rest-client/RestClient.js:7:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  statusCode: 401,
  responseHeaders: {
    ...snip...
  }
}
Dependency list snapshot was updated for project 'Dependabot'
```
^^^ this last log message shouldn't have happened, since the update actually failed.