### PR TITLE
Disable husky git hooks by default, opt-in using `npx husky`

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -61,3 +61,7 @@ pip install codespell
 codespell                   # to check for misspellings
 codespell --write-changes   # to automatically fix misspellings
 ```
+
+## Automatically run quality checks on commit
+
+If you'd like spelling, formatting, and linting checks to be run automatically on commit, enable the [Husky](https://typicode.github.io/husky/how-to.html) git hooks using `npx husky`; When enabled, your local commits will be rejected if any of the quality checks fail.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -9,6 +9,7 @@ Thank you for contributing to the Dependabot for Azure DevOps project.
   - [Static code analyzers and linters](#static-code-analyzers-and-linters)
   - [Formatters](#formatters)
   - [Spelling](#spelling)
+  - [Automatically run quality checks on commit](#automatically-run-quality-checks-on-commit)
 
 # Contribution workflow
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -70,4 +70,4 @@ If you'd like spelling, formatting, and linting checks to be run automatically o
 npx husky
 ```
 
-When enabled, your local commits will be rejected if any of the quality checks fail; Unit tests are **not** run due to their long execution time, you must still them manually.
+When enabled, your local commits will be rejected if any of the quality checks fail; Unit tests are **not** run due to their long execution time, you must still run them manually.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -65,4 +65,9 @@ codespell --write-changes   # to automatically fix misspellings
 
 ## Automatically run quality checks on commit
 
-If you'd like spelling, formatting, and linting checks to be run automatically on commit, enable the [Husky](https://typicode.github.io/husky/how-to.html) git hooks using `npx husky`; When enabled, your local commits will be rejected if any of the quality checks fail.
+If you'd like spelling, formatting, and linting checks to be run automatically on commit, enable the [Husky](https://typicode.github.io/husky/how-to.html) git hooks using:
+```bash
+npx husky
+```
+
+When enabled, your local commits will be rejected if any of the quality checks fail; Unit tests are **not** run due to their long execution time, you must still them manually.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "prepare": "husky",
     "postinstall": "npm --prefix extension install",
     "format": "prettier --write .",
     "format:check": "prettier --check ."


### PR DESCRIPTION
Fixes https://github.com/tinglesoftware/dependabot-azure-devops/pull/1450#issuecomment-2482445434.

Disable husky git hooks by default, opt-in using `npx husky`. 
The contributing guide has been updated to reflect this change too.