### PR TITLE
Use the project ID over the Name to allow for easier overriding

### DIFF
--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -569,14 +569,14 @@ export class AzureDevOpsWebApiClient {
 
   /**
    * Get project properties
-   * @param projectId
+   * @param project
    * @param valueBuilder
    * @returns
    */
-  public async getProjectProperties(projectId: string): Promise<Record<string, string> | undefined> {
+  public async getProjectProperties(project: string): Promise<Record<string, string> | undefined> {
     try {
       const core = await this.connection.getCoreApi();
-      const properties = await core.getProjectProperties(projectId);
+      const properties = await core.getProjectProperties(project);
       return properties?.map((p) => ({ [p.name]: p.value }))?.reduce((a, b) => ({ ...a, ...b }), {});
     } catch (e) {
       error(`Failed to get project properties: ${e}`);
@@ -593,18 +593,18 @@ export class AzureDevOpsWebApiClient {
    * @returns
    */
   public async updateProjectProperty(
-    projectId: string,
+    project: string,
     name: string,
     valueBuilder: (existingValue: string) => string,
   ): Promise<boolean> {
     try {
       // Get the existing project property value
       const core = await this.connection.getCoreApi();
-      const properties = await core.getProjectProperties(projectId);
+      const properties = await core.getProjectProperties(project);
       const propertyValue = properties?.find((p) => p.name === name)?.value;
 
       // Update the project property
-      await core.setProjectProperties(undefined, projectId, [
+      await core.setProjectProperties(undefined, project, [
         {
           op: 'add',
           path: '/' + name,

--- a/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
+++ b/extension/tasks/dependabotV2/utils/dependabot-cli/DependabotOutputProcessor.ts
@@ -75,7 +75,7 @@ export class DependabotOutputProcessor implements IDependabotUpdateOutputProcess
         // Store the dependency list snapshot in project properties, if configured
         if (this.taskInputs.storeDependencyList) {
           return await this.prAuthorClient.updateProjectProperty(
-            this.taskInputs.projectId,
+            this.taskInputs.project,
             DependabotOutputProcessor.PROJECT_PROPERTY_NAME_DEPENDENCY_LIST,
             function (existingValue: string) {
               const repoDependencyLists = JSON.parse(existingValue || '{}');

--- a/extension/tasks/dependabotV2/utils/getSharedVariables.ts
+++ b/extension/tasks/dependabotV2/utils/getSharedVariables.ts
@@ -21,8 +21,6 @@ export interface ISharedVariables {
   /** Organization name */
   organization: string;
   /** Project ID */
-  projectId: string;
-  /** Project name */
   project: string;
   /** Repository name */
   repository: string;
@@ -99,8 +97,7 @@ export default function getSharedVariables(): ISharedVariables {
     tl.debug(`Virtual directory detected; Running for an on-premises Azure DevOps Server.`);
   }
   let organization: string = extractOrganization(organizationUrl);
-  let projectId: string = tl.getVariable('System.TeamProjectId');
-  let project: string = encodeURI(tl.getVariable('System.TeamProject')); // encode special characters like spaces
+  let project: string = tl.getVariable('System.TeamProjectId');
   let repository: string = tl.getInput('targetRepositoryName');
   let repositoryOverridden = typeof repository === 'string';
   if (!repositoryOverridden) {
@@ -175,7 +172,6 @@ export default function getSharedVariables(): ISharedVariables {
     port,
     virtualDirectory,
     organization,
-    projectId,
     project,
     repository,
     repositoryOverridden,


### PR DESCRIPTION
The APIs allow for using the ID or the name. In a number of cases, the API response body contains the ID and not the name in its URL fields. Using the ID will allow this value to be overridden in the future without needing to fetch project information.

This may be reverted later incase it causes issues.