### PR TITLE
If no experiments are specified, use the GitHub defaults

### DIFF
--- a/docs/migrations/v1-to-v2.md
+++ b/docs/migrations/v1-to-v2.md
@@ -1,6 +1,6 @@
 
 > [!WARNING]
-> **:construction: Work in progress;** `dependabot@V2` is still under development and this document may change without notice up until general availability (GA).
+> **:construction: Work in progress;** `dependabot@2` is still under development and this document may change without notice up until general availability (GA).
 
 # Table of Contents
 - [Summary of changes V1 → V2](#summary-of-changes-v1-v2)
@@ -10,10 +10,10 @@
 # Summary of changes V1 → V2
 V2 is a complete re-write of the Dependabot task; It aims to:
 
-- Resolve the [numerous private feed/registry authentication issues](https://github.com/tinglesoftware/dependabot-azure-devops/discussions/1317) that currently exist in V1;
+- Resolve the [private feed/registry authentication issues](https://github.com/tinglesoftware/dependabot-azure-devops/discussions/1317) that exist in V1;
 - More closely align the update logic with the GitHub-hosted Dependabot service;
 
-The task now uses [Dependabot CLI](https://github.com/dependabot/cli) to perform dependency updates, which is the _[currently]_ recommended approach for running Dependabot. See [extension task architecture](../extension.md#architecture) for more details on the technical changes and impact to the update process.
+The task now uses [Dependabot CLI](https://github.com/dependabot/cli) to perform dependency updates, which is the _current_ recommended approach for running Dependabot. See [extension task architecture](../extension.md#architecture) for more details on the technical changes and impact to the update process.
 
 # Breaking changes V1 → V2
 
@@ -62,12 +62,12 @@ The following environment variables have been removed entirely; the feature is n
 
 | Removed Environment Variable | Reason |
 |--|--|
-|`DEPENDABOT_PR_NAME_PREFIX_STYLE`| Feature is not supported; It is not an official configuration |
-|`DEPENDABOT_COMPATIBILITY_SCORE_BADGE`| Feature is not supported; It is not an official configuration |
-|`DEPENDABOT_MESSAGE_HEADER`| Feature is not supported; It is not an official configuration |
-|`DEPENDABOT_MESSAGE_FOOTER`| Feature is not supported; It is not an official configuration |
-|`DEPENDABOT_SIGNATURE_KEY`| Feature is not supported; It is not an official configuration |
-|`DEPENDABOT_JOB_ID`| Set automatically by extension |
+|`DEPENDABOT_COMPATIBILITY_SCORE_BADGE`| Feature is now enabled by default, no configuration required. |
+|`DEPENDABOT_PR_NAME_PREFIX_STYLE`| Feature is not supported; It is not an official configuration. Use [`commit-message.prefix`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message) instead. |
+|`DEPENDABOT_MESSAGE_HEADER`| Feature is not supported; It is not an official configuration. |
+|`DEPENDABOT_MESSAGE_FOOTER`| Feature is not supported; It is not an official configuration. |
+|`DEPENDABOT_SIGNATURE_KEY`| Feature is not supported; It is not an official configuration. |
+|`DEPENDABOT_JOB_ID`| Set automatically, no configuration required. |
 
 ## Todo before general availability
 Before removing the preview flag from V2 `task.json`, we need to:

--- a/extension/README.md
+++ b/extension/README.md
@@ -20,19 +20,21 @@ An example of a YAML pipeline:
 trigger: none # Disable CI trigger
 
 schedules:
-- cron: '0 2 * * *' # daily at 2am UTC
+- cron: '0 0 * * 0' # weekly on sunday at midnight UTC
   always: true # run even when there are no code changes
   branches:
     include:
       - master
   batch: true
-  displayName: Daily
+  displayName: Weekly
 
 pool:
   vmImage: 'ubuntu-latest' # requires macos or ubuntu (windows is not supported)
 
 steps:
 - task: dependabot@2
+  inputs:
+    mergeStrategy: 'squash'
 ```
 
 ## Task Requirements
@@ -44,8 +46,8 @@ Dependabot uses Docker containers, which may take time to install if not already
 
 ## Task Parameters
 
-<details>
-<summary>dependabot@V2</summary>
+<details open>
+<summary>dependabot@2</summary>
 
 |Input|Description|
 |--|--|
@@ -67,12 +69,12 @@ Dependabot uses Docker containers, which may take time to install if not already
 |storeDependencyList|**_Optional_**. Determines if the last know dependency list information should be stored in the parent DevOps project properties. If enabled, the authenticated user must have the "Project & Team (Write)" permission for the project. Defaults to `false`.|
 |targetRepositoryName|**_Optional_**. The name of the repository to target for processing. If this value is not supplied then the Build Repository Name is used. Supplying this value allows creation of a single pipeline that runs Dependabot against multiple repositories by running a `dependabot` task for each repository to update.|
 |targetUpdateIds|**_Optional_**. A semicolon (`;`) delimited list of update identifiers run. Index are zero-based and in the order written in the configuration file. When not present, all the updates are run. This is meant to be used in scenarios where you want to run updates a different times from the same configuration file given you cannot schedule them independently in the pipeline.|
-|experiments|**_Optional_**. Comma separated list of Dependabot experiments; available options depend on the ecosystem. Example: `tidy=true,vendor=true,goprivate=*`. See: [Configuring experiments](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-experiments)|
+|experiments|**_Optional_**. Comma separated list of Dependabot experiments; available options depend on the ecosystem. Example: `tidy=true,vendor=true,goprivate=*`. If specified, this overrides the [default experiments](https://github.com/tinglesoftware/dependabot-azure-devops/blob/main/extension/tasks/dependabotV2/utils/dependabot/experiments.ts). See: [Configuring experiments](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-experiments)|
 
 </details>
 
 <details>
-<summary>dependabot@V1 <strong>(Deprecated)</strong></summary>
+<summary>dependabot@1 <strong>(deprecated)</strong></summary>
 
 |Input|Description|
 |--|--|

--- a/extension/tasks/dependabotV2/task.json
+++ b/extension/tasks/dependabotV2/task.json
@@ -226,7 +226,7 @@
       "groupName": "advanced",
       "label": "Dependabot updater experiments",
       "required": false,
-      "helpMarkDown": "Comma-seperated list of key/value pairs representing the enabled Dependabot experiments e.g. `experiments: 'tidy=true,vendor=true,goprivate=*'`. Available options vary depending on the package ecosystem. See [configuring experiments](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-experiments) for more details."
+      "helpMarkDown": "Comma-seperated list of key/value pairs representing the enabled Dependabot experiments e.g. `experiments: 'tidy=true,vendor=true,goprivate=*'`. Available options vary depending on the package ecosystem. If specified, this overrides the [default experiments](https://github.com/tinglesoftware/dependabot-azure-devops/blob/main/extension/tasks/dependabotV2/utils/dependabot/experiments.ts). See [configuring experiments](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-experiments) for more details."
     }
   ],
   "execution": {

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -148,7 +148,14 @@ function buildUpdateJobConfig(
               'prefix-development': update['commit-message']?.['prefix-development'],
               'include-scope': update['commit-message']?.['include'],
             },
-      'experiments': taskInputs.experiments,
+      'experiments': Object.keys(taskInputs.experiments || {}).reduce(
+        (acc, key) => {
+          // Replace '-' with '_' in the experiment keys to match the dependabot-core models
+          acc[key.replace(/-/g, '_')] = taskInputs.experiments[key];
+          return acc;
+        },
+        {} as Record<string, string | boolean>,
+      ),
       'max-updater-run-time': undefined, // TODO: add config for this?
       'reject-external-code': update['insecure-external-code-execution']?.toLocaleLowerCase() == 'allow',
       'repo-private': undefined, // TODO: add config for this?

--- a/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
@@ -1,0 +1,15 @@
+// The default experiments known to be used by the GitHub Dependabot service.
+// This changes often, update as needed by extracting them from a Dependabot GitHub Action run.
+//  e.g. https://github.com/tinglesoftware/dependabot-azure-devops/actions/workflows/dependabot/dependabot-updates
+export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
+  'record-ecosystem-versions': true,
+  'record-update-job-unknown-error': true,
+  'proxy-cached': true,
+  'move-job-token': true,
+  'dependency-change-validation': true,
+  'nuget-native-analysis': true,
+  'nuget-use-direct-discovery': true,
+  'enable-file-parser-python-local': true,
+  'lead-security-dependency': true,
+  'enable-record-ecosystem-meta': true,
+};

--- a/extension/tasks/dependabotV2/utils/getSharedVariables.ts
+++ b/extension/tasks/dependabotV2/utils/getSharedVariables.ts
@@ -1,4 +1,5 @@
 import * as tl from 'azure-pipelines-task-lib/task';
+import { DEFAULT_EXPERIMENTS } from './dependabot/experiments';
 import extractHostname from './extractHostname';
 import extractOrganization from './extractOrganization';
 import extractVirtualDirectory from './extractVirtualDirectory';
@@ -139,6 +140,14 @@ export default function getSharedVariables(): ISharedVariables {
       },
       {} as Record<string, string | boolean>,
     );
+
+  // If no experiments are defined, use the default experiments
+  if (!experiments) {
+    experiments = DEFAULT_EXPERIMENTS;
+    tl.debug('No experiments provided; Using default experiments.');
+  }
+
+  console.log('Experiments:', experiments);
 
   let debug: boolean = tl.getVariable('System.Debug')?.match(/true/i) ? true : false;
 


### PR DESCRIPTION
More closely match the behavior of the GitHub hosted Dependabot service by using the same default experiments. If the user explicitly sets the `experiments` task input, the default will not be used.

This PR also cleans up some of the documentation, fixes several inaccuracies and removes things which don't add much value anymore (e.g. V1 auth workarounds).