### PR TITLE
Use pattern '*' when group pattern is not specified in config

### DIFF
--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
@@ -1,0 +1,96 @@
+import { IDependabotGroup } from '../dependabot/interfaces/IDependabotConfig';
+import { mapGroupsFromDependabotConfigToJobConfig } from './DependabotJobBuilder';
+
+describe('mapGroupsFromDependabotConfigToJobConfig', () => {
+  it('should return undefined if dependencyGroups is undefined', () => {
+    const result = mapGroupsFromDependabotConfigToJobConfig(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return an empty array if dependencyGroups is an empty object', () => {
+    const result = mapGroupsFromDependabotConfigToJobConfig({});
+    expect(result).toEqual([]);
+  });
+
+  it('should filter out undefined groups', () => {
+    const dependencyGroups: Record<string, any> = {
+      group1: undefined,
+      group2: {
+        patterns: ['pattern2'],
+      },
+    };
+
+    const result = mapGroupsFromDependabotConfigToJobConfig(dependencyGroups);
+    expect(result).toEqual([
+      {
+        name: 'group2',
+        rules: {
+          patterns: ['pattern2'],
+        },
+      },
+    ]);
+  });
+
+  it('should filter out null groups', () => {
+    const dependencyGroups: Record<string, any> = {
+      group1: null,
+      group2: {
+        patterns: ['pattern2'],
+      },
+    };
+
+    const result = mapGroupsFromDependabotConfigToJobConfig(dependencyGroups);
+    expect(result).toEqual([
+      {
+        name: 'group2',
+        rules: {
+          patterns: ['pattern2'],
+        },
+      },
+    ]);
+  });
+
+  it('should map dependency group properties correctly', () => {
+    const dependencyGroups: Record<string, IDependabotGroup> = {
+      group: {
+        'applies-to': 'all',
+        'patterns': ['pattern1', 'pattern2'],
+        'exclude-patterns': ['exclude1'],
+        'dependency-type': 'direct',
+        'update-types': ['security'],
+      },
+    };
+
+    const result = mapGroupsFromDependabotConfigToJobConfig(dependencyGroups);
+
+    expect(result).toEqual([
+      {
+        'name': 'group',
+        'applies-to': 'all',
+        'rules': {
+          'patterns': ['pattern1', 'pattern2'],
+          'exclude-patterns': ['exclude1'],
+          'dependency-type': 'direct',
+          'update-types': ['security'],
+        },
+      },
+    ]);
+  });
+
+  it('should use pattern "*" if no patterns are provided', () => {
+    const dependencyGroups: Record<string, IDependabotGroup> = {
+      group: {},
+    };
+
+    const result = mapGroupsFromDependabotConfigToJobConfig(dependencyGroups);
+
+    expect(result).toEqual([
+      {
+        name: 'group',
+        rules: {
+          patterns: ['*'],
+        },
+      },
+    ]);
+  });
+});

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -182,7 +182,7 @@ function mapSourceFromDependabotConfigToJobConfig(taskInputs: ISharedVariables, 
   };
 }
 
-function mapGroupsFromDependabotConfigToJobConfig(dependencyGroups: Record<string, IDependabotGroup>): any[] {
+export function mapGroupsFromDependabotConfigToJobConfig(dependencyGroups: Record<string, IDependabotGroup>): any[] {
   if (!dependencyGroups) {
     return undefined;
   }

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -196,7 +196,7 @@ function mapGroupsFromDependabotConfigToJobConfig(dependencyGroups: Record<strin
         'name': name,
         'applies-to': group['applies-to'],
         'rules': {
-          'patterns': group['patterns'] || ['*'],
+          'patterns': group['patterns']?.length ? group['patterns'] : ['*'],
           'exclude-patterns': group['exclude-patterns'],
           'dependency-type': group['dependency-type'],
           'update-types': group['update-types'],

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -186,19 +186,24 @@ function mapGroupsFromDependabotConfigToJobConfig(dependencyGroups: Record<strin
   if (!dependencyGroups) {
     return undefined;
   }
-  return Object.keys(dependencyGroups).map((name) => {
-    const group = dependencyGroups[name];
-    return {
-      'name': name,
-      'applies-to': group['applies-to'],
-      'rules': {
-        'patterns': group['patterns'],
-        'exclude-patterns': group['exclude-patterns'],
-        'dependency-type': group['dependency-type'],
-        'update-types': group['update-types'],
-      },
-    };
-  });
+  return Object.keys(dependencyGroups)
+    .map((name) => {
+      const group = dependencyGroups[name];
+      if (!group) {
+        return;
+      }
+      return {
+        'name': name,
+        'applies-to': group['applies-to'],
+        'rules': {
+          'patterns': group['patterns'] || ['*'],
+          'exclude-patterns': group['exclude-patterns'],
+          'dependency-type': group['dependency-type'],
+          'update-types': group['update-types'],
+        },
+      };
+    })
+    .filter((g) => g);
 }
 
 function mapAllowedUpdatesFromDependabotConfigToJobConfig(allowedUpdates: IDependabotAllowCondition[]): any[] {


### PR DESCRIPTION
_Possible_ fix for #1527.
Error:
```json
{
  "error-class":"Dependabot::Sorbet::Runtime::InformationalError",
  "error-message":"Parameter 'rules': Expected type T::Hash[String, T.untyped], got type NilClass\nCaller: /home/dependabot/dependabot-updater/vendor/ruby/3.3.0/gems/sorbet-runtime-0.5.11577/lib/types/private/methods/call_validation.rb:215\nDefinition: /home/dependabot/common/lib/dependabot/dependency_group.rb:36 (Dependabot::DependencyGroup#initialize)"
}
```

Based on the stack trace, it appears that the [`group:` config didn't contain any rules](https://github.com/dependabot/dependabot-core/blame/b6e9029fb65e64f90d81087f8733e12f22cf33b6/updater/lib/dependabot/dependency_group_engine.rb#L30), resulting in an empty object. Dependabot CLI has an [`omitempty` attribute on the `rules` property](https://github.com/dependabot/cli/blob/4e7612fe884683ade8c54ad8fd137fc6da92bb84/internal/model/job.go#L89) which likely means that empty objects are not serialised, resulting in a `nil` once it reaches dependabot-core.

To ensure that group rules are always serialised, the pattern '*' will be used when no pattern is configured.
Additionally, null dependency groups are filtered out after being mapped from config.