### PR TITLE
Tidy up extension and task metadata

### DIFF
--- a/extension/tasks/dependabotV1/task.json
+++ b/extension/tasks/dependabotV1/task.json
@@ -7,10 +7,11 @@
   "helpMarkDown": "For help please visit https://github.com/tinglesoftware/dependabot-azure-devops/issues",
   "helpUrl": "https://github.com/tinglesoftware/dependabot-azure-devops/issues",
   "releaseNotes": "https://github.com/tinglesoftware/dependabot-azure-devops/releases",
-  "category": "Utility",
+  "author": "Tingle Software",
+  "category": "Azure Pipelines",
   "visibility": ["Build", "Release"],
   "runsOn": ["Agent", "DeploymentGroup"],
-  "author": "Tingle Software",
+  "minimumAgentVersion": "3.232.1",
   "demands": [],
   "version": {
     "Major": 1,
@@ -19,8 +20,7 @@
   },
   "deprecated": true,
   "deprecationMessage": "This task version is deprecated and is no longer maintained. Please upgrade to the latest version to continue receiving fixes and features. More details: https://github.com/tinglesoftware/dependabot-azure-devops/discussions/1317.",
-  "instanceNameFormat": "Dependabot",
-  "minimumAgentVersion": "3.232.1",
+  "instanceNameFormat": "Dependabot update",
   "groups": [
     {
       "name": "security_updates",
@@ -255,11 +255,9 @@
       "helpMarkDown": "Ensure that the host ssh socket is forwarded to the container to authenticate with ssh"
     }
   ],
-  "dataSourceBindings": [],
   "execution": {
     "Node20_1": {
-      "target": "index.js",
-      "argumentFormat": ""
+      "target": "index.js"
     }
   }
 }

--- a/extension/tasks/dependabotV2/task.json
+++ b/extension/tasks/dependabotV2/task.json
@@ -7,10 +7,11 @@
   "helpMarkDown": "For help please visit https://github.com/tinglesoftware/dependabot-azure-devops/issues",
   "helpUrl": "https://github.com/tinglesoftware/dependabot-azure-devops/issues",
   "releaseNotes": "https://github.com/tinglesoftware/dependabot-azure-devops/releases",
-  "category": "Utility",
+  "author": "Tingle Software",
+  "category": "Azure Pipelines",
   "visibility": ["Build", "Release"],
   "runsOn": ["Agent", "DeploymentGroup"],
-  "author": "Tingle Software",
+  "minimumAgentVersion": "3.232.1",
   "demands": [],
   "version": {
     "Major": 2,
@@ -18,8 +19,7 @@
     "Patch": 0
   },
   "preview": true,
-  "instanceNameFormat": "Dependabot",
-  "minimumAgentVersion": "3.232.1",
+  "instanceNameFormat": "Dependabot update",
   "groups": [
     {
       "name": "pull_requests",
@@ -229,11 +229,9 @@
       "helpMarkDown": "Comma-seperated list of key/value pairs representing the enabled Dependabot experiments e.g. `experiments: 'tidy=true,vendor=true,goprivate=*'`. Available options vary depending on the package ecosystem. See [configuring experiments](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-experiments) for more details."
     }
   ],
-  "dataSourceBindings": [],
   "execution": {
     "Node20_1": {
-      "target": "index.js",
-      "argumentFormat": ""
+      "target": "index.js"
     }
   }
 }

--- a/extension/vss-extension.json
+++ b/extension/vss-extension.json
@@ -3,6 +3,7 @@
   "manifestVersion": 1,
   "id": "dependabot",
   "name": "Dependabot",
+  "description": "Automatically update dependencies and vulnerabilities in your code",
   "version": "2.0.0",
   "publisher": "tingle-software",
   "public": false,
@@ -11,15 +12,45 @@
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
-  "description": "Automatically update dependencies and vulnerabilities in your code",
+  "demands": ["api-version/5.0"],
   "categories": ["Azure Pipelines"],
+  "tags": [
+    "dependabot",
+    "dependency",
+    "dependencies",
+    "package",
+    "update",
+    "vulnerability",
+    "vulnerabilities",
+    "security"
+  ],
+  "branding": {
+    "color": "rgb(3, 102, 214)",
+    "theme": "dark"
+  },
   "icons": {
     "default": "images/icon.png"
   },
   "links": {
+    "home": {
+      "uri": "https://github.com/tinglesoftware/dependabot-azure-devops"
+    },
+    "getstarted": {
+      "uri": "https://github.com/tinglesoftware/dependabot-azure-devops/blob/main/extension/README.md#usage"
+    },
+    "issues": {
+      "uri": "https://github.com/tinglesoftware/dependabot-azure-devops/issues"
+    },
     "support": {
       "uri": "https://github.com/tinglesoftware/dependabot-azure-devops/issues"
+    },
+    "license": {
+      "uri": "https://github.com/tinglesoftware/dependabot-azure-devops/blob/main/LICENSE"
     }
+  },
+  "customerQnASupport": {
+    "enablemarketplaceqna": true,
+    "url": "https://github.com/tinglesoftware/dependabot-azure-devops/discussions"
   },
   "repository": {
     "type": "git",
@@ -41,11 +72,11 @@
   ],
   "contributions": [
     {
-      "id": "dependabot",
+      "id": "dependabotTask",
       "type": "ms.vss-distributed-task.task",
       "targets": ["ms.vss-distributed-task.tasks"],
       "properties": {
-        "name": "tasks"
+        "name": "Dependabot"
       }
     }
   ]

--- a/extension/vss-extension.json
+++ b/extension/vss-extension.json
@@ -76,7 +76,7 @@
       "type": "ms.vss-distributed-task.task",
       "targets": ["ms.vss-distributed-task.tasks"],
       "properties": {
-        "name": "Dependabot"
+        "name": "tasks"
       }
     }
   ]

--- a/extension/vss-extension.json
+++ b/extension/vss-extension.json
@@ -24,10 +24,6 @@
     "vulnerabilities",
     "security"
   ],
-  "branding": {
-    "color": "rgb(3, 102, 214)",
-    "theme": "dark"
-  },
   "icons": {
     "default": "images/icon.png"
   },


### PR DESCRIPTION
Tidy up extension and task metadata.

## Changes

- **Extension now demands `api-version/5.0`**
Previously as seen in #1423, the extension could be installed on any server and would throw errors at PR creation time if the APIs were not available. Now, installation is prevented on servers that don't support the required APIs. 

- **Extension tags have been added**
For better discovery in the Visual Studio marketplace.

- **Extension links have been updated**
Add links for "home", "getstarted", "issues", and "license". The "Q & A" tab on the extension page now links to the GitHub project [discussions page](https://github.com/tinglesoftware/dependabot-azure-devops/discussions), rather than issues page.

- **Task category changed from "Utility" to "Azure Pipelines"**
The previous value was intended for TFS 2018 or earlier, the later value is correct for Azure DevOps 2019 or later.

## Before
![image](https://github.com/user-attachments/assets/0dcfb21d-d9c2-4b67-a5df-52d71c1a25aa)

## After
![image](https://github.com/user-attachments/assets/bde7ffb0-878b-485a-9a35-1d63144e2aee)


