### PR TITLE
Update experiment defaults and documentation to match GitHub Dependabot v0.296.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ By default, the enabled experiments will mirror the GitHub-hosted version of Dep
 | All | threaded_metadata | true/false | https://github.com/dependabot/dependabot-core/pull/9485 |
 | All | enable_shared_helpers_command_timeout | true/false | https://github.com/dependabot/dependabot-core/pull/11125 |
 | All | allow_refresh_for_existing_pr_dependencies | true/false | https://github.com/dependabot/dependabot-core/pull/11382 |
+| Bun | enable_bun_ecosystem | true/false | https://github.com/dependabot/dependabot-core/pull/11446 |
 | Go | tidy | true/false | |
 | Go | vendor | true/false | |
 | Go | goprivate | string | |

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ By default, the enabled experiments will mirror the GitHub-hosted version of Dep
 | All | add_deprecation_warn_to_pr_message | true/false | https://github.com/dependabot/dependabot-core/pull/10421 |
 | All | threaded_metadata | true/false | https://github.com/dependabot/dependabot-core/pull/9485 |
 | All | enable_shared_helpers_command_timeout | true/false | https://github.com/dependabot/dependabot-core/pull/11125 |
+| All | allow_refresh_for_existing_pr_dependencies | true/false | https://github.com/dependabot/dependabot-core/pull/11382 |
 | Go | tidy | true/false | |
 | Go | vendor | true/false | |
 | Go | goprivate | string | |

--- a/README.md
+++ b/README.md
@@ -162,15 +162,24 @@ By default, the enabled experiments will mirror the GitHub-hosted version of Dep
 | All | dependency_change_validation | true/false | https://github.com/dependabot/dependabot-core/pull/9888 |
 | All | add_deprecation_warn_to_pr_message | true/false | https://github.com/dependabot/dependabot-core/pull/10421 |
 | All | threaded_metadata | true/false | https://github.com/dependabot/dependabot-core/pull/9485 |
+| All | enable_shared_helpers_command_timeout | true/false | https://github.com/dependabot/dependabot-core/pull/11125 |
 | Go | tidy | true/false | |
 | Go | vendor | true/false | |
 | Go | goprivate | string | |
-| NPM | npm_fallback_version_above_v6 | true/false | https://github.com/dependabot/dependabot-core/pull/10757 |
 | NPM | enable_corepack_for_npm_and_yarn | true/false | https://github.com/dependabot/dependabot-core/pull/10985 |
+| NPM | npm_fallback_version_above_v6 | true/false | https://github.com/dependabot/dependabot-core/pull/10757 |
+| NPM | npm_v6_deprecation_warning | true/false | https://github.com/dependabot/dependabot-core/pull/11112 |
+| NPM | npm_v6_unsupported_error | true/false | https://github.com/dependabot/dependabot-core/pull/11112 |
+| NPM | enable_fix_for_pnpm_no_change_error | true/false | https://github.com/dependabot/dependabot-core/pull/11291 |
+| NPM | enable_engine_version_detection | true/false | https://github.com/dependabot/dependabot-core/pull/11392 |
+| NPM | avoid_duplicate_updates_package_json | true/false | https://github.com/dependabot/dependabot-core/pull/11423 |
 | NuGet | nuget_native_analysis | true/false | https://github.com/dependabot/dependabot-core/pull/10025 |
 | NuGet | nuget_native_updater | true/false | https://github.com/dependabot/dependabot-core/pull/10521 |
 | NuGet | nuget_legacy_dependency_solver | true/false | https://github.com/dependabot/dependabot-core/pull/10671 |
 | NuGet | nuget_use_direct_discovery | true/false | https://github.com/dependabot/dependabot-core/pull/10597 |
