### PR TITLE
experiments.ts: disable 'enable-record-ecosystem-meta'

### DIFF
--- a/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
@@ -11,5 +11,9 @@ export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
   'nuget-use-direct-discovery': true,
   'enable-file-parser-python-local': true,
   'lead-security-dependency': true,
-  'enable-record-ecosystem-meta': false, // this experiment currently does not work, and will produce timeouts
+  // NOTE: 'enable-record-ecosystem-meta' is not currently implemented in Dependabot-CLI.
+  //       This experiment is primarily for GitHub analytics and doesn't add much value in the DevOps implementation.
+  //       See: https://github.com/dependabot/dependabot-core/pull/10905
+  // TODO: Revsit this if/when Dependabot-CLI supports it.
+  //'enable-record-ecosystem-meta': true,
 };

--- a/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
@@ -11,5 +11,5 @@ export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
   'nuget-use-direct-discovery': true,
   'enable-file-parser-python-local': true,
   'lead-security-dependency': true,
-  'enable-record-ecosystem-meta': true,
+  'enable-record-ecosystem-meta': false, // this experiment currently does not work, and will produce timeouts
 };


### PR DESCRIPTION
When this experiment is enabled by default, it will produce http timeouts and retries, which cause the pipeline to run extremely slow and fail at the end.

The CLI tries to connect to "host.docker.internal" but the server returns the status code 501 (not implemented), so the cli logs "unexpected output type: record_ecosystem_meta".

This will cause a long timeout (see timestamp) and the action is performed 4 times per dependency, so the entire devops pipeline takes us currently ~16 minutes to run and it also cannot be cancelled.

![image](https://github.com/user-attachments/assets/ccbae7e2-511c-4435-a0d2-a971d50dc6e4)
