### PR TITLE
Add support for `proxyCertPath`, passed to `dependabot-cli`

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -105,6 +105,7 @@ async function run() {
       gitHubAccessToken: taskInputs.githubAccessToken,
       collectorImage: undefined, // TODO: Add config for this?
       collectorConfigPath: undefined, // TODO: Add config for this?
+      proxyCertPath: taskInputs.proxyCertPath,
       proxyImage: undefined, // TODO: Add config for this?
       updaterImage: taskInputs.dependabotUpdaterImage,
       timeoutDuration: undefined, // TODO: Add config for this?

--- a/extension/tasks/dependabotV2/task.json
+++ b/extension/tasks/dependabotV2/task.json
@@ -237,6 +237,14 @@
       "helpMarkDown": "The [Dependabot CLI container image](https://github.com/dependabot/dependabot-core/pkgs/container/dependabot-updater-bundler) to use for updates. The image must contain a '{ecosystem}' placeholder, which will be substituted with the package ecosystem for each update operation. This is intended to be used in scenarios where 'latest' has issues and you want to pin a known working version, or use a custom package. Defaults to `ghcr.io/dependabot/dependabot-updater-{ecosystem}:latest`"
     },
     {
+      "name": "proxyCertPath",
+      "type": "string",
+      "label": "Path to a certificate the proxy will trust",
+      "groupName": "advanced",
+      "helpMarkDown": "This is useful when the proxy is expected to connect to a server using a self-signed certificate. The default one is located at `/usr/local/share/ca-certificates/custom-ca-cert.crt` in the closed-source updater proxy container image.",
+      "required": false
+    },
+    {
       "name": "experiments",
       "type": "string",
       "groupName": "advanced",

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotCli.ts
@@ -49,6 +49,7 @@ export class DependabotCli {
       gitHubAccessToken?: string;
       collectorImage?: string;
       collectorConfigPath?: string;
+      proxyCertPath?: string;
       proxyImage?: string;
       updaterImage?: string;
       timeoutDurationMinutes?: number;
@@ -86,6 +87,9 @@ export class DependabotCli {
       }
       if (options?.collectorConfigPath && fs.existsSync(options.collectorConfigPath)) {
         dependabotArguments.push('--collector-config', options.collectorConfigPath);
+      }
+      if (options?.proxyCertPath && fs.existsSync(options.proxyCertPath)) {
+        dependabotArguments.push('--proxy-cert', options.proxyCertPath);
       }
       if (options?.proxyImage) {
         dependabotArguments.push('--proxy-image', options.proxyImage);

--- a/extension/tasks/dependabotV2/utils/getSharedVariables.ts
+++ b/extension/tasks/dependabotV2/utils/getSharedVariables.ts
@@ -77,6 +77,9 @@ export interface ISharedVariables {
   dependabotCliPackage?: string;
   /** The dependabot-updater docker image to use for updates. e.g. ghcr.io/dependabot/dependabot-updater-{ecosystem}:latest */
   dependabotUpdaterImage?: string;
+
+  /* Path to a certificate the proxy will trust */
+  proxyCertPath?: string;
 }
 
 /**
@@ -168,6 +171,8 @@ export default function getSharedVariables(): ISharedVariables {
   let dependabotCliPackage: string | undefined = tl.getInput('dependabotCliPackage');
   let dependabotUpdaterImage: string | undefined = tl.getInput('dependabotUpdaterImage');
 
+  let proxyCertPath: string | undefined = tl.getInput('proxyCertPath');
+
   return {
     organizationUrl: formattedOrganizationUrl,
     protocol,
@@ -211,5 +216,7 @@ export default function getSharedVariables(): ISharedVariables {
 
     dependabotCliPackage,
     dependabotUpdaterImage,
+
+    proxyCertPath,
   };
 }


### PR DESCRIPTION
This should allow use of self-signed certificates in OnPrem setups.