### PR TITLE
Fix open pull requests limit being ignored

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -138,8 +138,8 @@ async function run() {
 
       // Run an update job for "all dependencies"; this will create new pull requests for dependencies that need updating
       const openPullRequestsLimit = update['open-pull-requests-limit'];
-      const openPullRequests = Object.entries(existingPullRequestsForPackageEcosystem).length;
-      const hasReachedOpenPullRequestLimit = openPullRequestsLimit > 0 && openPullRequests >= openPullRequestsLimit;
+      const openPullRequestsCount = Object.entries(existingPullRequestsForPackageEcosystem).length;
+      const hasReachedOpenPullRequestLimit = openPullRequestsLimit > 0 && openPullRequestsCount >= openPullRequestsLimit;
       if (!hasReachedOpenPullRequestLimit) {
         failedTasks += handleUpdateOperationResults(
           await dependabot.update(

--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -139,7 +139,8 @@ async function run() {
       // Run an update job for "all dependencies"; this will create new pull requests for dependencies that need updating
       const openPullRequestsLimit = update['open-pull-requests-limit'];
       const openPullRequestsCount = Object.entries(existingPullRequestsForPackageEcosystem).length;
-      const hasReachedOpenPullRequestLimit = openPullRequestsLimit > 0 && openPullRequestsCount >= openPullRequestsLimit;
+      const hasReachedOpenPullRequestLimit =
+        openPullRequestsLimit > 0 && openPullRequestsCount >= openPullRequestsLimit;
       if (!hasReachedOpenPullRequestLimit) {
         failedTasks += handleUpdateOperationResults(
           await dependabot.update(

--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -138,8 +138,8 @@ async function run() {
 
       // Run an update job for "all dependencies"; this will create new pull requests for dependencies that need updating
       const openPullRequestsLimit = update['open-pull-requests-limit'];
-      const openPullRequests = Object.entries(existingPullRequestsForPackageEcosystem).length
-      const hasReachedOpenPullRequestLimit = (openPullRequestsLimit > 0 && openPullRequests >= openPullRequestsLimit);
+      const openPullRequests = Object.entries(existingPullRequestsForPackageEcosystem).length;
+      const hasReachedOpenPullRequestLimit = openPullRequestsLimit > 0 && openPullRequests >= openPullRequestsLimit;
       if (!hasReachedOpenPullRequestLimit) {
         failedTasks += handleUpdateOperationResults(
           await dependabot.update(
@@ -154,7 +154,7 @@ async function run() {
             dependabotUpdaterOptions,
           ),
         );
-      }else {
+      } else {
         warning(
           `Skipping update for ${packageEcosystem} packages as the open pull requests limit (${openPullRequestsLimit}) has already been reached`,
         );

--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -197,7 +197,7 @@ export class AzureDevOpsWebApiClient {
               isFlagged: true,
             });
           } else {
-            warning(` ! Unable to resolve assignee identity '${assignee}'`);
+            warning(`Unable to resolve assignee identity '${assignee}'`);
           }
         }
       }
@@ -209,7 +209,7 @@ export class AzureDevOpsWebApiClient {
               id: identityId,
             });
           } else {
-            warning(` ! Unable to resolve reviewer identity '${reviewer}'`);
+            warning(`Unable to resolve reviewer identity '${reviewer}'`);
           }
         }
       }

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -101,8 +101,8 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
 
         // Skip if active pull request limit reached.
         const openPullRequestsLimit = update.config['open-pull-requests-limit'];
-        const openPullRequests = this.createdPullRequestIds.length + this.existingPullRequests.length;
-        if (openPullRequestsLimit > 0 && openPullRequests >= openPullRequestsLimit) {
+        const openPullRequestsCount = this.createdPullRequestIds.length + this.existingPullRequests.length;
+        if (openPullRequestsLimit > 0 && openPullRequestsCount >= openPullRequestsLimit) {
           warning(
             `Skipping pull request creation of '${title}' as the open pull requests limit (${openPullRequestsLimit}) has been reached`,
           );

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -39,7 +39,7 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
     prAuthorClient: AzureDevOpsWebApiClient,
     prApproverClient: AzureDevOpsWebApiClient,
     existingBranchNames: string[],
-    existingPullRequests: IPullRequestProperties[]
+    existingPullRequests: IPullRequestProperties[],
     debug: boolean = false,
   ) {
     this.taskInputs = taskInputs;

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -196,8 +196,7 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
         if (newPullRequestId > 0) {
           this.createdPullRequestIds.push(newPullRequestId);
           return true;
-        }
-        else {
+        } else {
           return false;
         }
 


### PR DESCRIPTION
Fixes #1460

Ensures that the open pull requests limit cannot be exceeded. The "update all" step will now be skipped if the pull request limit has already been reached, since there is no point running it if no new PRs can be opened.