### PR TITLE
Fix missing virtual directory in `source.repo` config for DevOps Server

### DIFF
--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
@@ -60,9 +60,9 @@ describe('mapSourceFromDependabotConfigToJobConfig', () => {
 
   it('should map source correctly for Azure DevOps Server', () => {
     const taskInputs: ISharedVariables = {
-      apiEndpointUrl: 'https://azdo.my-org.com:8443/tfs',
-      hostname: 'azdo.my-org.com',
-      organization: 'my-org',
+      apiEndpointUrl: 'https://my-org.com:8443/tfs',
+      hostname: 'my-org.com',
+      organization: 'my-collection',
       project: 'my-project',
       repository: 'my-repo',
       virtualDirectory: 'tfs',
@@ -97,9 +97,9 @@ describe('mapSourceFromDependabotConfigToJobConfig', () => {
     const result = mapSourceFromDependabotConfigToJobConfig(taskInputs, update);
     expect(result).toMatchObject({
       'provider': 'azure',
-      'api-endpoint': 'https://azdo.my-org.com:8443/tfs',
-      'hostname': 'azdo.my-org.com',
-      'repo': 'tfs/my-org/my-project/_git/my-repo',
+      'api-endpoint': 'https://my-org.com:8443/tfs',
+      'hostname': 'my-org.com',
+      'repo': 'tfs/my-collection/my-project/_git/my-repo',
     });
   });
 });

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
@@ -1,10 +1,108 @@
-import { IDependabotGroup, IDependabotIgnoreCondition } from '../dependabot/interfaces/IDependabotConfig';
+import {
+  IDependabotGroup,
+  IDependabotIgnoreCondition,
+  IDependabotUpdate,
+} from '../dependabot/interfaces/IDependabotConfig';
+import { ISharedVariables } from '../getSharedVariables';
 import {
   mapAllowedUpdatesFromDependabotConfigToJobConfig,
   mapExperiments,
   mapGroupsFromDependabotConfigToJobConfig,
   mapIgnoreConditionsFromDependabotConfigToJobConfig,
+  mapSourceFromDependabotConfigToJobConfig,
 } from './DependabotJobBuilder';
+
+describe('mapSourceFromDependabotConfigToJobConfig', () => {
+  it('should map source correctly for Azure DevOps Services', () => {
+    const taskInputs: ISharedVariables = {
+      apiEndpointUrl: 'https://dev.azure.com',
+      hostname: 'dev.azure.com',
+      organization: 'my-org',
+      project: 'my-project',
+      repository: 'my-repo',
+      virtualDirectory: '',
+      port: '',
+      organizationUrl: undefined,
+      protocol: '',
+      projectId: '',
+      repositoryOverridden: false,
+      githubAccessToken: '',
+      systemAccessUser: '',
+      systemAccessToken: '',
+      storeDependencyList: false,
+      setAutoComplete: false,
+      mergeStrategy: '',
+      autoCompleteIgnoreConfigIds: [],
+      autoApprove: false,
+      autoApproveUserToken: '',
+      experiments: undefined,
+      debug: false,
+      targetUpdateIds: [],
+      securityAdvisoriesFile: '',
+      skipPullRequests: false,
+      commentPullRequests: false,
+      abandonUnwantedPullRequests: false,
+    };
+    const update: IDependabotUpdate = {
+      'package-ecosystem': 'nuget',
+      'directory': '/',
+      'directories': [],
+    };
+
+    const result = mapSourceFromDependabotConfigToJobConfig(taskInputs, update);
+    expect(result).toMatchObject({
+      'provider': 'azure',
+      'api-endpoint': 'https://dev.azure.com',
+      'hostname': 'dev.azure.com',
+      'repo': 'my-org/my-project/_git/my-repo',
+    });
+  });
+
+  it('should map source correctly for Azure DevOps Server', () => {
+    const taskInputs: ISharedVariables = {
+      apiEndpointUrl: 'https://azdo.my-org.com:8443/tfs',
+      hostname: 'azdo.my-org.com',
+      organization: 'my-org',
+      project: 'my-project',
+      repository: 'my-repo',
+      virtualDirectory: 'tfs',
+      port: '8443',
+      organizationUrl: undefined,
+      protocol: '',
+      projectId: '',
+      repositoryOverridden: false,
+      githubAccessToken: '',
+      systemAccessUser: '',
+      systemAccessToken: '',
+      storeDependencyList: false,
+      setAutoComplete: false,
+      mergeStrategy: '',
+      autoCompleteIgnoreConfigIds: [],
+      autoApprove: false,
+      autoApproveUserToken: '',
+      experiments: undefined,
+      debug: false,
+      targetUpdateIds: [],
+      securityAdvisoriesFile: '',
+      skipPullRequests: false,
+      commentPullRequests: false,
+      abandonUnwantedPullRequests: false,
+    };
+    const update: IDependabotUpdate = {
+      'package-ecosystem': 'nuget',
+      'directory': '/',
+      'directories': [],
+    };
+
+    const result = mapSourceFromDependabotConfigToJobConfig(taskInputs, update);
+    expect(result).toMatchObject({
+      'provider': 'azure',
+      'api-endpoint': 'https://azdo.my-org.com:8443/tfs',
+      'hostname': 'azdo.my-org.com',
+      'repo': 'tfs/my-org/my-project/_git/my-repo',
+    });
+  });
+});
 
 describe('mapGroupsFromDependabotConfigToJobConfig', () => {
   it('should return undefined if dependencyGroups is undefined', () => {

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.ts
@@ -171,11 +171,14 @@ export function buildUpdateJobConfig(
 }
 
 export function mapSourceFromDependabotConfigToJobConfig(taskInputs: ISharedVariables, update: IDependabotUpdate): any {
+  const isDevOpsServices = !taskInputs.virtualDirectory?.length; // Azure DevOps Services does not use a virtual directory
   return {
     'provider': 'azure',
     'api-endpoint': taskInputs.apiEndpointUrl,
     'hostname': taskInputs.hostname,
-    'repo': `${taskInputs.organization}/${taskInputs.project}/_git/${taskInputs.repository}`,
+    'repo': isDevOpsServices
+      ? `${taskInputs.organization}/${taskInputs.project}/_git/${taskInputs.repository}`
+      : `${taskInputs.virtualDirectory}/${taskInputs.organization}/${taskInputs.project}/_git/${taskInputs.repository}`,
     'branch': update['target-branch'],
     'commit': undefined, // use latest commit of target branch
     'directory': update.directory,

--- a/extension/tasks/dependabotV2/utils/dependabot/interfaces/IDependabotConfig.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot/interfaces/IDependabotConfig.ts
@@ -37,7 +37,7 @@ export interface IDependabotUpdate {
   'groups'?: Record<string, IDependabotGroup>;
   'ignore'?: IDependabotIgnoreCondition[];
   'insecure-external-code-execution'?: string;
-  'labels': string[];
+  'labels'?: string[];
   'milestone'?: string;
   'open-pull-requests-limit'?: number;
   'pull-request-branch-name'?: IDependabotPullRequestBranchName;


### PR DESCRIPTION
Fixes #1550.

I have not been able to test this using a real DevOps Server install; However, by emulating the same configs that would be used in a DevOps Server, I was able to reproduce the issue.

I was not able to confirm if git clone would actually succeed after this change, so it is possible that there _might_ be other errors further in to the update process.
 