### PR TITLE
Add support for dotnet-sdk package ecosystem

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,6 +16,7 @@ jobs:
           - { ecosystem: cargo }
           - { ecosystem: composer }
           - { ecosystem: docker }
+          - { ecosystem: dotnet-sdk }
           - { ecosystem: elm }
           - { ecosystem: gitsubmodule }
           - { ecosystem: github-actions }

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -35,6 +35,7 @@ jobs:
           - { ecosystem: cargo }
           - { ecosystem: composer }
           - { ecosystem: docker }
+          - { ecosystem: dotnet-sdk }
           - { ecosystem: elm }
           - { ecosystem: gitsubmodule }
           - { ecosystem: github-actions }

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,6 @@ GEMSPECS = %w(
   go_modules/dependabot-go_modules.gemspec
   terraform/dependabot-terraform.gemspec
   docker/dependabot-docker.gemspec
-  dotnet_sdk/dependabot-dotnet_sdk.gemspec
   git_submodules/dependabot-git_submodules.gemspec
   github_actions/dependabot-github_actions.gemspec
   nuget/dependabot-nuget.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ GEMSPECS = %w(
   go_modules/dependabot-go_modules.gemspec
   terraform/dependabot-terraform.gemspec
   docker/dependabot-docker.gemspec
+  dotnet_sdk/dependabot-dotnet_sdk.gemspec
   git_submodules/dependabot-git_submodules.gemspec
   github_actions/dependabot-github_actions.gemspec
   nuget/dependabot-nuget.gemspec

--- a/extension/tasks/dependabotV2/utils/dependabot/parseConfigFile.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/parseConfigFile.ts
@@ -158,6 +158,8 @@ function parseUpdates(config: any): IDependabotUpdate[] {
       switch (ecosystem) {
         case 'devcontainer':
           return 'devcontainers';
+        case 'dotnet-sdk':
+          return 'dotnet_sdk';
         case 'github-actions':
           return 'github_actions';
         case 'gitsubmodule':

--- a/server/Tingle.Dependabot.Tests/Workflow/UpdateRunnerTests.cs
+++ b/server/Tingle.Dependabot.Tests/Workflow/UpdateRunnerTests.cs
@@ -309,6 +309,7 @@ public class UpdateRunnerTests
 
     public static TheoryData<string, string> ConvertEcosystemToPackageManagerValues => new()
     {
+        { "dotnet-sdk", "dotnet_sdk" },
         { "github-actions", "github_actions" },
         { "gitsubmodule", "submodules" },
         { "gomod", "go_modules" },

--- a/server/Tingle.Dependabot/Workflow/UpdateRunner.cs
+++ b/server/Tingle.Dependabot/Workflow/UpdateRunner.cs
@@ -474,6 +474,7 @@ internal partial class UpdateRunner
 
         return ecosystem switch
         {
+            "dotnet-sdk" => "dotnet_sdk",
             "github-actions" => "github_actions",
             "gitsubmodule" => "submodules",
             "gomod" => "go_modules",

--- a/updater/bin/update_script.rb
+++ b/updater/bin/update_script.rb
@@ -132,6 +132,7 @@ $package_manager = ENV["DEPENDABOT_PACKAGE_MANAGER"] || "bundler"
 # https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem
 # [Hash<String, String>]
 PACKAGE_ECOSYSTEM_MAPPING = {
+  "dotnet-sdk" => "dotnet_sdk",
   "github-actions" => "github_actions",
   "gitsubmodule" => "submodules",
   "gomod" => "go_modules",

--- a/updater/lib/tinglesoftware/dependabot/job.rb
+++ b/updater/lib/tinglesoftware/dependabot/job.rb
@@ -190,6 +190,7 @@ module TingleSoftware
         # GitHub native implementation modifies some of the names in the config file
         # https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem
         {
+          "dotnet-sdk" => "dotnet_sdk",
           "github-actions" => "github_actions",
           "gitsubmodule" => "submodules",
           "gomod" => "go_modules",


### PR DESCRIPTION
Add support for dotnet-sdk package ecosystem:
https://github.com/dependabot/dependabot-core/pull/10756

This should only be merged after https://github.com/tinglesoftware/dependabot-azure-devops/pull/1453.