### PR TITLE
Restore original task id; Fix publish workflow

### DIFF
--- a/extension/vss-extension.json
+++ b/extension/vss-extension.json
@@ -68,7 +68,7 @@
   ],
   "contributions": [
     {
-      "id": "dependabotTask",
+      "id": "dependabot",
       "type": "ms.vss-distributed-task.task",
       "targets": ["ms.vss-distributed-task.tasks"],
       "properties": {


### PR DESCRIPTION
@mburumaxwell sorry, I broke the publish workflow; The task id [was renamed during some of the manifest updates](https://github.com/tinglesoftware/dependabot-azure-devops/pull/1451/files), I didn't realise this cannot be renamed once set.

```log
error: Contribution Microsoft.VisualStudio.Services.TaskId.DEPENDABOTTASK is re-using task ID of some other contribution from earlier version. To publish the extension, change the task ID.
```