### PR TITLE
Support `linux/arm64` images for server

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     schedule:
       interval: 'weekly'
       time: '02:00'
+    group:
+      docker:
+        patterns: ['docker/*']
 
   - package-ecosystem: 'devcontainers'
     directory: '/'

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -122,23 +122,63 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        run: |
-          docker build \
-          -f server/Tingle.Dependabot/Dockerfile.CI \
-          --label com.github.image.run.id=${{ github.run_id }} \
-          --label com.github.image.run.number=${{ github.run_number }} \
-          --label com.github.image.job.id=${{ github.job }} \
-          --label com.github.image.source.sha=${{ github.sha }} \
-          --label com.github.image.source.branch=${{ github.ref }} \
-          -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest" \
-          -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.shortSha }}" \
-          -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.fullSemVer }}" \
-          -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.major}}.${{ steps.gitversion.outputs.minor }}" \
-          -t "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.major }}" \
-          --cache-from ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
-          ${{ github.workspace }}/drop/Tingle.Dependabot
+      # Generate tags to use in multi-arch build.
+      # This is because we cannot build multi-arch images and load them for later pushing.
+      # Different tags are pushed depending on the current ref.
+      - name: Compute Docker tags
+        id: docker-tags-generator
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { ref } = context;
+            const { owner: repoOwner } = context.repo;
+            const {
+              IMAGE_NAME: imageName,
+              SHORT_SHA: shortSha,
+              FULL_SEMVER: fullSemVer,
+              MAJOR: major,
+              MINOR: minor,
+            } = process.env;
+
+            let tags = [`ghcr.io/${repoOwner}/${imageName}:${fullSemVer}`];
+            if (ref === 'refs/heads/main' || ref.startsWith('refs/tags/')) {
+              tags.push(`ghcr.io/${repoOwner}/${imageName}:latest`);
+              tags.push(`ghcr.io/${repoOwner}/${imageName}:${shortSha}`);
+            }
+            if (ref.startsWith('refs/tags/')) {
+              tags.push(`ghcr.io/${repoOwner}/${imageName}:${major}.${minor}`);
+              tags.push(`ghcr.io/${repoOwner}/${imageName}:${major}`);
+            }
+
+            // result is list or CSV
+            core.setOutput('tags', tags.join(','));
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          SHORT_SHA: ${{ steps.gitversion.outputs.shortSha }}
+          FULL_SEMVER: ${{ steps.gitversion.outputs.fullSemVer }}
+          MAJOR: ${{ steps.gitversion.outputs.major }}
+          MINOR: ${{ steps.gitversion.outputs.minor }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ github.workspace }}/drop/Tingle.Dependabot
+          file: server/Tingle.Dependabot/Dockerfile.CI
+          platforms: linux/amd64,linux/arm64
+          push: ${{ !startsWith(github.ref, 'refs/pull') }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+          cache-to: type=inline # sets BUILDKIT_INLINE_CACHE=1
+          tags: ${{ steps.docker-tags-generator.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.gitversion.outputs.fullSemVer }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+            com.github.image.run.id=${{ github.run_id }}
+            com.github.image.run.number=${{ github.run_number }}
+            com.github.image.job.id=${{ github.job }}
+            com.github.image.source.sha=${{ github.sha }}
+            com.github.image.source.branch=${{ github.ref }}
 
       - name: Log into registry
         if: ${{ (github.ref == 'refs/heads/main') || (!startsWith(github.ref, 'refs/pull')) || startsWith(github.ref, 'refs/tags') }}
@@ -147,22 +187,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push image (latest, ShortSha)
-        if: ${{ (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags') }}
-        run: |
-          docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest"
-          docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.shortSha }}"
-
-      - name: Push image (NuGetVersionV2)
-        if: ${{ !startsWith(github.ref, 'refs/pull') }}
-        run: docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.fullSemVer }}"
-
-      - name: Push image (major, minor)
-        if: startsWith(github.ref, 'refs/tags')
-        run: |
-          docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}"
-          docker push "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.gitversion.outputs.major }}"
 
       - name: Upload Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -139,7 +139,11 @@ jobs:
 
       - name: Log into registry
         if: ${{ (github.ref == 'refs/heads/main') || (!startsWith(github.ref, 'refs/pull')) || startsWith(github.ref, 'refs/tags') }}
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image (latest, ShortSha)
         if: ${{ (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -119,6 +119,9 @@ jobs:
       - name: Pull Docker base image & warm Docker cache
         run: docker pull "ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build image
         run: |
           docker build \


### PR DESCRIPTION
This builds multi-arch images (`linux/amd64` and `linux/arm64`) to allow running the server on a Raspberry Pi and on local macOS machines.

- Use `docker/login-action@v3` for login (better).
- Setup builder using `docker/setup-buildx-action@v3`.
- Build multi-arch images using `docker/build-push-action@v5`.