### PR TITLE
Don't log output from highly verbose components, unless debugging

### DIFF
--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -7,7 +7,7 @@ import {
   PullRequestAsyncStatus,
   PullRequestStatus,
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
-import { error, warning } from 'azure-pipelines-task-lib/task';
+import { debug, error, warning } from 'azure-pipelines-task-lib/task';
 import { IHttpClientResponse } from 'typed-rest-client/Interfaces';
 import {
   IAbandonPullRequest,
@@ -683,10 +683,10 @@ export class AzureDevOpsWebApiClient {
     requestAsync: () => Promise<IHttpClientResponse>,
   ): Promise<any | undefined> {
     // Send the request, ready the response
-    if (this.debug) console.debug(`🌎 🠊 [${method}] ${url}`);
+    if (this.debug) debug(`🌎 🠊 [${method}] ${url}`);
     const response = await requestAsync();
     const body = await response.readBody();
-    if (this.debug) console.debug(`🌎 🠈 [${response.message.statusCode}] ${response.message.statusMessage}`);
+    if (this.debug) debug(`🌎 🠈 [${response.message.statusCode}] ${response.message.statusMessage}`);
 
     try {
       // Check that the request was successful
@@ -702,13 +702,13 @@ export class AzureDevOpsWebApiClient {
       // In debug mode, log the error, request, and response for debugging
       if (this.debug) {
         if (payload) {
-          console.debug('REQUEST:', JSON.stringify(payload, null, 2));
+          debug(`REQUEST: ${JSON.stringify(payload, null, 2)}`);
         }
         if (body) {
           try {
-            console.debug('RESPONSE:', JSON.stringify(JSON.parse(body), null, 2));
+            debug(`RESPONSE: ${JSON.stringify(JSON.parse(body), null, 2)}`);
           } catch {
-            console.debug('RESPONSE:', body); // If the response is not JSON, just log the raw body
+            debug(`RESPONSE: ${body}`); // If the response is not JSON, just log the raw body
           }
         }
       }

--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -702,14 +702,10 @@ export class AzureDevOpsWebApiClient {
       // In debug mode, log the error, request, and response for debugging
       if (this.debug) {
         if (payload) {
-          debug(`REQUEST: ${JSON.stringify(payload, null, 2)}`);
+          debug(`REQUEST: ${JSON.stringify(payload)}`);
         }
         if (body) {
-          try {
-            debug(`RESPONSE: ${JSON.stringify(JSON.parse(body), null, 2)}`);
-          } catch {
-            debug(`RESPONSE: ${body}`); // If the response is not JSON, just log the raw body
-          }
+          debug(`RESPONSE: ${body}`);
         }
       }
 

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -264,7 +264,7 @@ function logComponentOutput(
 
         // Log output from all other components
         default:
-          console.log(line);
+          console.info(line);
           break;
       }
     });

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -1,5 +1,5 @@
 import { GitPullRequestMergeStrategy, VersionControlChangeType } from 'azure-devops-node-api/interfaces/GitInterfaces';
-import { error, warning } from 'azure-pipelines-task-lib/task';
+import { debug, error, warning } from 'azure-pipelines-task-lib/task';
 import * as path from 'path';
 import { AzureDevOpsWebApiClient } from '../azure-devops/AzureDevOpsWebApiClient';
 import { section } from '../azure-devops/formattingCommands';
@@ -65,7 +65,7 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
 
     section(`Processing '${type}'`);
     if (this.debug) {
-      console.debug(JSON.stringify(data, null, 2));
+      debug(JSON.stringify(data, null, 2));
     }
     switch (type) {
       // Documentation on the 'data' model for each output type can be found here:

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -65,7 +65,7 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
 
     section(`Processing '${type}'`);
     if (this.debug) {
-      debug(JSON.stringify(data, null, 2));
+      debug(JSON.stringify(data));
     }
     switch (type) {
       // Documentation on the 'data' model for each output type can be found here:


### PR DESCRIPTION
Refs #1441, #1473.

Don't log output from highly verbose components (e.g. collector, proxy), unless debugging.
In normal happy day scenarios, these logs provide little to no value but consume a lot of space.

## Example when debug disabled

![image](https://github.com/user-attachments/assets/df617ba3-3235-4884-b8ac-6af45416b5f0)

## Example when debug enabled

![image](https://github.com/user-attachments/assets/73f49806-2e60-41ad-af25-4483ee7c6f63)
