### PR TITLE
Make masking of secrets optional via `System.Secrets` ENV (defaults to false)

### DIFF
--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -35,18 +35,20 @@ async function run() {
     // Mask environment, organisation, and project specific variables from the logs.
     // Most user's environments are private and they're less likely to share diagnostic info when it exposes information about their environment or organisation.
     // Although not exhaustive, this will mask the most common information that could be used to identify the user's environment.
-    setSecrets(
-      taskInputs.hostname,
-      taskInputs.virtualDirectory,
-      taskInputs.organization,
-      taskInputs.project,
-      taskInputs.repository,
-      taskInputs.githubAccessToken,
-      taskInputs.systemAccessUser,
-      taskInputs.systemAccessToken,
-      taskInputs.autoApproveUserToken,
-      taskInputs.authorEmail,
-    );
+    if (taskInputs.secrets) {
+      setSecrets(
+        taskInputs.hostname,
+        taskInputs.virtualDirectory,
+        taskInputs.organization,
+        taskInputs.project,
+        taskInputs.repository,
+        taskInputs.githubAccessToken,
+        taskInputs.systemAccessUser,
+        taskInputs.systemAccessToken,
+        taskInputs.autoApproveUserToken,
+        taskInputs.authorEmail,
+      );
+    }
 
     // Parse dependabot.yaml configuration file
     const dependabotConfig = await parseDependabotConfigFile(taskInputs);

--- a/extension/tasks/dependabotV2/utils/getSharedVariables.ts
+++ b/extension/tasks/dependabotV2/utils/getSharedVariables.ts
@@ -58,6 +58,8 @@ export interface ISharedVariables {
 
   /** Determines if verbose log messages are logged */
   debug: boolean;
+  /** Determines if secrets are protected */
+  secrets: boolean;
 
   /** List of update identifiers to run */
   targetUpdateIds: number[];
@@ -169,6 +171,7 @@ export default function getSharedVariables(): ISharedVariables {
   console.log('Experiments:', experiments);
 
   let debug: boolean = tl.getVariable('System.Debug')?.match(/true/i) ? true : false;
+  let secrets: boolean = tl.getVariable('System.Secrets')?.match(/true/i) ? true : false;
 
   // Get the target identifiers
   let targetUpdateIds = tl.getDelimitedInput('targetUpdateIds', ';', false).map(Number);
@@ -216,6 +219,7 @@ export default function getSharedVariables(): ISharedVariables {
     experiments,
 
     debug,
+    secrets,
 
     targetUpdateIds,
     securityAdvisoriesFile,


### PR DESCRIPTION
Apparently, lots of people believe that since they work in a corporate repo, even the URLs are very secret. While it makes sense in some cases, it more often than not is getting in the way of being able to debug correctly. A new environment variable, `System.Secrets` that is not official but used in this PR, makes it an opt-in functionality.

Resolves: #1551 