### PR TITLE
Abandon pull requests when the source branch has been deleted

### DIFF
--- a/extension/tasks/dependabotV2/azure-devops/models.ts
+++ b/extension/tasks/dependabotV2/azure-devops/models.ts
@@ -2,6 +2,14 @@ import { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/Gi
 import { VersionControlChangeType } from 'azure-devops-node-api/interfaces/TfvcInterfaces';
 
 /**
+ * Pull request property names used to store metadata about the pull request.
+ * https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-properties
+ */
+export const DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME = 'Microsoft.Git.PullRequest.SourceRefName';
+export const DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER = 'Dependabot.PackageManager';
+export const DEVOPS_PR_PROPERTY_DEPENDABOT_DEPENDENCIES = 'Dependabot.Dependencies';
+
+/**
  * File change
  */
 export interface IFileChange {
@@ -91,6 +99,6 @@ export interface IAbandonPullRequest {
   project: string;
   repository: string;
   pullRequestId: number;
-  comment: string;
-  deleteSourceBranch: boolean;
+  comment?: string;
+  deleteSourceBranch?: boolean;
 }

--- a/extension/tasks/dependabotV2/dependabot/output-processor.test.ts
+++ b/extension/tasks/dependabotV2/dependabot/output-processor.test.ts
@@ -1,7 +1,11 @@
 import { error, warning } from 'azure-pipelines-task-lib/task';
 import * as fs from 'fs';
 import { AzureDevOpsWebApiClient } from '../azure-devops/client';
-import { IPullRequestProperties } from '../azure-devops/models';
+import {
+  DEVOPS_PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+  DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
+  IPullRequestProperties,
+} from '../azure-devops/models';
 import { ISharedVariables } from '../utils/shared-variables';
 import { IDependabotUpdate } from './config';
 import { IDependabotUpdateOperation } from './models';
@@ -134,9 +138,9 @@ describe('DependabotOutputProcessor', () => {
       existingPullRequests.push({
         id: 1,
         properties: [
-          { name: DependabotOutputProcessor.PR_PROPERTY_NAME_PACKAGE_MANAGER, value: 'npm' },
+          { name: DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'npm' },
           {
-            name: DependabotOutputProcessor.PR_PROPERTY_NAME_DEPENDENCIES,
+            name: DEVOPS_PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
             value: JSON.stringify([{ 'dependency-name': 'dependency1' }]),
           },
         ],
@@ -182,9 +186,9 @@ describe('DependabotOutputProcessor', () => {
       existingPullRequests.push({
         id: 1,
         properties: [
-          { name: DependabotOutputProcessor.PR_PROPERTY_NAME_PACKAGE_MANAGER, value: 'npm' },
+          { name: DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'npm' },
           {
-            name: DependabotOutputProcessor.PR_PROPERTY_NAME_DEPENDENCIES,
+            name: DEVOPS_PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
             value: JSON.stringify([{ 'dependency-name': 'dependency1' }]),
           },
         ],

--- a/extension/tasks/dependabotV2/index.test.ts
+++ b/extension/tasks/dependabotV2/index.test.ts
@@ -36,7 +36,7 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
 
   it('should abandon pull requests where the source branch has been deleted', async () => {
     devOpsPrAuthorClient.abandonPullRequest = jest.fn().mockResolvedValue(true);
-    existingBranchNames = ['main', 'develop'];
+    existingBranchNames = [];
     existingPullRequests = [
       {
         id: 1,
@@ -62,8 +62,8 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
   });
 
   it('should not abandon pull requests where the source branch still exists', async () => {
-    devOpsPrAuthorClient.abandonPullRequest = jest.fn().mockResolvedValue(false);
-    existingBranchNames = ['main', 'develop', 'dependabot/nuget/dependency1-1.0.0'];
+    devOpsPrAuthorClient.abandonPullRequest = jest.fn().mockResolvedValue(undefined);
+    existingBranchNames = ['dependabot/nuget/dependency1-1.0.0'];
     existingPullRequests = [
       {
         id: 1,
@@ -86,18 +86,20 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
     expect(devOpsPrAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
   });
 
-  it('should not abandon any pull requests if existingBranchNames is undefined', async () => {
+  it('should not abandon any pull requests if existingBranchNames is undefined or null', async () => {
     devOpsPrAuthorClient.abandonPullRequest = jest.fn().mockResolvedValue(undefined);
 
     await abandonPullRequestsWhereSourceRefIsDeleted(taskInputs, devOpsPrAuthorClient, undefined, existingPullRequests);
+    await abandonPullRequestsWhereSourceRefIsDeleted(taskInputs, devOpsPrAuthorClient, null, existingPullRequests);
 
     expect(devOpsPrAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
   });
 
-  it('should not abandon any pull requests if existingPullRequests is undefined', async () => {
+  it('should not abandon any pull requests if existingPullRequests is undefined or null', async () => {
     devOpsPrAuthorClient.abandonPullRequest = jest.fn().mockResolvedValue(undefined);
 
     await abandonPullRequestsWhereSourceRefIsDeleted(taskInputs, devOpsPrAuthorClient, existingBranchNames, undefined);
+    await abandonPullRequestsWhereSourceRefIsDeleted(taskInputs, devOpsPrAuthorClient, existingBranchNames, null);
 
     expect(devOpsPrAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
   });

--- a/extension/tasks/dependabotV2/index.test.ts
+++ b/extension/tasks/dependabotV2/index.test.ts
@@ -1,10 +1,13 @@
 import { TaskResult } from 'azure-pipelines-task-lib';
-import { IPullRequestProperties } from './azure-devops/models';
+import {
+  DEVOPS_PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
+  DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
+  IPullRequestProperties,
+} from './azure-devops/models';
 import { DependabotCli } from './dependabot/cli';
 import { IDependabotConfig } from './dependabot/config';
 import { DependabotJobBuilder } from './dependabot/job-builder';
 import { IDependabotUpdateOperationResult } from './dependabot/models';
-import { DependabotOutputProcessor } from './dependabot/output-processor';
 import { GitHubGraphClient } from './github';
 import { performDependabotUpdatesAsync } from './index';
 import { ISharedVariables } from './utils/shared-variables';
@@ -66,11 +69,11 @@ describe('performDependabotUpdatesAsync', () => {
       id: 1,
       properties: [
         {
-          name: DependabotOutputProcessor.PR_PROPERTY_NAME_PACKAGE_MANAGER,
+          name: DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
           value: 'npm_and_yarn',
         },
         {
-          name: DependabotOutputProcessor.PR_PROPERTY_NAME_DEPENDENCIES,
+          name: DEVOPS_PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
           value: JSON.stringify([{ 'dependency-name': 'dependency1' }]),
         },
       ],
@@ -115,11 +118,11 @@ describe('performDependabotUpdatesAsync', () => {
       id: 1,
       properties: [
         {
-          name: DependabotOutputProcessor.PR_PROPERTY_NAME_PACKAGE_MANAGER,
+          name: DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER,
           value: 'npm_and_yarn',
         },
         {
-          name: DependabotOutputProcessor.PR_PROPERTY_NAME_DEPENDENCIES,
+          name: DEVOPS_PR_PROPERTY_DEPENDABOT_DEPENDENCIES,
           value: JSON.stringify([{ 'dependency-name': 'dependency1' }]),
         },
       ],

--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -1,7 +1,7 @@
 import { debug, error, setResult, TaskResult, warning, which } from 'azure-pipelines-task-lib/task';
 import { AzureDevOpsWebApiClient } from './azure-devops/client';
 import { section, setSecrets } from './azure-devops/formatting';
-import { IPullRequestProperties } from './azure-devops/models';
+import { DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME, IPullRequestProperties } from './azure-devops/models';
 import { DependabotCli } from './dependabot/cli';
 import { IDependabotConfig, IDependabotUpdate, parseConfigFile } from './dependabot/config';
 import { DependabotJobBuilder, mapPackageEcosystemToPackageManager } from './dependabot/job-builder';
@@ -123,6 +123,14 @@ async function run() {
       dependabotUpdatesToPerform = dependabotConfig.updates;
     }
 
+    // Abandon all pull requests where the source branch has been deleted
+    await abandonPullRequestsWhereSourceRefIsDeleted(
+      taskInputs,
+      devOpsPrAuthorClient,
+      existingBranchNames,
+      existingPullRequests,
+    );
+
     // Perform updates for each of the [targeted] update blocks in dependabot.yaml
     const taskResult = await performDependabotUpdatesAsync(
       taskInputs,
@@ -151,6 +159,42 @@ async function run() {
     exception(e);
   } finally {
     dependabotCli?.cleanup();
+  }
+}
+
+/**
+ * Abandon all pull requests where the source branch has been deleted.
+ * @param taskInputs The shared task inputs.
+ * @param devOpsPrAuthorClient The Azure DevOps API client for authoring pull requests.
+ * @param existingBranchNames The names of the existing branches.
+ * @param existingPullRequests The existing pull requests.
+ */
+export async function abandonPullRequestsWhereSourceRefIsDeleted(
+  taskInputs: ISharedVariables,
+  devOpsPrAuthorClient: AzureDevOpsWebApiClient,
+  existingBranchNames: string[],
+  existingPullRequests: IPullRequestProperties[],
+): Promise<void> {
+  if (!existingBranchNames || !existingPullRequests) {
+    return;
+  }
+  for (const pullRequestId in existingPullRequests) {
+    const pullRequest = existingPullRequests[pullRequestId];
+    const pullRequestSourceRefName = pullRequest.properties[DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME];
+    if (pullRequestSourceRefName && !existingBranchNames.includes(pullRequestSourceRefName)) {
+      warning(`Detected source branch for PR #${pullRequest.id} has been deleted; The pull request will be abandoned`);
+      await devOpsPrAuthorClient.abandonPullRequest({
+        project: taskInputs.project,
+        repository: taskInputs.repository,
+        pullRequestId: pullRequest.id,
+        comment: taskInputs.commentPullRequests
+          ? "OK, I won't notify you again about this release, but will get in touch when a new version is available. " +
+            "If you'd rather skip all updates until the next major or minor version, add an " +
+            '[ignore condition](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) ' +
+            'with the desired `update-types` to your config file.'
+          : undefined,
+      });
+    }
   }
 }
 

--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -180,7 +180,9 @@ export async function abandonPullRequestsWhereSourceRefIsDeleted(
   }
   for (const pullRequestId in existingPullRequests) {
     const pullRequest = existingPullRequests[pullRequestId];
-    const pullRequestSourceRefName = pullRequest.properties[DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME];
+    const pullRequestSourceRefName = pullRequest.properties.find(
+      (x) => x.name === DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME,
+    )?.value;
     if (pullRequestSourceRefName && !existingBranchNames.includes(pullRequestSourceRefName)) {
       warning(`Detected source branch for PR #${pullRequest.id} has been deleted; The pull request will be abandoned`);
       await devOpsPrAuthorClient.abandonPullRequest({

--- a/extension/tasks/dependabotV2/index.ts
+++ b/extension/tasks/dependabotV2/index.ts
@@ -192,7 +192,7 @@ export async function abandonPullRequestsWhereSourceRefIsDeleted(
         comment: taskInputs.commentPullRequests
           ? "OK, I won't notify you again about this release, but will get in touch when a new version is available. " +
             "If you'd rather skip all updates until the next major or minor version, add an " +
-            '[ignore condition](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) ' +
+            '[`ignore` condition](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) ' +
             'with the desired `update-types` to your config file.'
           : undefined,
       });


### PR DESCRIPTION
Fixes https://github.com/tinglesoftware/dependabot-azure-devops/issues/1609#issuecomment-2710029621

When the user deletes the source branch for a Dependabot pull request, the task will still attempt to run updates for it. This ends up causing "400 Bad Request" errors. e.g.

```log
2025-03-11T13:38:45.9730394Z Error: HTTP GET 'https://dev.azure.com//_apis/git/repositories/.../stats/branches?api-version=5.0&name=dependabot-docker-Development-/-python-3.13.2' failed: 400 Bad Request
2025-03-11T13:38:45.9736384Z     at AzureDevOpsWebApiClient.restApiRequest (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.44.1228/azure-devops/client.js:508:23)
2025-03-11T13:38:45.9737131Z     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2025-03-11T13:38:45.9738284Z     at async AzureDevOpsWebApiClient.restApiGet (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.44.1228/azure-devops/client.js:475:16)
2025-03-11T13:38:45.9738855Z     at async AzureDevOpsWebApiClient.updatePullRequest (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.44.1228/azure-devops/client.js:300:27)
2025-03-11T13:38:45.9739424Z     at async DependabotOutputProcessor.process (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.44.1228/dependabot/output-processor.js:168:47)
2025-03-11T13:38:45.9739960Z     at async DependabotCli.update (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.44.1228/dependabot/cli.js:129:55)
2025-03-11T13:38:45.9740467Z     at async performDependabotUpdatesAsync (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.44.1228/index.js:171:37)
2025-03-11T13:38:45.9740936Z     at async run (/home/vsts/work/_tasks/dependabot_d98b873d-cf18-41eb-8ff5-234f14697896/2.44.1228/index.js:77:28)
```

To fix this, before doing any updates, abandon any pull request that was created by the Dependabot user and where the source branch has been deleted. This matches the behaviour of GitHub Dependabot:

## GitHub

![image](https://github.com/user-attachments/assets/25253b73-69ae-4ccb-8324-150cccc906b1)

## DevOps

![image](https://github.com/user-attachments/assets/d6f8c2da-8c4a-4705-bf11-f2eb52ef7ecd)

