### PR TITLE
Fix "source branch already exists" and "unknown package ecosystem" errors

### DIFF
--- a/extension/tasks/dependabotV2/index.test.ts
+++ b/extension/tasks/dependabotV2/index.test.ts
@@ -1,0 +1,141 @@
+import { performDependabotUpdatesAsync } from './index';
+import { IPullRequestProperties } from './utils/azure-devops/interfaces/IPullRequest';
+import { DependabotCli } from './utils/dependabot-cli/DependabotCli';
+import { DependabotJobBuilder } from './utils/dependabot-cli/DependabotJobBuilder';
+import { DependabotOutputProcessor } from './utils/dependabot-cli/DependabotOutputProcessor';
+import { IDependabotUpdateOperationResult } from './utils/dependabot-cli/interfaces/IDependabotUpdateOperationResult';
+import { IDependabotConfig } from './utils/dependabot/interfaces/IDependabotConfig';
+import { ISharedVariables } from './utils/getSharedVariables';
+import { GitHubGraphClient } from './utils/github/GitHubGraphClient';
+
+jest.mock('./utils/dependabot-cli/DependabotCli');
+jest.mock('./utils/dependabot-cli/DependabotJobBuilder');
+jest.mock('./utils/github/GitHubGraphClient');
+
+const tsDependabotJobBuilder = require('./utils/dependabot-cli/DependabotJobBuilder');
+const tsDependabotOutputProcessor = require('./utils/dependabot-cli/DependabotOutputProcessor');
+
+describe('performDependabotUpdatesAsync', () => {
+  let taskInputs: ISharedVariables;
+  let dependabotConfig: IDependabotConfig;
+  let dependabotCli: DependabotCli;
+  let dependabotCliUpdateOptions: any;
+  let existingPullRequests: IPullRequestProperties[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    taskInputs = {} as ISharedVariables;
+    dependabotConfig = {
+      updates: [
+        {
+          'package-ecosystem': 'npm',
+          'directory': '/',
+        },
+      ],
+      registries: {},
+    } as IDependabotConfig;
+    dependabotCli = new DependabotCli(DependabotCli.CLI_PACKAGE_LATEST, null, true);
+    dependabotCli.update = jest
+      .fn()
+      .mockResolvedValue([
+        { success: true, output: { type: 'mark_as_processed', data: {} } },
+      ] as IDependabotUpdateOperationResult[]);
+    dependabotCliUpdateOptions = {};
+    existingPullRequests = [];
+  });
+
+  it('should perform "update all" job successfully', async () => {
+    const failedUpdates = await performDependabotUpdatesAsync(
+      taskInputs,
+      dependabotConfig,
+      dependabotConfig.updates,
+      dependabotCli,
+      dependabotCliUpdateOptions,
+      existingPullRequests,
+    );
+
+    expect(failedUpdates).toBe(0);
+    expect(dependabotCli.update).toHaveBeenCalled();
+    expect(DependabotJobBuilder.updateAllDependenciesJob).toHaveBeenCalled();
+  });
+
+  it('should skip "update all" job if open pull requests limit is reached', async () => {
+    dependabotConfig.updates[0]['open-pull-requests-limit'] = 1;
+    existingPullRequests.push({
+      id: 1,
+      properties: [
+        {
+          name: DependabotOutputProcessor.PR_PROPERTY_NAME_PACKAGE_MANAGER,
+          value: 'npm_and_yarn',
+        },
+        {
+          name: DependabotOutputProcessor.PR_PROPERTY_NAME_DEPENDENCIES,
+          value: JSON.stringify([{ 'dependency-name': 'dependency1' }]),
+        },
+      ],
+    });
+
+    jest.spyOn(tsDependabotOutputProcessor, 'parsePullRequestProperties').mockReturnValue('npm_and_yarn');
+
+    const failedUpdates = await performDependabotUpdatesAsync(
+      taskInputs,
+      dependabotConfig,
+      dependabotConfig.updates,
+      dependabotCli,
+      dependabotCliUpdateOptions,
+      existingPullRequests,
+    );
+
+    expect(failedUpdates).toBe(0);
+    expect(DependabotJobBuilder.updateAllDependenciesJob).not.toHaveBeenCalled();
+  });
+
+  it('should perform "update security-only" job if open pull request limit is zero', async () => {
+    dependabotConfig.updates[0]['open-pull-requests-limit'] = 0;
+    const ghsaClient = new GitHubGraphClient('fake-token');
+    ghsaClient.getSecurityVulnerabilitiesAsync = jest.fn().mockResolvedValue([]);
+
+    const failedUpdates = await performDependabotUpdatesAsync(
+      taskInputs,
+      dependabotConfig,
+      dependabotConfig.updates,
+      dependabotCli,
+      dependabotCliUpdateOptions,
+      existingPullRequests,
+    );
+
+    expect(failedUpdates).toBe(0);
+    expect(DependabotJobBuilder.listAllDependenciesJob).toHaveBeenCalled();
+  });
+
+  it('should perform "update pull request" job successfully if there are existing pull requests', async () => {
+    dependabotConfig.updates[0]['open-pull-requests-limit'] = 1;
+    existingPullRequests.push({
+      id: 1,
+      properties: [
+        {
+          name: DependabotOutputProcessor.PR_PROPERTY_NAME_PACKAGE_MANAGER,
+          value: 'npm_and_yarn',
+        },
+        {
+          name: DependabotOutputProcessor.PR_PROPERTY_NAME_DEPENDENCIES,
+          value: JSON.stringify([{ 'dependency-name': 'dependency1' }]),
+        },
+      ],
+    });
+
+    jest.spyOn(tsDependabotJobBuilder, 'mapPackageEcosystemToPackageManager').mockReturnValue('npm_and_yarn');
+
+    const failedUpdates = await performDependabotUpdatesAsync(
+      taskInputs,
+      dependabotConfig,
+      dependabotConfig.updates,
+      dependabotCli,
+      dependabotCliUpdateOptions,
+      existingPullRequests,
+    );
+
+    expect(failedUpdates).toBe(0);
+    expect(DependabotJobBuilder.updatePullRequestJob).toHaveBeenCalled();
+  });
+});

