### PR TITLE
Log task errors immediately when raised; Do not deferring logging till end of task

### DIFF
--- a/extension/tasks/dependabotV2/dependabot/cli.ts
+++ b/extension/tasks/dependabotV2/dependabot/cli.ts
@@ -168,6 +168,8 @@ export class DependabotCli {
             } catch (e) {
               operationResult.success = false;
               operationResult.error = e;
+              error(`An unhandled exception occurred while processing '${type}': ${e}`);
+              console.debug(e); // Dump the stack trace to help with debugging
             } finally {
               operationResults.push(operationResult);
             }

--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -286,9 +286,6 @@ export async function performDependabotUpdatesAsync(
     }
   }
 
-  // Log the errors of all failed updateoperations
-  failedOperations.forEach((u) => exception(u.error));
-
   // Return an overall result based on the success/failure of all the update operations
   if (successfulOperations.length > 0) {
     return failedOperations.length == 0 ? TaskResult.Succeeded : TaskResult.SucceededWithIssues;


### PR DESCRIPTION
Fixes https://github.com/tinglesoftware/dependabot-azure-devops/issues/1609#issuecomment-2710029621

Currently we process all updates and aggregate the errors in to an array which is only logged at the very end of the task. This has the side-effect of logging errors out of order, which can be seen in https://github.com/tinglesoftware/dependabot-azure-devops/issues/1609#issue-2906495831 and https://github.com/tinglesoftware/dependabot-azure-devops/issues/1609#issuecomment-2710029621 where the Zod validation error is logged **after** all other outputs have already been processed.

This change moves the error logging earlier in to the process so that errors appear directly next to the action that caused them, which makes the logs easier to read and follow.
