### PR TITLE
No longer storing dependency list in project properties

### DIFF
--- a/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
+++ b/extension/tasks/dependabotV2/utils/azure-devops/AzureDevOpsWebApiClient.ts
@@ -567,59 +567,6 @@ export class AzureDevOpsWebApiClient {
     }
   }
 
-  /**
-   * Get project properties
-   * @param project
-   * @param valueBuilder
-   * @returns
-   */
-  public async getProjectProperties(project: string): Promise<Record<string, string> | undefined> {
-    try {
-      const core = await this.connection.getCoreApi();
-      const properties = await core.getProjectProperties(project);
-      return properties?.map((p) => ({ [p.name]: p.value }))?.reduce((a, b) => ({ ...a, ...b }), {});
-    } catch (e) {
-      error(`Failed to get project properties: ${e}`);
-      console.debug(e); // Dump the error stack trace to help with debugging
-      return undefined;
-    }
-  }
-
-  /**
-   * Update a project property
-   * @param project
-   * @param name
-   * @param valueBuilder
-   * @returns
-   */
-  public async updateProjectProperty(
-    project: string,
-    name: string,
-    valueBuilder: (existingValue: string | undefined) => string,
-  ): Promise<boolean> {
-    try {
-      // Get the existing project property value
-      const core = await this.connection.getCoreApi();
-      const properties = await core.getProjectProperties(project);
-      const propertyValue = properties?.find((p) => p.name === name)?.value;
-
-      // Update the project property
-      await core.setProjectProperties(undefined, project, [
-        {
-          op: 'add',
-          path: '/' + name,
-          value: valueBuilder(propertyValue),
-        },
-      ]);
-
-      return true;
-    } catch (e) {
-      error(`Failed to update project property '${name}': ${e}`);
-      console.debug(e); // Dump the error stack trace to help with debugging
-      return false;
-    }
-  }
-
   private async restApiGet(
     url: string,
     params?: Record<string, string>,


### PR DESCRIPTION
The list of dependencies can grow quite large (>10KB in non trivial repos) and may surpass the limit allowed or slow down the AzDo UI which loads all properties. This PR removes that code and outputs an warning instead as we research if there is a valid alternative.

Consequently, all code that access/modifies project properties is also removed as it is unused.