--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.test.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.test.ts
@@ -16,9 +16,6 @@ describe('AzureDevOpsWebApiClient', () => {
 
   beforeEach(() => {
     client = new AzureDevOpsWebApiClient(organisationApiUrl, accessToken);
-  });
-
-  afterEach(() => {
     jest.clearAllMocks();
   });
 

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotJobBuilder.test.ts
@@ -14,40 +14,21 @@ import {
 
 describe('mapSourceFromDependabotConfigToJobConfig', () => {
   it('should map source correctly for Azure DevOps Services', () => {
-    const taskInputs: ISharedVariables = {
+    const taskInputs = {
       apiEndpointUrl: 'https://dev.azure.com',
       hostname: 'dev.azure.com',
       organization: 'my-org',
       project: 'my-project',
       repository: 'my-repo',
       virtualDirectory: '',
-      port: '',
-      organizationUrl: undefined,
-      protocol: '',
-      projectId: '',
-      repositoryOverridden: false,
-      githubAccessToken: '',
-      systemAccessUser: '',
-      systemAccessToken: '',
-      storeDependencyList: false,
-      setAutoComplete: false,
-      mergeStrategy: '',
-      autoCompleteIgnoreConfigIds: [],
-      autoApprove: false,
-      autoApproveUserToken: '',
-      experiments: undefined,
-      debug: false,
-      targetUpdateIds: [],
-      securityAdvisoriesFile: '',
-      skipPullRequests: false,
-      commentPullRequests: false,
-      abandonUnwantedPullRequests: false,
-    };
-    const update: IDependabotUpdate = {
+      port: '443',
+      protocol: 'https',
+    } as ISharedVariables;
+    const update = {
       'package-ecosystem': 'nuget',
       'directory': '/',
       'directories': [],
-    };
+    } as IDependabotUpdate;
 
     const result = mapSourceFromDependabotConfigToJobConfig(taskInputs, update);
     expect(result).toMatchObject({
@@ -59,7 +40,7 @@ describe('mapSourceFromDependabotConfigToJobConfig', () => {
   });
 
   it('should map source correctly for Azure DevOps Server', () => {
-    const taskInputs: ISharedVariables = {
+    const taskInputs = {
       apiEndpointUrl: 'https://my-org.com:8443/tfs',
       hostname: 'my-org.com',
       organization: 'my-collection',
@@ -67,32 +48,13 @@ describe('mapSourceFromDependabotConfigToJobConfig', () => {
       repository: 'my-repo',
       virtualDirectory: 'tfs',
       port: '8443',
-      organizationUrl: undefined,
-      protocol: '',
-      projectId: '',
-      repositoryOverridden: false,
-      githubAccessToken: '',
-      systemAccessUser: '',
-      systemAccessToken: '',
-      storeDependencyList: false,
-      setAutoComplete: false,
-      mergeStrategy: '',
-      autoCompleteIgnoreConfigIds: [],
-      autoApprove: false,
-      autoApproveUserToken: '',
-      experiments: undefined,
-      debug: false,
-      targetUpdateIds: [],
-      securityAdvisoriesFile: '',
-      skipPullRequests: false,
-      commentPullRequests: false,
-      abandonUnwantedPullRequests: false,
-    };
-    const update: IDependabotUpdate = {
+      protocol: 'https',
+    } as ISharedVariables;
+    const update = {
       'package-ecosystem': 'nuget',
       'directory': '/',
       'directories': [],
-    };
+    } as IDependabotUpdate;
 
     const result = mapSourceFromDependabotConfigToJobConfig(taskInputs, update);
     expect(result).toMatchObject({

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.test.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.test.ts
@@ -39,16 +39,13 @@ describe('DependabotOutputProcessor', () => {
     let data: any;
 
     beforeEach(() => {
+      jest.clearAllMocks();
       update = {
         job: {} as any,
         credentials: {} as any,
         config: {} as IDependabotUpdate,
       } as IDependabotUpdateOperation;
       data = {};
-    });
-
-    afterEach(() => {
-      jest.clearAllMocks();
     });
 
     it('should skip processing "update_dependency_list" if "storeDependencyList" is false', async () => {
@@ -58,7 +55,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'update_dependency_list', data);
 
       expect(result).toBe(true);
-      expect(prApproverClient.updateProjectProperty).toHaveBeenCalledTimes(0);
+      expect(prApproverClient.updateProjectProperty).not.toHaveBeenCalled();
     });
 
     it('should process "update_dependency_list"', async () => {
@@ -68,7 +65,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'update_dependency_list', data);
 
       expect(result).toBe(true);
-      expect(prAuthorClient.updateProjectProperty).toHaveBeenCalledTimes(1);
+      expect(prAuthorClient.updateProjectProperty).toHaveBeenCalled();
     });
 
     it('should skip processing "create_pull_request" if "skipPullRequests" is true', async () => {
@@ -77,7 +74,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'create_pull_request', data);
 
       expect(result).toBe(true);
-      expect(prAuthorClient.createPullRequest).toHaveBeenCalledTimes(0);
+      expect(prAuthorClient.createPullRequest).not.toHaveBeenCalled();
     });
 
     it('should skip processing "create_pull_request" if open pull request limit is reached', async () => {
@@ -86,7 +83,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'create_pull_request', data);
 
       expect(result).toBe(true);
-      expect(prAuthorClient.createPullRequest).toHaveBeenCalledTimes(0);
+      expect(prAuthorClient.createPullRequest).not.toHaveBeenCalled();
     });
 
     it('should process "create_pull_request"', async () => {
@@ -107,8 +104,8 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'create_pull_request', data);
 
       expect(result).toBe(true);
-      expect(prAuthorClient.createPullRequest).toHaveBeenCalledTimes(1);
-      expect(prApproverClient.approvePullRequest).toHaveBeenCalledTimes(1);
+      expect(prAuthorClient.createPullRequest).toHaveBeenCalled();
+      expect(prApproverClient.approvePullRequest).toHaveBeenCalled();
     });
 
     it('should skip processing "update_pull_request" if "skipPullRequests" is false', async () => {
@@ -117,7 +114,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'update_pull_request', data);
 
       expect(result).toBe(true);
-      expect(prAuthorClient.updatePullRequest).toHaveBeenCalledTimes(0);
+      expect(prAuthorClient.updatePullRequest).not.toHaveBeenCalled();
     });
 
     it('should fail processing "update_pull_request" if pull request does not exist', async () => {
@@ -128,7 +125,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'update_pull_request', data);
 
       expect(result).toBe(false);
-      expect(prAuthorClient.updatePullRequest).toHaveBeenCalledTimes(0);
+      expect(prAuthorClient.updatePullRequest).not.toHaveBeenCalled();
     });
 
     it('should process "update_pull_request"', async () => {
@@ -158,8 +155,8 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'update_pull_request', data);
 
       expect(result).toBe(true);
-      expect(prAuthorClient.updatePullRequest).toHaveBeenCalledTimes(1);
-      expect(prApproverClient.approvePullRequest).toHaveBeenCalledTimes(1);
+      expect(prAuthorClient.updatePullRequest).toHaveBeenCalled();
+      expect(prApproverClient.approvePullRequest).toHaveBeenCalled();
     });
 
     it('should skip processing "close_pull_request" if "abandonUnwantedPullRequests" is false', async () => {
@@ -168,7 +165,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'close_pull_request', data);
 
       expect(result).toBe(true);
-      expect(prAuthorClient.abandonPullRequest).toHaveBeenCalledTimes(0);
+      expect(prAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
     });
 
     it('should fail processing "close_pull_request" if pull request does not exist', async () => {
@@ -180,7 +177,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'close_pull_request', data);
 
       expect(result).toBe(false);
-      expect(prAuthorClient.abandonPullRequest).toHaveBeenCalledTimes(0);
+      expect(prAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
     });
 
     it('should process "close_pull_request"', async () => {
@@ -205,7 +202,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'close_pull_request', data);
 
       expect(result).toBe(true);
-      expect(prAuthorClient.abandonPullRequest).toHaveBeenCalledTimes(1);
+      expect(prAuthorClient.abandonPullRequest).toHaveBeenCalled();
     });
 
     it('should process "mark_as_processed"', async () => {
@@ -224,14 +221,14 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'record_update_job_error', data);
 
       expect(result).toBe(false);
-      expect(error).toHaveBeenCalledTimes(1);
+      expect(error).toHaveBeenCalled();
     });
 
     it('should process "record_update_job_unknown_error"', async () => {
       const result = await processor.process(update, 'record_update_job_unknown_error', data);
 
       expect(result).toBe(false);
-      expect(error).toHaveBeenCalledTimes(1);
+      expect(error).toHaveBeenCalled();
     });
 
     it('should process "increment_metric"', async () => {
@@ -244,7 +241,7 @@ describe('DependabotOutputProcessor', () => {
       const result = await processor.process(update, 'non_existant_output_type', data);
 
       expect(result).toBe(true);
-      expect(warning).toHaveBeenCalledTimes(1);
+      expect(warning).toHaveBeenCalled();
     });
   });
 });

--- a/extension/tasks/dependabotV2/utils/github/PackageEcosystem.ts
+++ b/extension/tasks/dependabotV2/utils/github/PackageEcosystem.ts
@@ -13,10 +13,10 @@ export enum PackageEcosystem {
   Swift = 'SWIFT',
 }
 
-export function getGhsaPackageEcosystemFromDependabotPackageEcosystem(
-  dependabotPackageEcosystem: string,
+export function getGhsaPackageEcosystemFromDependabotPackageManager(
+  dependabotPackageManager: string,
 ): PackageEcosystem {
-  switch (dependabotPackageEcosystem) {
+  switch (dependabotPackageManager) {
     case 'composer':
       return PackageEcosystem.Composer;
     case 'elm':
@@ -42,6 +42,6 @@ export function getGhsaPackageEcosystemFromDependabotPackageEcosystem(
     case 'swift':
       return PackageEcosystem.Swift;
     default:
-      throw new Error(`Unknown dependabot package ecosystem: ${dependabotPackageEcosystem}`);
+      throw new Error(`Unknown dependabot package manager: ${dependabotPackageManager}`);
   }
 }


### PR DESCRIPTION
Fixes #1575
Fixes #1577

These are both regressions introduced recently by https://github.com/tinglesoftware/dependabot-azure-devops/pull/1556 when I attempted to clean up the some of the confusing "package ecosystem" _(e.g. npm)_ and "package manager" _(e.g. npm_and_yarn)_ usage to be more clear. In hindsight, there were more usages of this than I originally thought.

I have updated the variables to be more self-describing and added unit tests to validate the package ecosystem/manager usage.

Unfortunately the diff is hard to follow because I extracted some of the logic in to a function to break down the size of `run()` and make it easier to unit test.