### PR TITLE
Fixed typo in label for v2 Task

### DIFF
--- a/extension/tasks/dependabotV2/task.json
+++ b/extension/tasks/dependabotV2/task.json
@@ -134,7 +134,7 @@
       "name": "authorEmail",
       "type": "string",
       "groupName": "pull_requests",
-      "label": "Git commit uthor email address",
+      "label": "Git commit author email address",
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "The email address to use for the change commit author. Can be used to associate the committer with an existing account, to provide a profile picture. Defaults to `noreply@github.com`."


### PR DESCRIPTION
This simple PR fixes the typo in the label of the v2 task for the Git Author email address field
![image](https://github.com/user-attachments/assets/65c3e58f-8204-4494-a76a-831d655bc787)
