### PR TITLE
Remove support for reviewers (assignees remain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In this repository you'll find:
 - [Configuring private feeds and registries](#configuring-private-feeds-and-registries)
 - [Configuring security advisories and known vulnerabilities](#configuring-security-advisories-and-known-vulnerabilities)
 - [Configuring experiments](#configuring-experiments)
-- [Configuring assignees and reviewers](#configuring-assignees-and-reviewers)
+- [Configuring assignees](#configuring-assignees)
 - [Unsupported features and configurations](#unsupported-features-and-configurations)
   - [Dependabot Task](#dependabot-task)
     - [dependabot@2](#dependabot2)
@@ -193,14 +193,13 @@ By default, the enabled experiments will mirror the GitHub-hosted version of Dep
 
 </details>
 
-## Configuring assignees and reviewers
+## Configuring assignees
 
-Dependabot supports [`assignees`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#assignees--) and [`reviewers`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#reviewers--). However, Azure DevOps does not have the concept of pull request assignees. To work around this:
+Dependabot supports [`assignees`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#assignees--). However, Azure DevOps does not have the concept of pull request assignees. To work around this:
 
 - [`assignees`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#assignees--) are treated as **required** pull request reviewers.
-- [`reviewers`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#reviewers--) are treated as **optional** pull request reviewers.
 
-The following values can be used as assignees or reviewers:
+The following values can be used as assignees:
 
 - User GUID
 - User username
@@ -228,7 +227,7 @@ No longer functional.
 - [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) is not supported.
 - [`directories`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--) are not supported.
 - [`groups`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--) are not supported.
-- [`assignees`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#assignees--) and [`reviewers`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#reviewers--) must be a list of user GUIDs; email addresses and group/team names are not supported.
+- [`assignees`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#assignees--) must be a list of user GUIDs; email addresses and group/team names are not supported.
 - Private feed/registry authentication may not work with all package ecosystems. See [problems with authentication](https://github.com/tinglesoftware/dependabot-azure-devops/discussions/1317) for more.
 
 ## Contributing

--- a/extension/README.md
+++ b/extension/README.md
@@ -85,5 +85,5 @@ Dependabot uses Docker containers, which may take time to install if not already
 - [Configuring private feeds and registries](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-private-feeds-and-registries)
 - [Configuring security advisories and known vulnerabilities](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-security-advisories-and-known-vulnerabilities)
 - [Configuring experiments](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-experiments)
-- [Configuring assignees and reviewers](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-assignees-and-reviewers)
+- [Configuring assignees](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-assignees)
 - [Unsupported features and configurations](https://github.com/tinglesoftware/dependabot-azure-devops/#unsupported-features-and-configurations)

--- a/extension/tasks/dependabotV2/azure-devops/client.test.ts
+++ b/extension/tasks/dependabotV2/azure-devops/client.test.ts
@@ -70,12 +70,11 @@ describe('AzureDevOpsWebApiClient', () => {
 
       // Act
       pr.assignees = ['user1', 'user2'];
-      pr.reviewers = ['user1', 'user3'];
       const pullRequestId = await client.createPullRequest(pr);
 
       // Assert
       expect(mockRestApiPost).toHaveBeenCalledTimes(2);
-      expect((mockRestApiPost.mock.calls[1] as any)[1].reviewers.length).toBe(3);
+      expect((mockRestApiPost.mock.calls[1] as any)[1].reviewers.length).toBe(2);
       expect((mockRestApiPost.mock.calls[1] as any)[1].reviewers).toContainEqual({
         id: 'user1',
         isRequired: true,
@@ -86,7 +85,6 @@ describe('AzureDevOpsWebApiClient', () => {
         isRequired: true,
         isFlagged: true,
       });
-      expect((mockRestApiPost.mock.calls[1] as any)[1].reviewers).toContainEqual({ id: 'user3' });
       expect(pullRequestId).toBe(1);
     });
   });

--- a/extension/tasks/dependabotV2/azure-devops/client.ts
+++ b/extension/tasks/dependabotV2/azure-devops/client.ts
@@ -176,7 +176,7 @@ export class AzureDevOpsWebApiClient {
   /**
    * Create a new pull request.
    * Requires scope "Code (Write)" (vso.code_write).
-   * Requires scope "Identity (Read)" (vso.identity), if assignees or reviewers are specified.
+   * Requires scope "Identity (Read)" (vso.identity), if assignees are specified.
    * @param pr
    * @returns
    */
@@ -186,7 +186,7 @@ export class AzureDevOpsWebApiClient {
       const userId = await this.getUserId();
 
       // Map the list of the pull request reviewer ids
-      // NOTE: Azure DevOps does not have a concept of assignees, only reviewers.
+      // NOTE: Azure DevOps does not have a concept of assignees.
       //       We treat assignees as required reviewers and all other reviewers as optional.
       const allReviewers: IdentityRefWithVote[] = [];
       if (pr.assignees?.length > 0) {
@@ -200,18 +200,6 @@ export class AzureDevOpsWebApiClient {
             });
           } else {
             warning(`Unable to resolve assignee identity '${assignee}'`);
-          }
-        }
-      }
-      if (pr.reviewers?.length > 0) {
-        for (const reviewer of pr.reviewers) {
-          const identityId = isGuid(reviewer) ? reviewer : await this.resolveIdentityId(reviewer);
-          if (identityId && !allReviewers.some((r) => r.id === identityId)) {
-            allReviewers.push({
-              id: identityId,
-            });
-          } else {
-            warning(`Unable to resolve reviewer identity '${reviewer}'`);
           }
         }
       }

--- a/extension/tasks/dependabotV2/azure-devops/models.ts
+++ b/extension/tasks/dependabotV2/azure-devops/models.ts
@@ -55,7 +55,6 @@ export interface ICreatePullRequest {
     mergeStrategy?: GitPullRequestMergeStrategy;
   };
   assignees?: string[];
-  reviewers?: string[];
   labels?: string[];
   workItems?: string[];
   changes: IFileChange[];

--- a/extension/tasks/dependabotV2/dependabot/config.ts
+++ b/extension/tasks/dependabotV2/dependabot/config.ts
@@ -54,7 +54,6 @@ export interface IDependabotUpdate {
   'pull-request-branch-name'?: IDependabotPullRequestBranchName;
   'rebase-strategy'?: string;
   'registries'?: string[];
-  'reviewers'?: string[];
   'schedule'?: IDependabotSchedule;
   'target-branch'?: string;
   'vendor'?: boolean;

--- a/extension/tasks/dependabotV2/dependabot/output-processor.ts
+++ b/extension/tasks/dependabotV2/dependabot/output-processor.ts
@@ -185,7 +185,6 @@ export class DependabotOutputProcessor {
               }
             : undefined,
           assignees: update.config.assignees,
-          reviewers: update.config.reviewers,
           labels: update.config.labels?.map((label) => label?.trim()) || [],
           workItems: update.config.milestone ? [update.config.milestone] : [],
           changes: changedFiles,


### PR DESCRIPTION
This aligns with support for this in deprecation announcement about 2-3 weeks https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

We have always joined assignees and reviewers because Azure DevOps does not have the concept of assignees.

GitHub is deprecating reviewers in favour of CODEOWNERS. This is also something that Azure DevOps does not support but it can be done using Branch Policies.