### PR TITLE
Always clone repo, even if it already exists locally

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -90,7 +90,6 @@ async function run() {
 
     const dependabotUpdaterOptions = {
       sourceProvider: 'azure',
-      sourceLocalPath: taskInputs.repositorySourcePath,
       azureDevOpsAccessToken: taskInputs.systemAccessToken,
       gitHubAccessToken: taskInputs.githubAccessToken,
       collectorImage: undefined, // TODO: Add config for this?

--- a/extension/tasks/dependabotV2/utils/getSharedVariables.ts
+++ b/extension/tasks/dependabotV2/utils/getSharedVariables.ts
@@ -27,8 +27,6 @@ export interface ISharedVariables {
   repository: string;
   /** Whether the repository was overridden via input */
   repositoryOverridden: boolean;
-  /** Path to the local repository source. When specified, Dependabot will use this local repo rather than cloning it from the remote repo again */
-  repositorySourcePath?: string;
 
   /** Organisation API endpoint URL */
   apiEndpointUrl: string;
@@ -107,10 +105,6 @@ export default function getSharedVariables(): ISharedVariables {
   }
   repository = encodeURI(repository); // encode special characters like spaces
 
-  // If the repository name is NOT overridden, then use the already cloned repository source directory
-  // for the dependabot update operation. This will save time and bandwidth as we don't have to clone the repository again.
-  let repositorySourcePath = repositoryOverridden ? undefined : tl.getVariable('Build.SourcesDirectory');
-
   const virtualDirectorySuffix = virtualDirectory?.length > 0 ? `${virtualDirectory}/` : '';
   let apiEndpointUrl = `${protocol}://${hostname}:${port}/${virtualDirectorySuffix}`;
 
@@ -168,7 +162,6 @@ export default function getSharedVariables(): ISharedVariables {
     project,
     repository,
     repositoryOverridden,
-    repositorySourcePath,
 
     apiEndpointUrl,
 


### PR DESCRIPTION
Fixes #1413.

This reverts the part of https://github.com/tinglesoftware/dependabot-azure-devops/pull/1382 that was added to stop Dependabot re-cloning the repo if it already existed locally. It seems that in [some situations](https://github.com/tinglesoftware/dependabot-azure-devops/issues/1413#issuecomment-2482809895), this can cause Dependabot to base its PR on a dirty/uncommitted working state.

Dependabot will now always clone the source repo, even if it already exists locally