### PR TITLE
Add support for cooldown config

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,19 +226,22 @@ We aim to support all [official configuration options](https://docs.github.com/e
 #### `dependabot@1`
 
 - [`schedule`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval) is ignored, use [pipeline scheduled triggers](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#scheduled-triggers) instead.
+- [`cooldown`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown) is not supported.
 - [`directories`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories) are only supported if task input `useUpdateScriptVNext: true` is set.
 - [`groups`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) are only supported if task input `useUpdateScriptVNext: true` is set.
 - [`ignore`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore) may not behave to official specifications unless task input `useUpdateScriptVNext: true` is set. If you are having issues, search for related issues such as <https://github.com/tinglesoftware/dependabot-azure-devops/pull/582> before creating a new issue.
 - [`assignees`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees) and [`reviewers`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers) must be a list of user GUIDs or email addresses; group/team names are not supported.
-- Private feed/registry authentication may not work with all package ecosystems. Support is _slightly_ improved when task input `useUpdateScriptVNext: true` is set, but not still not fully supported. See [problems with authentication](https://github.com/tinglesoftware/dependabot-azure-devops/discussions/1317) for more.
+- Private feed/registry authentication may not work with all package ecosystems. See [problems with authentication](https://github.com/tinglesoftware/dependabot-azure-devops/discussions/1317) for more.
 
 ### Dependabot Updater Docker Image
 
+- [`cooldown`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown) is not supported.
 - `DEPENDABOT_ASSIGNEES` and `DEPENDABOT_REVIEWERS` must be a list of user GUIDs; email addresses and group/team names are not supported.
 - Private feed/registry authentication may not work with all package ecosystems. See [problems with authentication](https://github.com/tinglesoftware/dependabot-azure-devops/discussions/1317) for more.
 
 ### Dependabot Server
 
+- [`cooldown`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown) is not supported.
 - [`directories`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories) are not supported.
 - [`groups`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) are not supported.
 - [`assignees`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees) and [`reviewers`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers) must be a list of user GUIDs; email addresses and group/team names are not supported.

--- a/extension/tasks/dependabotV2/dependabot/config.ts
+++ b/extension/tasks/dependabotV2/dependabot/config.ts
@@ -44,6 +44,7 @@ export interface IDependabotUpdate {
   'allow'?: IDependabotAllowCondition[];
   'assignees'?: string[];
   'commit-message'?: IDependabotCommitMessage;
+  'cooldown'?: IDependabotCooldown;
   'groups'?: Record<string, IDependabotGroup>;
   'ignore'?: IDependabotIgnoreCondition[];
   'insecure-external-code-execution'?: string;
@@ -105,6 +106,15 @@ export interface IDependabotCommitMessage {
   'prefix'?: string;
   'prefix-development'?: string;
   'include'?: string;
+}
+
+export interface IDependabotCooldown {
+  'default-days'?: number;
+  'semver-major-days'?: number;
+  'semver-minor-days'?: number;
+  'semver-patch-days'?: number;
+  'include'?: string[];
+  'exclude'?: string[];
 }
 
 export interface IDependabotPullRequestBranchName {

--- a/extension/tasks/dependabotV2/dependabot/experiments.ts
+++ b/extension/tasks/dependabotV2/dependabot/experiments.ts
@@ -24,4 +24,7 @@ export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
   'allow-refresh-for-existing-pr-dependencies': true,
   'enable-bun-ecosystem': true,
   'exclude-local-composer-packages': true,
+  'enable-cooldown-for-python': true,
+  'enable-cooldown-for-uv': true,
+  'enable-cooldown-for-npm-and-yarn': true,
 };

--- a/extension/tasks/dependabotV2/dependabot/job-builder.test.ts
+++ b/extension/tasks/dependabotV2/dependabot/job-builder.test.ts
@@ -1,4 +1,4 @@
-import { IDependabotCooldown } from '../utils/dependabot/interfaces/IDependabotConfig';
+import { IDependabotCooldown } from '../dependabot/config';
 import { ISharedVariables } from '../utils/shared-variables';
 import { IDependabotGroup, IDependabotIgnoreCondition, IDependabotUpdate } from './config';
 import {

--- a/extension/tasks/dependabotV2/dependabot/job-builder.test.ts
+++ b/extension/tasks/dependabotV2/dependabot/job-builder.test.ts
@@ -1,7 +1,9 @@
+import { IDependabotCooldown } from '../utils/dependabot/interfaces/IDependabotConfig';
 import { ISharedVariables } from '../utils/shared-variables';
 import { IDependabotGroup, IDependabotIgnoreCondition, IDependabotUpdate } from './config';
 import {
   mapAllowedUpdatesFromDependabotConfigToJobConfig,
+  mapCooldownFromDependabotConfigToJobConfig,
   mapExperiments,
   mapGroupsFromDependabotConfigToJobConfig,
   mapIgnoreConditionsFromDependabotConfigToJobConfig,
@@ -219,6 +221,34 @@ describe('mapIgnoreConditionsFromDependabotConfigToJobConfig', () => {
         'version-requirement': '',
       },
     ]);
+  });
+});
+
+describe('mapCooldownFromDependabotConfigToJobConfig', () => {
+  it('should return undefined if cooldown is undefined', () => {
+    const result = mapCooldownFromDependabotConfigToJobConfig(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should map cooldown properties correctly', () => {
+    const cooldown = {
+      'default-days': 7,
+      'semver-major-days': 14,
+      'semver-minor-days': 7,
+      'semver-patch-days': 1,
+      'include': ['dependencies'],
+      'exclude': ['devDependencies'],
+    } as IDependabotCooldown;
+
+    const result = mapCooldownFromDependabotConfigToJobConfig(cooldown);
+    expect(result).toEqual({
+      'default-days': 7,
+      'semver-major-days': 14,
+      'semver-minor-days': 7,
+      'semver-patch-days': 1,
+      'include': ['dependencies'],
+      'exclude': ['devDependencies'],
+    });
   });
 });
 

--- a/extension/tasks/dependabotV2/dependabot/job-builder.test.ts
+++ b/extension/tasks/dependabotV2/dependabot/job-builder.test.ts
@@ -232,22 +232,22 @@ describe('mapCooldownFromDependabotConfigToJobConfig', () => {
 
   it('should map cooldown properties correctly', () => {
     const cooldown = {
-      'default-days': 7,
-      'semver-major-days': 14,
-      'semver-minor-days': 7,
-      'semver-patch-days': 1,
-      'include': ['dependencies'],
-      'exclude': ['devDependencies'],
+      'default-days': 3,
+      'semver-major-days': 7,
+      'semver-minor-days': 5,
+      'semver-patch-days': 2,
+      'include': ['dependency-name-1', 'dependency-name-2'],
+      'exclude': ['dependency-name-3', 'dependency-name-4'],
     } as IDependabotCooldown;
 
     const result = mapCooldownFromDependabotConfigToJobConfig(cooldown);
     expect(result).toEqual({
-      'default-days': 7,
-      'semver-major-days': 14,
-      'semver-minor-days': 7,
-      'semver-patch-days': 1,
-      'include': ['dependencies'],
-      'exclude': ['devDependencies'],
+      'default-days': 3,
+      'semver-major-days': 7,
+      'semver-minor-days': 5,
+      'semver-patch-days': 2,
+      'include': ['dependency-name-1', 'dependency-name-2'],
+      'exclude': ['dependency-name-3', 'dependency-name-4'],
     });
   });
 });

--- a/extension/tasks/dependabotV2/dependabot/job-builder.ts
+++ b/extension/tasks/dependabotV2/dependabot/job-builder.ts
@@ -2,6 +2,7 @@ import { ISecurityVulnerability } from '../github';
 import { ISharedVariables } from '../utils/shared-variables';
 import {
   IDependabotAllowCondition,
+  IDependabotCooldown,
   IDependabotGroup,
   IDependabotIgnoreCondition,
   IDependabotRegistry,
@@ -149,6 +150,7 @@ export function buildUpdateJobConfig(
               'include-scope':
                 update['commit-message']?.['include']?.toLocaleLowerCase()?.trim() == 'scope' ? true : undefined,
             },
+      'cooldown': mapCooldownFromDependabotConfigToJobConfig(update.cooldown),
       'experiments': mapExperiments(taskInputs.experiments),
       'reject-external-code': update['insecure-external-code-execution']?.toLocaleLowerCase()?.trim() == 'allow',
       'repo-private': undefined, // TODO: add config for this?
@@ -255,6 +257,20 @@ export function mapIgnoreConditionsFromDependabotConfigToJobConfig(
         : <string>ignore['versions'],
     };
   });
+}
+
+export function mapCooldownFromDependabotConfigToJobConfig(cooldown: IDependabotCooldown): any {
+  if (!cooldown) {
+    return undefined;
+  }
+  return {
+    'default-days': cooldown['default-days'],
+    'semver-major-days': cooldown['semver-major-days'],
+    'semver-minor-days': cooldown['semver-minor-days'],
+    'semver-patch-days': cooldown['semver-patch-days'],
+    'include': cooldown.include,
+    'exclude': cooldown.exclude,
+  };
 }
 
 export function mapSecurityAdvisories(securityVulnerabilities: ISecurityVulnerability[]): any[] {

--- a/extension/tasks/dependabotV2/dependabot/models.ts
+++ b/extension/tasks/dependabotV2/dependabot/models.ts
@@ -71,6 +71,14 @@ export interface IDependabotUpdateJobConfig {
       'prefix-development'?: string;
       'include-scope'?: boolean;
     };
+    'cooldown'?: {
+      'default-days'?: number;
+      'semver-major-days'?: number;
+      'semver-minor-days'?: number;
+      'semver-patch-days'?: number;
+      'include'?: string[];
+      'exclude'?: string[];
+    };
     'experiments'?: Record<string, string | boolean>;
     'max-updater-run-time'?: number;
     'reject-external-code'?: boolean;


### PR DESCRIPTION
Starting from dependabot-core v0.300.0 and dependabot-cli v1.62.0, `cooldown` config is supported.
See:
- https://github.com/dependabot/dependabot-core/issues/3651#issuecomment-2773808317
- https://github.com/dependabot/dependabot-core/pull/11693
- https://github.com/dependabot/cli/pull/405