+| NuGet | nuget_install_dotnet_sdks | true/false | https://github.com/dependabot/dependabot-core/pull/11090 |
+| Python| python_3_8_deprecation_warning | true/false | https://github.com/dependabot/dependabot-core/pull/11166 |
+| Python| python_3_8_unsupported_error | true/false | https://github.com/dependabot/dependabot-core/pull/11166 |
 
 > [!NOTE]
 > Dependabot experiment names are not [publicly] documented and these may be out-of-date at the time of reading. To find the latest list of experiments, search the `dependabot-core` GitHub repository using queries like ["enabled?(x)"](https://github.com/search?q=repo%3Adependabot%2Fdependabot-core+%2Fenabled%5CW%5C%28.*%5C%29%2F&type=code) and ["options.fetch(x)"](https://github.com/search?q=repo%3Adependabot%2Fdependabot-core+%2Foptions%5C.fetch%5C%28.*%2C%2F&type=code). 

--- a/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
@@ -7,13 +7,22 @@ export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
   'proxy-cached': true,
   'move-job-token': true,
   'dependency-change-validation': true,
+  'nuget-install-dotnet-sdks': true,
   'nuget-native-analysis': true,
   'nuget-use-direct-discovery': true,
   'enable-file-parser-python-local': true,
+  'npm-fallback-version-above-v6': true,
+  'npm-v6-deprecation-warning': true,
+  'npm-v6-unsupported-error': true,
+  'python-3-8-deprecation-warning': true,
   'lead-security-dependency': true,
   // NOTE: 'enable-record-ecosystem-meta' is not currently implemented in Dependabot-CLI.
   //       This experiment is primarily for GitHub analytics and doesn't add much value in the DevOps implementation.
   //       See: https://github.com/dependabot/dependabot-core/pull/10905
   // TODO: Revsit this if/when Dependabot-CLI supports it.
   //'enable-record-ecosystem-meta': true,
+  'enable-shared-helpers-command-timeout': true,
+  'enable-fix-for-pnpm-no-change-error': true,
+  'enable-engine-version-detection': true,
+  'avoid-duplicate-updates-package-json': true,
 };

--- a/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
@@ -25,4 +25,5 @@ export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
   'enable-fix-for-pnpm-no-change-error': true,
   'enable-engine-version-detection': true,
   'avoid-duplicate-updates-package-json': true,
+  'allow-refresh-for-existing-pr-dependencies': true,
 };

--- a/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/experiments.ts
@@ -15,6 +15,7 @@ export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
   'npm-v6-deprecation-warning': true,
   'npm-v6-unsupported-error': true,
   'python-3-8-deprecation-warning': true,
+  'python-3-8-unsupported-error': true,
   'lead-security-dependency': true,
   // NOTE: 'enable-record-ecosystem-meta' is not currently implemented in Dependabot-CLI.
   //       This experiment is primarily for GitHub analytics and doesn't add much value in the DevOps implementation.


### PR DESCRIPTION
Update experiment defaults and documentation to match 0.296.0; This helps keep the DevOps Dependabot behavior aligned with what has been observed in GitHub.

Based on this GitHub Dependabot run:
https://github.com/tinglesoftware/dependabot-azure-devops/actions/runs/13232477372/job/36931750293

New experiments that are now enabled by default:

```txt
  'nuget-install-dotnet-sdks': true,
  'npm-fallback-version-above-v6': true,
  'npm-v6-deprecation-warning': true,
  'npm-v6-unsupported-error': true,
  'python-3-8-deprecation-warning': true,
  'python-3-8-unsupported-error': true,
  'enable-shared-helpers-command-timeout': true,
  'enable-fix-for-pnpm-no-change-error': true,
  'enable-engine-version-detection': true,
  'avoid-duplicate-updates-package-json': true,
  'allow-refresh-for-existing-pr-dependencies': true,
```
New experiments added to documentation:

|Package Ecosystem|Experiment Name|Value Type|More Information|
|--|--|--|--|
| All | enable_shared_helpers_command_timeout | true/false | https://github.com/dependabot/dependabot-core/pull/11125 |
| All | allow_refresh_for_existing_pr_dependencies | true/false | https://github.com/dependabot/dependabot-core/pull/11382 |
| Bun | enable_bun_ecosystem | true/false | https://github.com/dependabot/dependabot-core/pull/11446 |
| NPM | npm_fallback_version_above_v6 | true/false | https://github.com/dependabot/dependabot-core/pull/10757 |
| NPM | npm_v6_deprecation_warning | true/false | https://github.com/dependabot/dependabot-core/pull/11112 |
| NPM | npm_v6_unsupported_error | true/false | https://github.com/dependabot/dependabot-core/pull/11112 |
| NPM | enable_fix_for_pnpm_no_change_error | true/false | https://github.com/dependabot/dependabot-core/pull/11291 |
| NPM | enable_engine_version_detection | true/false | https://github.com/dependabot/dependabot-core/pull/11392 |
| NPM | avoid_duplicate_updates_package_json | true/false | https://github.com/dependabot/dependabot-core/pull/11423 |
| NuGet | nuget_install_dotnet_sdks | true/false | https://github.com/dependabot/dependabot-core/pull/11090 |
| Python| python_3_8_deprecation_warning | true/false | https://github.com/dependabot/dependabot-core/pull/11166 |
| Python| python_3_8_unsupported_error | true/false | https://github.com/dependabot/dependabot-core/pull/11166 |

