### PR TITLE
Fix for `directories` config not working when there is only one entry in the list

### DIFF
--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -88,7 +88,6 @@ function buildUpdateJobConfig(
   updateDependencyNames: string[] | undefined,
   existingPullRequests: any[],
 ) {
-  const hasMultipleDirectories = update.directories?.length > 1;
   return {
     config: update,
     job: {
@@ -110,8 +109,8 @@ function buildUpdateJobConfig(
         'repo': `${taskInputs.organization}/${taskInputs.project}/_git/${taskInputs.repository}`,
         'branch': update['target-branch'],
         'commit': undefined, // use latest commit of target branch
-        'directory': hasMultipleDirectories ? undefined : update.directory || '/',
-        'directories': hasMultipleDirectories ? update.directories : undefined,
+        'directory': update.directory,
+        'directories': update.directories,
       },
       'existing-pull-requests': existingPullRequests.filter((pr) => !pr['dependency-group-name']),
       'existing-group-pull-requests': existingPullRequests.filter((pr) => pr['dependency-group-name']),


### PR DESCRIPTION
Fix: https://github.com/tinglesoftware/dependabot-azure-devops/issues/1328#issuecomment-2406991153

Pass-through `directory` and `directories` config verbatim, don't transform it. Dependabot will throw an error during `validate_job` if the config is wrong, the extension doesn't need to pre-check it.
