### PR TITLE
Fix publish workflows GitVersion tool version error

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.0.3
         with:
-          versionSpec: '6.x'
+          versionSpec: '6.0.x'
 
       - name: Determine Version
         id: gitversion

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.0.3
         with:
-          versionSpec: '6.x'
+          versionSpec: '6.0.x'
 
       - name: Determine Version
         uses: gittools/actions/gitversion/execute@v3.0.3

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.0.3
         with:
-          versionSpec: '6.x'
+          versionSpec: '6.0.x'
 
       - name: Determine Version
         uses: gittools/actions/gitversion/execute@v3.0.3


### PR DESCRIPTION
Update GitVersion tool spec to 6.0.x so that the resolved version stays below 6.1.
Fixes the error:

```
Querying tool versions for GitVersion.Tool@6.x 
Found matching version: 6.1.0
Error: Version spec '6.x' resolved as '6.1.0' does not satisfy the range '>=5.2.0 <6.1.0'.See https://github.com/GitTools/actions/blob/main/docs/versions.md for more information.
```