### PR TITLE
Pass `--debug` to dependabot-cli

### DIFF
--- a/extension/src/dependabot/cli.ts
+++ b/extension/src/dependabot/cli.ts
@@ -116,6 +116,9 @@ export class DependabotCli {
       if (options?.apiUrl) {
         dependabotArguments.push('--api-url', options.apiUrl);
       }
+      if (this.debug) {
+        dependabotArguments.push('--debug');
+      }
 
       // Generate the job input file
       writeJobConfigFile(jobInputPath, operation);


### PR DESCRIPTION
The value is controlled by `System.Debug` which can be set in the pipeline yaml or toggled on the UI for a given run.