### PR TITLE
Improved accuracy of Dependabot config handling; Align to observed GitHub behaviour

### DIFF
--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
@@ -7,9 +7,9 @@ describe('mapGroupsFromDependabotConfigToJobConfig', () => {
     expect(result).toBeUndefined();
   });
 
-  it('should return an empty array if dependencyGroups is an empty object', () => {
+  it('should return undefined if dependencyGroups is an empty object', () => {
     const result = mapGroupsFromDependabotConfigToJobConfig({});
-    expect(result).toEqual([]);
+    expect(result).toBeUndefined();
   });
 
   it('should filter out undefined groups', () => {
@@ -21,14 +21,7 @@ describe('mapGroupsFromDependabotConfigToJobConfig', () => {
     };
 
     const result = mapGroupsFromDependabotConfigToJobConfig(dependencyGroups);
-    expect(result).toEqual([
-      {
-        name: 'group2',
-        rules: {
-          patterns: ['pattern2'],
-        },
-      },
-    ]);
+    expect(result).toHaveLength(1);
   });
 
   it('should filter out null groups', () => {
@@ -40,14 +33,7 @@ describe('mapGroupsFromDependabotConfigToJobConfig', () => {
     };
 
     const result = mapGroupsFromDependabotConfigToJobConfig(dependencyGroups);
-    expect(result).toEqual([
-      {
-        name: 'group2',
-        rules: {
-          patterns: ['pattern2'],
-        },
-      },
-    ]);
+    expect(result).toHaveLength(1);
   });
 
   it('should map dependency group properties correctly', () => {

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -132,7 +132,7 @@ export function buildUpdateJobConfig(
       'updating-a-pull-request': updatingPullRequest || false,
       'dependency-group-to-refresh': updateDependencyGroupName,
       'dependency-groups': mapGroupsFromDependabotConfigToJobConfig(update.groups),
-      'dependencies': updateDependencyNames.length ? updateDependencyNames : undefined,
+      'dependencies': updateDependencyNames?.length ? updateDependencyNames : undefined,
       'allowed-updates': mapAllowedUpdatesFromDependabotConfigToJobConfig(update.allow, securityOnlyUpdate),
       'ignore-conditions': mapIgnoreConditionsFromDependabotConfigToJobConfig(update.ignore),
       'security-updates-only': securityOnlyUpdate,

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -1,6 +1,7 @@
 import {
   IDependabotAllowCondition,
   IDependabotGroup,
+  IDependabotIgnoreCondition,
   IDependabotRegistry,
   IDependabotUpdate,
 } from '../dependabot/interfaces/IDependabotConfig';
@@ -149,22 +150,7 @@ export function buildUpdateJobConfig(
               'include-scope':
                 update['commit-message']?.['include']?.toLocaleLowerCase()?.trim() == 'scope' ? true : undefined,
             },
-      'experiments': Object.keys(taskInputs.experiments || {}).reduce(
-        (acc, key) => {
-          // Experiment values are known to be either 'true', 'false', or a string value.
-          // If the value is 'true' or 'false', convert it to a boolean type so that dependabot-core handles it correctly.
-          const value = taskInputs.experiments[key];
-          if (typeof value === 'string' && value?.toLocaleLowerCase() === 'true') {
-            acc[key] = true;
-          } else if (typeof value === 'string' && value?.toLocaleLowerCase() === 'false') {
-            acc[key] = false;
-          } else {
-            acc[key] = value;
-          }
-          return acc;
-        },
-        {} as Record<string, string | boolean>,
-      ),
+      'experiments': mapExperiments(taskInputs.experiments),
       'reject-external-code': update['insecure-external-code-execution']?.toLocaleLowerCase()?.trim() == 'allow',
       'repo-private': undefined, // TODO: add config for this?
       'repo-contents-path': undefined, // TODO: add config for this?
@@ -248,7 +234,7 @@ export function mapAllowedUpdatesFromDependabotConfigToJobConfig(
 }
 
 export function mapIgnoreConditionsFromDependabotConfigToJobConfig(
-  ignoreConditions: IDependabotAllowCondition[],
+  ignoreConditions: IDependabotIgnoreCondition[],
 ): any[] {
   if (!ignoreConditions) {
     return undefined;
@@ -355,4 +341,23 @@ export function mapRegistryCredentialsFromDependabotConfigToJobConfig(
   }
 
   return registryCredentials;
+}
+
+export function mapExperiments(experiments: Record<string, string | boolean>): Record<string, string | boolean> {
+  return Object.keys(experiments || {}).reduce(
+    (acc, key) => {
+      // Experiment values are known to be either 'true', 'false', or a string value.
+      // If the value is 'true' or 'false', convert it to a boolean type so that dependabot-core handles it correctly.
+      const value = experiments[key];
+      if (typeof value === 'string' && value?.toLocaleLowerCase() === 'true') {
+        acc[key] = true;
+      } else if (typeof value === 'string' && value?.toLocaleLowerCase() === 'false') {
+        acc[key] = false;
+      } else {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {} as Record<string, string | boolean>,
+  );
 }

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -149,7 +149,22 @@ export function buildUpdateJobConfig(
               'include-scope':
                 update['commit-message']?.['include']?.toLocaleLowerCase()?.trim() == 'scope' ? true : undefined,
             },
-      'experiments': taskInputs.experiments,
+      'experiments': Object.keys(taskInputs.experiments || {}).reduce(
+        (acc, key) => {
+          // Experiment values are known to be either 'true', 'false', or a string value.
+          // If the value is 'true' or 'false', convert it to a boolean type so that dependabot-core handles it correctly.
+          const value = taskInputs.experiments[key];
+          if (typeof value === 'string' && value?.toLocaleLowerCase() === 'true') {
+            acc[key] = true;
+          } else if (typeof value === 'string' && value?.toLocaleLowerCase() === 'false') {
+            acc[key] = false;
+          } else {
+            acc[key] = value;
+          }
+          return acc;
+        },
+        {} as Record<string, string | boolean>,
+      ),
       'reject-external-code': update['insecure-external-code-execution']?.toLocaleLowerCase()?.trim() == 'allow',
       'repo-private': undefined, // TODO: add config for this?
       'repo-contents-path': undefined, // TODO: add config for this?

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -179,7 +179,7 @@ function mapSourceFromDependabotConfigToJobConfig(taskInputs: ISharedVariables, 
   };
 }
 
-function mapGroupsFromDependabotConfigToJobConfig(
+export function mapGroupsFromDependabotConfigToJobConfig(
   dependencyGroups: Record<string, IDependabotGroup>,
 ): any[] | undefined {
   if (!dependencyGroups || !Object.keys(dependencyGroups).length) {

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -158,10 +158,9 @@ export function buildUpdateJobConfig(
       'vendor-dependencies': update.vendor,
       'debug': taskInputs.debug,
 
-      // TODO: Investigate if these options are needed or are obsolete
-      // The following options don't appear to be used by dependabot-core yet/anymore, but do appear in GitHub dependabot job logs.
-      // They are added here for completeness and so that we mimic the GitHub dependabot config as closely as possible.
-      // It is possible that these options might become live in a future dependabot-core release.
+      // TODO: Investigate if these options are needed or are now obsolete.
+      //       These options don't appear to be used by dependabot-core yet/anymore,
+      //       but do appear in GitHub Dependabot job logs seen in the wild.
       //'max-updater-run-time': 2700,
       //'proxy-log-response-body-on-auth-failure': true,
       //'update-subdependencies': false,
@@ -213,8 +212,8 @@ export function mapAllowedUpdatesFromDependabotConfigToJobConfig(
   allowedUpdates: IDependabotAllowCondition[],
   securityOnlyUpdate?: boolean,
 ): any[] {
-  // If no allow conditions are specified, update direct dependencies by default
-  // NOTE: 'update-type' appears to be a deprecated config, but still appears in the dependabot-core model and GitHub dependabot job logs.
+  // If no allow conditions are specified, update direct dependencies by default; This is what GitHub does.
+  // NOTE: 'update-type' appears to be a deprecated config, but still appears in the dependabot-core model and GitHub Dependabot job logs.
   //       See: https://github.com/dependabot/dependabot-core/blob/b3a0c1f86c20729494097ebc695067099f5b4ada/updater/lib/dependabot/job.rb#L253C1-L257C78
   if (!allowedUpdates) {
     return [

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/interfaces/IDependabotUpdateJobConfig.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/interfaces/IDependabotUpdateJobConfig.ts
@@ -40,11 +40,6 @@ export interface IDependabotUpdateJobConfig {
       'affected-versions': string[];
       'patched-versions': string[];
       'unaffected-versions': string[];
-      // TODO: The below configs are not in the dependabot-cli model, but are in the dependabot-core model
-      'title'?: string;
-      'description'?: string;
-      'source-name'?: string;
-      'source-url'?: string;
     }[];
     'source': {
       'provider': string;
@@ -72,7 +67,7 @@ export interface IDependabotUpdateJobConfig {
     'commit-message-options'?: {
       'prefix'?: string;
       'prefix-development'?: string;
-      'include-scope'?: string;
+      'include-scope'?: boolean;
     };
     'experiments'?: Record<string, string | boolean>;
     'max-updater-run-time'?: number;

--- a/extension/tasks/dependabotV2/utils/dependabot/parseConfigFile.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/parseConfigFile.ts
@@ -27,7 +27,8 @@ export default async function parseConfigFile(taskInputs: ISharedVariables): Pro
     '/.github/dependabot.yml',
   ];
 
-  let contents: null | string;
+  let configPath: null | string;
+  let configContents: null | string;
 
   /*
    * The configuration file can be available locally if the repository is cloned.
@@ -54,7 +55,8 @@ export default async function parseConfigFile(taskInputs: ISharedVariables): Pro
         });
         if (response.status === 200) {
           tl.debug(`Found configuration file at '${url}'`);
-          contents = response.data;
+          configContents = response.data;
+          configPath = fp;
           break;
         }
       } catch (error) {
@@ -78,7 +80,8 @@ export default async function parseConfigFile(taskInputs: ISharedVariables): Pro
       var filePath = path.join(rootDir, fp);
       if (fs.existsSync(filePath)) {
         tl.debug(`Found configuration file cloned at ${filePath}`);
-        contents = fs.readFileSync(filePath, 'utf-8');
+        configContents = fs.readFileSync(filePath, 'utf-8');
+        configPath = filePath;
         break;
       } else {
         tl.debug(`No configuration file cloned at ${filePath}`);
@@ -87,13 +90,13 @@ export default async function parseConfigFile(taskInputs: ISharedVariables): Pro
   }
 
   // Ensure we have file contents. Otherwise throw a well readable error.
-  if (!contents || typeof contents !== 'string') {
+  if (!configContents || typeof configContents !== 'string') {
     throw new Error(`Configuration file not found at possible locations: ${possibleFilePaths.join(', ')}`);
   } else {
     tl.debug('Configuration file contents read.');
   }
 
-  let config: any = load(contents);
+  let config: any = load(configContents);
 
   // Ensure the config object parsed is an object
   if (config === null || typeof config !== 'object') {
@@ -120,7 +123,7 @@ export default async function parseConfigFile(taskInputs: ISharedVariables): Pro
     throw new Error('Only version 2 of dependabot is supported. Version specified: ' + version);
   }
 
-  const updates = parseUpdates(config);
+  const updates = parseUpdates(config, configPath);
   const registries = parseRegistries(config);
   validateConfiguration(updates, registries);
 
@@ -131,7 +134,7 @@ export default async function parseConfigFile(taskInputs: ISharedVariables): Pro
   };
 }
 
-function parseUpdates(config: any): IDependabotUpdate[] {
+function parseUpdates(config: any, configPath: string): IDependabotUpdate[] {
   var updates: IDependabotUpdate[] = [];
 
   // Check the updates parsed
@@ -191,10 +194,26 @@ function parseUpdates(config: any): IDependabotUpdate[] {
       dependabotUpdate['open-pull-requests-limit'] = 5;
     }
 
+    // either 'directory' or 'directories' must be specified
     if (!dependabotUpdate.directory && dependabotUpdate.directories.length === 0) {
       throw new Error(
         "The values 'directory' and 'directories' in dependency update config is missing, you must specify at least one",
       );
+    }
+
+    // populate the 'ignore' conditions 'source' and 'updated-at' properties, if missing
+    // NOTE: 'source' and 'updated-at' are not documented in the dependabot.yml config docs, but are defined in the dependabot-core and dependabot-cli models.
+    //       Currently they don't appear to add much value to the update process, but are populated here for completeness.
+    if (dependabotUpdate.ignore) {
+      dependabotUpdate.ignore.forEach((ignoreCondition) => {
+        if (!ignoreCondition['source']) {
+          ignoreCondition['source'] = configPath;
+        }
+        if (!ignoreCondition['updated-at']) {
+          // we don't know the last updated time, so we use the current time
+          ignoreCondition['updated-at'] = new Date().toISOString();
+        }
+      });
     }
 
     updates.push(dependabotUpdate);


### PR DESCRIPTION
Fixes #1531.
Fixes https://github.com/tinglesoftware/dependabot-azure-devops/issues/1527#issuecomment-2593877195.

This change attempts to further align the job definition config with what has been observed in GitHub; 
Based on this recent Dependabot run:
https://github.com/tinglesoftware/dependabot-azure-devops/actions/runs/13232477372/job/36931750293

This change should also improve performance when using the default `allow` configuration by only updating **direct** dependencies instead of **all** dependencies, which is inline with what GitHub's Dependabot does; Refs #1518, #1441, https://github.com/tinglesoftware/dependabot-azure-devops/issues/1527#issuecomment-2597028711.

### Dependabot configuration changes
- `allow.dependency-type` now defaults to `direct` instead of `all`
- `ignore.version-requirement` now accepts string values _(single version)_ and string arrays _(multiple versions)_
- `ignore.source` is now automatically populated
- `ignore.updated-at` is now automatically populated
- `commit-message.include` now only accepts the value `scope`
- `experiments` now correctly converts `true` and `false` string values to boolean values; This fixes the issue where `experiment=false` would incorrectly evaluate to `true` because string "false" is truthy