### PR TITLE
Normalise branch names when checking if a pull request ssource branch is deleted

### DIFF
--- a/extension/tasks/dependabotV2/azure-devops/client.ts
+++ b/extension/tasks/dependabotV2/azure-devops/client.ts
@@ -9,6 +9,7 @@ import {
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { debug, error, warning } from 'azure-pipelines-task-lib/task';
 import { IHttpClientResponse } from 'typed-rest-client/Interfaces';
+import { normalizeBranchName, normalizeFilePath } from './formatting';
 import {
   IAbandonPullRequest,
   IApprovePullRequest,
@@ -659,19 +660,6 @@ export class AzureDevOpsWebApiClient {
       throw e;
     }
   }
-}
-
-function normalizeFilePath(path: string): string {
-  // Convert backslashes to forward slashes, convert './' => '/' and ensure the path starts with a forward slash if it doesn't already, this is how DevOps paths are formatted
-  return path
-    .replace(/\\/g, '/')
-    .replace(/^\.\//, '/')
-    .replace(/^([^/])/, '/$1');
-}
-
-function normalizeBranchName(branch: string): string {
-  // Strip the 'refs/heads/' prefix from the branch name, if present
-  return branch.replace(/^refs\/heads\//i, '');
 }
 
 function mergeCommitMessage(id: number, title: string, description: string): string {

--- a/extension/tasks/dependabotV2/azure-devops/formatting.ts
+++ b/extension/tasks/dependabotV2/azure-devops/formatting.ts
@@ -29,3 +29,16 @@ export function setSecrets(...args: string[]) {
     setSecret(encodeURIComponent(arg));
   }
 }
+
+export function normalizeFilePath(path: string): string {
+  // Convert backslashes to forward slashes, convert './' => '/' and ensure the path starts with a forward slash if it doesn't already, this is how DevOps paths are formatted
+  return path
+    ?.replace(/\\/g, '/')
+    ?.replace(/^\.\//, '/')
+    ?.replace(/^([^/])/, '/$1');
+}
+
+export function normalizeBranchName(branch: string): string {
+  // Strip the 'refs/heads/' prefix from the branch name, if present
+  return branch?.replace(/^refs\/heads\//i, '');
+}

--- a/extension/tasks/dependabotV2/index.test.ts
+++ b/extension/tasks/dependabotV2/index.test.ts
@@ -86,6 +86,56 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
     expect(devOpsPrAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
   });
 
+  it('should ignore "refs/heads/" prefix when comparing branch names', async () => {
+    devOpsPrAuthorClient.abandonPullRequest = jest.fn().mockResolvedValue(undefined);
+    existingBranchNames = ['dependabot/nuget/dependency1-1.0.0'];
+    existingPullRequests = [
+      {
+        id: 1,
+        properties: [
+          {
+            name: DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME,
+            value: 'refs/heads/dependabot/nuget/dependency1-1.0.0',
+          },
+        ],
+      },
+    ];
+
+    await abandonPullRequestsWhereSourceRefIsDeleted(
+      taskInputs,
+      devOpsPrAuthorClient,
+      existingBranchNames,
+      existingPullRequests,
+    );
+
+    expect(devOpsPrAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
+  });
+
+  it('should remove the pull request from the existing pull requests list after abandoning it', async () => {
+    devOpsPrAuthorClient.abandonPullRequest = jest.fn().mockResolvedValue(true);
+    existingBranchNames = [];
+    existingPullRequests = [
+      {
+        id: 1,
+        properties: [
+          {
+            name: DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME,
+            value: 'dependabot/nuget/dependency1-1.0.0',
+          },
+        ],
+      },
+    ];
+
+    await abandonPullRequestsWhereSourceRefIsDeleted(
+      taskInputs,
+      devOpsPrAuthorClient,
+      existingBranchNames,
+      existingPullRequests,
+    );
+
+    expect(existingPullRequests.length).toBe(0);
+  });
+
   it('should not abandon any pull requests if existingBranchNames is undefined or null', async () => {
     devOpsPrAuthorClient.abandonPullRequest = jest.fn().mockResolvedValue(undefined);
 


### PR DESCRIPTION
Fixes an missed scenario from https://github.com/tinglesoftware/dependabot-azure-devops/pull/1614.

Branch names need to be normalised before comparing to avoid false positives.
After testing this in a real DevOps environment, I found a case where it was comparing:

`refs/heads/dependabot/nuget/main/WebApplicationNetCore/Project/System.Text.Json-9.0.3`
with
`dependabot/nuget/main/WebApplicationNetCore/Project/System.Text.Json-9.0.3`

These are the same branch, but the code considers them different. I have added a test case for this.

This change also ensures that after successfully abandoning a pull request, it is removed from the "existing pull requests" list to ensure that it ignored during the rest of the update process.