### PR TITLE
support multiple origins by the same connection

### DIFF
--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -34,7 +34,7 @@ export class AzureDevOpsWebApiClient {
   constructor(organisationApiUrl: string, accessToken: string, debug: boolean = false) {
     this.organisationApiUrl = organisationApiUrl.replace(/\/$/, ''); // trim trailing slash
     this.identityApiUrl = getIdentityApiUrl(organisationApiUrl).replace(/\/$/, ''); // trim trailing slash
-    this.connection = new WebApi(organisationApiUrl, getPersonalAccessTokenHandler(accessToken));
+    this.connection = new WebApi(organisationApiUrl, getPersonalAccessTokenHandler(accessToken, true));
     this.debug = debug;
     this.resolvedUserIds = {};
   }


### PR DESCRIPTION
This fixes https://github.com/tinglesoftware/dependabot-azure-devops/issues/1499#issuecomment-2681781370

when the project is hosted on azure devops cloud the identity url changes domain to vssps.dev.azure.com. This breaks the connection (WebAPI) since it's configured not to allow requests across multiple origins. 
Since no origin is configured explicitly , the first request will determine the origin and so later in the code when the identity url is invoked the auth header will not be added to the request, causing 401 responses. 

This pr updates the webapi connection to allow the auth handling to support cross domain requests. 