### PR TITLE
Add task input options for overriding `dependabot-cli` package and `dependabot-updater` image

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -87,7 +87,7 @@ async function run() {
 
     // Initialise the Dependabot updater
     dependabot = new DependabotCli(
-      taskInputs.dependabotCliImage || DependabotCli.CLI_IMAGE_LATEST,
+      taskInputs.dependabotCliPackage || DependabotCli.CLI_PACKAGE_LATEST,
       new DependabotOutputProcessor(
         taskInputs,
         prAuthorClient,

--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -87,7 +87,7 @@ async function run() {
 
     // Initialise the Dependabot updater
     dependabot = new DependabotCli(
-      DependabotCli.CLI_IMAGE_LATEST, // TODO: Add config for this?
+      taskInputs.dependabotCliImage || DependabotCli.CLI_IMAGE_LATEST,
       new DependabotOutputProcessor(
         taskInputs,
         prAuthorClient,
@@ -106,7 +106,7 @@ async function run() {
       collectorImage: undefined, // TODO: Add config for this?
       collectorConfigPath: undefined, // TODO: Add config for this?
       proxyImage: undefined, // TODO: Add config for this?
-      updaterImage: undefined, // TODO: Add config for this?
+      updaterImage: taskInputs.dependabotUpdaterImage,
       timeoutDuration: undefined, // TODO: Add config for this?
       flamegraph: taskInputs.debug,
     };

--- a/extension/tasks/dependabotV2/task.json
+++ b/extension/tasks/dependabotV2/task.json
@@ -221,10 +221,26 @@
       "helpMarkDown": "A semicolon (`;`) delimited list of update identifiers run. Index are zero-based and in the order written in the configuration file. When not present, all the updates are run. This is meant to be used in scenarios where you want to run updates a different times from the same configuration file given you cannot schedule them independently in the pipeline."
     },
     {
+      "name": "dependabotCliPackage",
+      "type": "string",
+      "groupName": "advanced",
+      "label": "Dependabot CLI package",
+      "required": false,
+      "helpMarkDown": "The [Dependabot CLI package](https://pkg.go.dev/github.com/dependabot/cli) to use for updates. This is intended to be used in scenarios where 'latest' has issues and you want to pin a known working version, or use a custom package. Defaults to `github.com/dependabot/cli/cmd/dependabot@latest`"
+    },
+    {
+      "name": "dependabotUpdaterImage",
+      "type": "string",
+      "groupName": "advanced",
+      "label": "Dependabot Updater image",
+      "required": false,
+      "helpMarkDown": "The [Dependabot CLI container image](https://github.com/dependabot/dependabot-core/pkgs/container/dependabot-updater-bundler) to use for updates. The image must contain a '{ecosystem}' placeholder, which will be substituted with the package ecosystem for each update operation. This is intended to be used in scenarios where 'latest' has issues and you want to pin a known working version, or use a custom package. Defaults to `ghcr.io/dependabot/dependabot-updater-{ecosystem}:latest`"
+    },
+    {
       "name": "experiments",
       "type": "string",
       "groupName": "advanced",
-      "label": "Dependabot updater experiments",
+      "label": "Dependabot Updater experiments",
       "required": false,
       "helpMarkDown": "Comma-seperated list of key/value pairs representing the enabled Dependabot experiments e.g. `experiments: 'tidy=true,vendor=true,goprivate=*'`. Available options vary depending on the package ecosystem. If specified, this overrides the [default experiments](https://github.com/tinglesoftware/dependabot-azure-devops/blob/main/extension/tasks/dependabotV2/utils/dependabot/experiments.ts). See [configuring experiments](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-experiments) for more details."
     }

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -91,7 +91,10 @@ export class DependabotCli {
         dependabotArguments.push('--proxy-image', options.proxyImage);
       }
       if (options?.updaterImage) {
-        dependabotArguments.push('--updater-image', options.updaterImage);
+        dependabotArguments.push(
+          '--updater-image',
+          options.updaterImage.replace(/\{ecosystem\}/i, operation.config['package-ecosystem']),
+        );
       }
       if (options?.timeoutDurationMinutes) {
         dependabotArguments.push('--timeout', `${options.timeoutDurationMinutes}m`);

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -91,6 +91,13 @@ export class DependabotCli {
         dependabotArguments.push('--proxy-image', options.proxyImage);
       }
       if (options?.updaterImage) {
+        // If the updater image is provided but does not contain the "{ecosystem}" placeholder, tell the user they've misconfigured it
+        if (!options.updaterImage.includes('{ecosystem}')) {
+          throw new Error(
+            `Dependabot Updater image '${options.updaterImage}' is invalid. ` +
+              `Please ensure the image contains a "{ecosystem}" placeholder to denote the package ecosystem; e.g. "ghcr.io/dependabot/dependabot-updater-{ecosystem}:latest"`,
+          );
+        }
         dependabotArguments.push(
           '--updater-image',
           options.updaterImage.replace(/\{ecosystem\}/i, operation.config['package-ecosystem']),

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -16,17 +16,17 @@ import { IDependabotUpdateOutputProcessor } from './interfaces/IDependabotUpdate
  */
 export class DependabotCli {
   private readonly jobsPath: string;
-  private readonly toolImage: string;
+  private readonly toolPackage: string;
   private readonly outputProcessor: IDependabotUpdateOutputProcessor;
   private readonly debug: boolean;
   private readonly outputLogStream: Writable;
   private toolPath: string;
 
-  public static readonly CLI_IMAGE_LATEST = 'github.com/dependabot/cli/cmd/dependabot@latest';
+  public static readonly CLI_PACKAGE_LATEST = 'github.com/dependabot/cli/cmd/dependabot@latest';
 
-  constructor(cliToolImage: string, outputProcessor: IDependabotUpdateOutputProcessor, debug: boolean = false) {
+  constructor(toolPackage: string, outputProcessor: IDependabotUpdateOutputProcessor, debug: boolean = false) {
     this.jobsPath = path.join(os.tmpdir(), 'dependabot-jobs');
-    this.toolImage = cliToolImage;
+    this.toolPackage = toolPackage;
     this.outputProcessor = outputProcessor;
     this.outputLogStream = new Writable();
     this.outputLogStream._write = (chunk, encoding, callback) => logComponentOutput(debug, chunk, encoding, callback);
@@ -193,7 +193,7 @@ export class DependabotCli {
     debug('Dependabot CLI install was not found, installing now with `go install dependabot`...');
     section('Installing Dependabot CLI');
     const goTool: ToolRunner = tool(which('go', true));
-    goTool.arg(['install', this.toolImage]);
+    goTool.arg(['install', this.toolPackage]);
     await goTool.execAsync();
 
     // Depending on how Go is configured on the host agent, the "go/bin" path may not be in the PATH environment variable.

--- a/extension/tasks/dependabotV2/utils/dependabot/parseConfigFile.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/parseConfigFile.ts
@@ -150,42 +150,6 @@ function parseUpdates(config: any): IDependabotUpdate[] {
       throw new Error("The value 'package-ecosystem' in dependency update config is missing");
     }
 
-    // Remap the package ecyosystem name from config to a value that dependabot-core/cli understands.
-    // Config values: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
-    // Core/CLI values: https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/config/file.rb
-    dependabotUpdate['package-ecosystem'] = (() => {
-      const ecosystem = dependabotUpdate['package-ecosystem'].toLowerCase();
-      switch (ecosystem) {
-        case 'devcontainer':
-          return 'devcontainers';
-        case 'dotnet-sdk':
-          return 'dotnet_sdk';
-        case 'github-actions':
-          return 'github_actions';
-        case 'gitsubmodule':
-          return 'submodules';
-        case 'gomod':
-          return 'go_modules';
-        case 'mix':
-          return 'hex';
-        case 'npm':
-          return 'npm_and_yarn';
-        // Additional aliases, for convenience
-        case 'pipenv':
-          return 'pip';
-        case 'pip-compile':
-          return 'pip';
-        case 'poetry':
-          return 'pip';
-        case 'pnpm':
-          return 'npm_and_yarn';
-        case 'yarn':
-          return 'npm_and_yarn';
-        default:
-          return ecosystem;
-      }
-    })();
-
     // zero is a valid value
     if (!dependabotUpdate['open-pull-requests-limit'] && dependabotUpdate['open-pull-requests-limit'] !== 0) {
       dependabotUpdate['open-pull-requests-limit'] = 5;

--- a/extension/tasks/dependabotV2/utils/getSharedVariables.ts
+++ b/extension/tasks/dependabotV2/utils/getSharedVariables.ts
@@ -72,6 +72,11 @@ export interface ISharedVariables {
   commentPullRequests: boolean;
   /** Determines whether to abandon unwanted pull requests */
   abandonUnwantedPullRequests: boolean;
+
+  /** The dependabot-cli go module image to use for updates. e.g. github.com/dependabot/cli/cmd/dependabot@latest */
+  dependabotCliImage?: string;
+  /** The dependabot-updater docker image to use for updates. e.g. ghcr.io/dependabot/dependabot-updater-{ecosystem}:latest */
+  dependabotUpdaterImage?: string;
 }
 
 /**
@@ -160,6 +165,9 @@ export default function getSharedVariables(): ISharedVariables {
   let commentPullRequests: boolean = tl.getBoolInput('commentPullRequests', false);
   let abandonUnwantedPullRequests: boolean = tl.getBoolInput('abandonUnwantedPullRequests', true);
 
+  let dependabotCliImage: string | undefined = tl.getInput('dependabotCliImage');
+  let dependabotUpdaterImage: string | undefined = tl.getInput('dependabotUpdaterImage');
+
   return {
     organizationUrl: formattedOrganizationUrl,
     protocol,
@@ -200,5 +208,8 @@ export default function getSharedVariables(): ISharedVariables {
     skipPullRequests,
     commentPullRequests,
     abandonUnwantedPullRequests,
+
+    dependabotCliImage,
+    dependabotUpdaterImage,
   };
 }

--- a/extension/tasks/dependabotV2/utils/getSharedVariables.ts
+++ b/extension/tasks/dependabotV2/utils/getSharedVariables.ts
@@ -73,8 +73,8 @@ export interface ISharedVariables {
   /** Determines whether to abandon unwanted pull requests */
   abandonUnwantedPullRequests: boolean;
 
-  /** The dependabot-cli go module image to use for updates. e.g. github.com/dependabot/cli/cmd/dependabot@latest */
-  dependabotCliImage?: string;
+  /** The dependabot-cli go package to use for updates. e.g. github.com/dependabot/cli/cmd/dependabot@latest */
+  dependabotCliPackage?: string;
   /** The dependabot-updater docker image to use for updates. e.g. ghcr.io/dependabot/dependabot-updater-{ecosystem}:latest */
   dependabotUpdaterImage?: string;
 }
@@ -165,7 +165,7 @@ export default function getSharedVariables(): ISharedVariables {
   let commentPullRequests: boolean = tl.getBoolInput('commentPullRequests', false);
   let abandonUnwantedPullRequests: boolean = tl.getBoolInput('abandonUnwantedPullRequests', true);
 
-  let dependabotCliImage: string | undefined = tl.getInput('dependabotCliImage');
+  let dependabotCliPackage: string | undefined = tl.getInput('dependabotCliPackage');
   let dependabotUpdaterImage: string | undefined = tl.getInput('dependabotUpdaterImage');
 
   return {
@@ -209,7 +209,7 @@ export default function getSharedVariables(): ISharedVariables {
     commentPullRequests,
     abandonUnwantedPullRequests,
 
-    dependabotCliImage,
+    dependabotCliPackage,
     dependabotUpdaterImage,
   };
 }


### PR DESCRIPTION
Currently, the extension will always use the latest image for the `dependabot-cli` and `dependabot-updater` components. 

There have been several issues raised recently that essentially boil down to "this was working fine last week, I haven't changed anything". In many cases, these issues happen because there was an upstream change in dependabot-core that changed the behaviour of the updater.

This change aims to allow users to pin a known working version if/when the latest image causes issues.
e.g.

```yaml
steps:
- task: dependabot@2
  inputs:
    dependabotCliPackage: 'github.com/dependabot/cli/cmd/dependabot@latest'
    dependabotUpdaterImage: 'ghcr.io/dependabot/dependabot-updater-{ecosystem}:latest'
```

This change also tidies up the use of "package ecosystem" _(e.g. npm)_ and "package manager" _(e.g. npm_and_yarn)_; The ecosystem name is now used whenever the data is visible to the user (e.g. branch names, job name, log messages, etc). The package manager name is used only for data sent to dependabot-cli/dependabot.core.