### PR TITLE
Add support for `record_ecosystem_meta` output; Renable `enable-record-ecosystem-meta` experiment by default

### DIFF
--- a/extension/tasks/dependabotV2/dependabot/experiments.ts
+++ b/extension/tasks/dependabotV2/dependabot/experiments.ts
@@ -13,11 +13,7 @@ export const DEFAULT_EXPERIMENTS: Record<string, string | boolean> = {
   'enable-file-parser-python-local': true,
   'npm-fallback-version-above-v6': true,
   'lead-security-dependency': true,
-  // NOTE: 'enable-record-ecosystem-meta' is not currently implemented in Dependabot-CLI.
-  //       This experiment is primarily for GitHub analytics and doesn't add much value in the DevOps implementation.
-  //       See: https://github.com/dependabot/dependabot-core/pull/10905
-  // TODO: Revisit this if/when Dependabot-CLI supports it.
-  //'enable-record-ecosystem-meta': true,
+  'enable-record-ecosystem-meta': true,
   'enable-shared-helpers-command-timeout': true,
   'enable-engine-version-detection': true,
   'avoid-duplicate-updates-package-json': true,

--- a/extension/tasks/dependabotV2/dependabot/output-processor.test.ts
+++ b/extension/tasks/dependabotV2/dependabot/output-processor.test.ts
@@ -214,6 +214,12 @@ describe('DependabotOutputProcessor', () => {
       expect(result).toBe(true);
     });
 
+    it('should process "record_ecosystem_meta"', async () => {
+      const result = await processor.process(update, 'record_ecosystem_meta', data);
+
+      expect(result).toBe(true);
+    });
+
     it('should process "record_update_job_error"', async () => {
       const result = await processor.process(update, 'record_update_job_error', data);
 

--- a/extension/tasks/dependabotV2/dependabot/output-processor.ts
+++ b/extension/tasks/dependabotV2/dependabot/output-processor.ts
@@ -287,6 +287,10 @@ export class DependabotOutputProcessor {
         // No action required
         return true;
 
+      case 'record_ecosystem_meta':
+        // No action required
+        return true;
+
       case 'record_update_job_error':
         error(`Update job error: ${data['error-type']} ${JSON.stringify(data['error-details'])}`);
         return false;


### PR DESCRIPTION
This is the long-term fix for https://github.com/tinglesoftware/dependabot-azure-devops/pull/1537, see https://github.com/tinglesoftware/dependabot-azure-devops/pull/1537#issuecomment-2599117739 for more context.

https://github.com/dependabot/cli/pull/407 will add support for the `record_ecosystem_meta` output in Dependabot-CLI. After it is merged, the `enable-record-ecosystem-meta` experiment will be reenabled, which is what GitHub Dependabot does.

Ultimately, this change adds zero extra functionality to the DevOps Dependabot implementation. However, it does:
1. Keep the behaviour between GitHub and DevOps aligned
2. Remove the special handling that was previously required for this experiment
3. Prevent https://github.com/tinglesoftware/dependabot-azure-devops/pull/1537 from regressing if the dependabot-core team decide to bake this experiment in to the core code through a future update